### PR TITLE
Replaces XOR-based hashing with byte folding methods

### DIFF
--- a/control-core/src/helpers/hashing.rs
+++ b/control-core/src/helpers/hashing.rs
@@ -1,40 +1,108 @@
-pub fn xor_u128_to_u64(value: u128) -> u64 {
-    (value as u64) ^ ((value >> 64) as u64)
+/// Folds bytes using XOR to produce a u128 value.
+///
+/// Takes a slice of bytes and XORs them together in chunks to produce a u128.
+/// If there are fewer than 16 bytes, the remaining bytes are padded with zeros.
+pub fn byte_folding_u128(bytes: &[u8]) -> u128 {
+    let mut result = 0u128;
+    for (i, &byte) in bytes.iter().enumerate() {
+        let shift = (i % 16) * 8;
+        result ^= (byte as u128) << shift;
+    }
+    result
 }
 
-pub fn xor_u128_to_u32(value: u128) -> u32 {
-    (value as u32) ^ ((value >> 32) as u32) ^ ((value >> 64) as u32) ^ ((value >> 96) as u32)
+/// Folds bytes using XOR to produce a u64 value.
+///
+/// Takes a slice of bytes and XORs them together in chunks to produce a u64.
+/// If there are fewer than 8 bytes, the remaining bytes are padded with zeros.
+pub fn byte_folding_u64(bytes: &[u8]) -> u64 {
+    let mut result = 0u64;
+    for (i, &byte) in bytes.iter().enumerate() {
+        let shift = (i % 8) * 8;
+        result ^= (byte as u64) << shift;
+    }
+    result
 }
 
-pub fn xor_u128_to_u16(value: u128) -> u16 {
-    value
-        .to_le_bytes()
-        .iter()
-        .fold(0, |buf, &byte| buf ^ byte as u16)
+/// Folds bytes using XOR to produce a u32 value.
+///
+/// Takes a slice of bytes and XORs them together in chunks to produce a u32.
+/// If there are fewer than 4 bytes, the remaining bytes are padded with zeros.
+pub fn byte_folding_u32(bytes: &[u8]) -> u32 {
+    let mut result = 0u32;
+    for (i, &byte) in bytes.iter().enumerate() {
+        let shift = (i % 4) * 8;
+        result ^= (byte as u32) << shift;
+    }
+    result
 }
 
-pub fn xor_u128_to_u8(value: u128) -> u8 {
-    value.to_le_bytes().iter().fold(0, |buf, &byte| buf ^ byte)
+/// Folds bytes using XOR to produce a u16 value.
+///
+/// Takes a slice of bytes and XORs them together in chunks to produce a u16.
+/// If there are fewer than 2 bytes, the remaining bytes are padded with zeros.
+pub fn byte_folding_u16(bytes: &[u8]) -> u16 {
+    let mut result = 0u16;
+    for (i, &byte) in bytes.iter().enumerate() {
+        let shift = (i % 2) * 8;
+        result ^= (byte as u16) << shift;
+    }
+    result
 }
 
-// hash algorithm djb2
-pub fn hashing(input_to_hash: &str) -> u128 {
-    let mut hash: u128 = 5381;
-    let chars = input_to_hash.chars();
+/// Folds bytes using XOR to produce a u8 value.
+///
+/// Takes a slice of bytes and XORs them all together to produce a u8.
+pub fn byte_folding_u8(bytes: &[u8]) -> u8 {
+    bytes.iter().fold(0u8, |acc, &byte| acc ^ byte)
+}
 
-    for ch in chars {
-        hash = ((hash << 5) + hash) + (ch as u128);
+/// Computes a djb2 hash of the input bytes.
+///
+/// The djb2 algorithm is a simple non-cryptographic hash function created by
+/// Daniel J. Bernstein. It uses the formula: `hash = hash * 33 + byte` for each byte.
+///
+/// This implementation uses the traditional 32-bit hash value and uses wrapping
+/// arithmetic to handle potential overflows gracefully.
+///
+/// # Arguments
+///
+/// * `bytes` - A slice of bytes to hash
+///
+/// # Returns
+///
+/// A 32-bit hash value as a `u32`
+///
+/// # Examples
+///
+/// ```
+/// use control_core::helpers::hashing::hash_djb2;
+///
+/// let hash = hash_djb2(b"hello world");
+/// assert_ne!(hash, 0);
+/// ```
+///
+/// # Algorithm Details
+///
+/// - Initial hash value: 5381 (djb2 magic number)
+/// - For each byte: `hash = hash * 33 + byte`
+/// - Uses wrapping arithmetic to prevent overflow panics
+pub fn hash_djb2(bytes: &[u8]) -> u32 {
+    let mut hash: u32 = 5381;
+
+    for byte in bytes {
+        hash = hash.wrapping_mul(33).wrapping_add(*byte as u32);
     }
     hash
 }
+
 #[test]
 fn test_hash() {
     let test_case = "/dev/ttyUSB1";
-    let hash = hashing(test_case);
-    let hash_2bytes = xor_u128_to_u16(hash);
+    let hash_u32 = hash_djb2(test_case.as_bytes());
+    let hash_u16 = byte_folding_u16(&hash_u32.to_le_bytes());
     tracing::info!("{}", test_case);
     assert_eq!(test_case, "/dev/ttyUSB1");
-    assert!(hash == 8977446972540388683742);
-    assert!(hash_2bytes == 165);
-    println!("{:?}", hash);
+    assert_eq!(hash_u32, 266121182);
+    assert_eq!(hash_u16, 40962);
 }

--- a/server/src/serial/devices/laser/mod.rs
+++ b/server/src/serial/devices/laser/mod.rs
@@ -9,7 +9,7 @@ use crate::machines::{MACHINE_LASER_V1, VENDOR_QITECH};
 use anyhow::anyhow;
 use control_core::{
     helpers::{
-        hashing::{hashing, xor_u128_to_u16},
+        hashing::{hash_djb2, byte_folding_u16},
         retry::retry_n_times,
     },
     machines::identification::{
@@ -79,8 +79,8 @@ impl SerialDeviceNew for Laser {
             diameter: Length::new::<uom::si::length::millimeter>(0.0),
             last_timestamp: Instant::now(),
         });
-        let hash = hashing(&params.path.clone());
-        let serial = xor_u128_to_u16(hash);
+        let hash = hash_djb2(params.path.as_bytes());
+        let serial = byte_folding_u16(&hash.to_le_bytes());
         let device_identification = DeviceIdentification {
             device_machine_identification: Some(DeviceMachineIdentification {
                 machine_identification_unique: MachineIdentificationUnique {

--- a/server/src/serial/devices/mock/mod.rs
+++ b/server/src/serial/devices/mock/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use control_core::{
-    helpers::hashing::{hashing, xor_u128_to_u16},
+    helpers::hashing::{byte_folding_u16, hash_djb2},
     machines::identification::{
         DeviceHardwareIdentification, DeviceHardwareIdentificationSerial, DeviceIdentification,
         DeviceMachineIdentification, MachineIdentification, MachineIdentificationUnique,
@@ -29,8 +29,8 @@ impl SerialDeviceNew for MockSerialDevice {
         Self: Sized,
     {
         // Generate a unique serial number based on the path
-        let hash = hashing(&params.path);
-        let serial = xor_u128_to_u16(hash);
+        let hash = hash_djb2(params.path.as_bytes());
+        let serial = byte_folding_u16(&hash.to_le_bytes());
 
         let device_identification = DeviceIdentification {
             device_machine_identification: Some(DeviceMachineIdentification {


### PR DESCRIPTION
fix #442

Replaces previous XOR-based hashing functions with new byte folding methods for improved clarity and flexibility. Introduces a djb2 hashing implementation for non-cryptographic use cases.

Updates affected modules to use the new hashing functions, simplifying logic and enhancing maintainability.

Fixes inconsistencies in hashing logic across different data types.

