### PR TITLE
Disable Laserpointer Buttons if `traverseState` is Not Available

### DIFF
--- a/control-core/src/actors/digital_output_setter.rs
+++ b/control-core/src/actors/digital_output_setter.rs
@@ -13,7 +13,7 @@ impl DigitalOutputSetter {
     pub fn new(output: DigitalOutput) -> Self {
         Self {
             output,
-            enabled: true,
+            enabled: false,
         }
     }
     pub fn set(&mut self, enabled: bool) {

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -143,7 +143,11 @@ export function Winder2ControlPage() {
           <Label label="Laserpointer">
             <SelectionGroupBoolean
               value={laserpointer}
-              disabled={laserpointerIsLoading}
+              disabled={
+                laserpointerIsLoading ||
+                traverseStateIsLoading ||
+                traverseStateIsDisabled
+              }
               loading={laserpointerIsDisabled}
               optionFalse={{ children: "Off", icon: "lu:LightbulbOff" }}
               optionTrue={{ children: "On", icon: "lu:Lightbulb" }}


### PR DESCRIPTION
- disable `DigitalOutputSetter` by default
- disable laserpointer buttons if `traverseState` is not available