### PR TITLE
Handle Thread Panics

### DIFF
--- a/control-core/src/ethercat/interface_discovery.rs
+++ b/control-core/src/ethercat/interface_discovery.rs
@@ -81,13 +81,13 @@ pub async fn discover_ethercat_interface() -> Result<String, anyhow::Error> {
         .collect::<Vec<_>>();
 
     // Return first successful interface
-    let result = tasks.into_iter().find_map(|task| {
-        if let Ok(Some(name)) = task.join() {
-            Some(name)
-        } else {
-            None
-        }
-    });
+    let result =
+        tasks
+            .into_iter()
+            .find_map(|task| match task.join().expect("Should join thread") {
+                Some(name) => Some(name),
+                None => None,
+            });
 
     // Restore the default panic hook
     std::panic::set_hook(default_hook);

--- a/docs/threading.md
+++ b/docs/threading.md
@@ -5,23 +5,35 @@ Mid-term we want to get rid of `tokio` for the ethercat part but keep it for `ax
 ## Threads
 ### Main Thread from `server::main::main`
 
+Main thread that inits the program and starts the other threads.
+
+Listend to a channel for panics other threads can send via the `send_panic` function.
+If the main thread recieves the panic signal it exits (`exit(1)`) the program.
+
+### `ApiThread` from `server::api::init::init_api`
 Creates a tokio runtime for the `init_api` function which starts the `axum` & `socketoxide` servers.
+
+Used `send_panic` to exit program if this thread panics.
 
 ### Ethercat Interface Test Threads from `server::ethercat::init::init_ethercat`  
 Starts threads for testing different interfaces in parallel.
 
 Uses Smol `LocalExecutor`.
 
-### `EthercatSetupLoopThread` from `server::ethercat::init::init_ethercat`
+### `EthercatLoopThread` from `server::ethercat::init::init_ethercat`
 Uses thread-local `smol` runtime.
 
 Starts the Ethercrab TX/RX thread.
 
 Runs the main control loop.
 
+Used `send_panic` to exit program if this thread panics.
+
 TODO: Should use realtime priority.
 
-### Ethercrab TX/RX Thread from `server::ethercat::loop::setup_loop`
+### `EthercatTxRxThread` from `server::ethercat::loop::setup_loop`
 Runs the Ethercrab TX/RX loop.
 
 TODO: Should use realtime priority.
+
+Used `send_panic` to exit program if this thread panics.

--- a/server/src/ethercat/init.rs
+++ b/server/src/ethercat/init.rs
@@ -1,19 +1,22 @@
 use super::r#loop::setup_loop;
 use crate::{
     app_state::{AppState, APP_STATE},
+    panic::PanicDetails,
     socketio::main_namespace::{
         ethercat_interface_discovery_event::EthercatInterfaceDiscoveryEvent, MainNamespaceEvents,
     },
 };
-use anyhow::anyhow;
 use control_core::{
     ethercat::interface_discovery::discover_ethercat_interface,
     socketio::namespace::NamespaceCacheingLogic,
 };
+use smol::channel::Sender;
 use std::sync::Arc;
-use thread_priority::{ThreadBuilderExt, ThreadPriority};
 
-pub async fn init_ethercat(app_state: Arc<AppState>) -> Result<(), anyhow::Error> {
+pub fn init_ethercat(
+    thread_panic_tx: Sender<PanicDetails>,
+    app_state: Arc<AppState>,
+) -> Result<(), anyhow::Error> {
     // Notify client via socketio
     let _ = smol::block_on(async move {
         let main_namespace = &mut APP_STATE
@@ -27,19 +30,21 @@ pub async fn init_ethercat(app_state: Arc<AppState>) -> Result<(), anyhow::Error
     });
 
     // tries to find a suitable interface in a loop
-    let interface = loop {
-        match discover_ethercat_interface().await {
-            Ok(interface) => {
-                log::info!("Found working interface: {}", interface);
-                break interface;
-            }
-            Err(_) => {
-                log::warn!("No working interface found, retrying...");
-                // wait 1 seconds before retrying
-                smol::Timer::after(std::time::Duration::from_secs(1)).await;
+    let interface = smol::block_on(async {
+        loop {
+            match discover_ethercat_interface().await {
+                Ok(interface) => {
+                    log::info!("Found working interface: {}", interface);
+                    break interface;
+                }
+                Err(_) => {
+                    log::warn!("No working interface found, retrying...");
+                    // wait 1 seconds before retrying
+                    smol::Timer::after(std::time::Duration::from_secs(1)).await;
+                }
             }
         }
-    };
+    });
 
     // Notify client via socketio
     let interface_clone = interface.clone();
@@ -54,24 +59,7 @@ pub async fn init_ethercat(app_state: Arc<AppState>) -> Result<(), anyhow::Error
         main_namespace.emit_cached(MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(event));
     });
 
-    // start the event loop
-    let loop_thread_handle = std::thread::Builder::new()
-        .name("EthercatSetupLoopThread".to_owned())
-        .spawn_with_priority(ThreadPriority::Max, move |_| {
-            let rt = smol::LocalExecutor::new();
-            smol::block_on(rt.run(async move {
-                log::info!("Starting Ethercat PDU loop");
-                let error = setup_loop(&interface, app_state.clone()).await;
-                log::error!("Ethercat PDU loop error: {}", error.unwrap_err());
-            }));
-        });
-
-    match loop_thread_handle {
-        Ok(_) => {}
-        Err(err) => {
-            return Err(anyhow!("Ethercat loop thread couldn't be created: {}", err));
-        }
-    };
+    smol::block_on(setup_loop(thread_panic_tx, &interface, app_state.clone()))?;
 
     Ok(())
 }

--- a/server/src/panic.rs
+++ b/server/src/panic.rs
@@ -1,0 +1,16 @@
+use smol::channel::Sender;
+
+#[derive(Debug)]
+pub struct PanicDetails {
+    pub thread_name: &'static str,
+}
+
+pub fn send_panic(thread_name: &'static str, thread_panic_tx: Sender<PanicDetails>) {
+    let old_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        smol::block_on(async {
+            let _ = thread_panic_tx.send(PanicDetails { thread_name }).await;
+        });
+        old_hook(panic_info);
+    }));
+}


### PR DESCRIPTION
The three essential threads `EthercatTxRxThread`, `EthertcatLoopThread` & `ApiThread` use a `smol::channel` to `send_panic` to the main thread. If one thread panics the main thread `exit(1)` the program.

fix #23 