### PR TITLE
Use only a StateEvent and LiveValuesEvent on Laser V1

### DIFF
--- a/electron/src/machines/laser/laser1/Laser1ControlPage.tsx
+++ b/electron/src/machines/laser/laser1/Laser1ControlPage.tsx
@@ -13,17 +13,17 @@ import { DiameterVisualisation } from "../DiameterVisualisation";
 
 export function Laser1ControlPage() {
   const {
-    laserDiameter: laserDiameter,
-    laserState,
-    laserSetTargetDiameter,
-    laserSetLowerTolerance,
-    laserSetHigherTolerance,
+    diameter,
+    state,
+    setTargetDiameter,
+    setLowerTolerance,
+    setHigherTolerance,
   } = useLaser1();
 
-  // Controlled local states synced with laserState
-  const targetDiameter = laserState?.data?.target_diameter ?? 0;
-  const lowerTolerance = laserState?.data?.lower_tolerance ?? 0;
-  const higherTolerance = laserState?.data?.higher_tolerance ?? 0;
+  // Extract values from consolidated state
+  const targetDiameter = state?.laser_state?.target_diameter ?? 0;
+  const lowerTolerance = state?.laser_state?.lower_tolerance ?? 0;
+  const higherTolerance = state?.laser_state?.higher_tolerance ?? 0;
   return (
     <Page>
       <ControlGrid columns={2}>
@@ -32,13 +32,13 @@ export function Laser1ControlPage() {
             targetDiameter={targetDiameter}
             lowTolerance={lowerTolerance}
             highTolerance={higherTolerance}
-            diameter={laserDiameter}
+            diameter={diameter}
           />
           <div className="flex flex-row items-center gap-6">
             <TimeSeriesValueNumeric
               label="Current Diameter"
               unit="mm"
-              timeseries={laserDiameter}
+              timeseries={diameter}
               renderValue={(value) => value.toFixed(3)}
             />
           </div>
@@ -55,9 +55,9 @@ export function Laser1ControlPage() {
               renderValue={(value) => value.toFixed(2)}
               onChange={(val) => {
                 if (val < lowerTolerance) {
-                  laserSetLowerTolerance(val);
+                  setLowerTolerance(val);
                 }
-                laserSetTargetDiameter(val);
+                setTargetDiameter(val);
               }}
               defaultValue={0}
             />
@@ -71,7 +71,7 @@ export function Laser1ControlPage() {
               min={0}
               max={Math.min(targetDiameter, 1)}
               renderValue={(value) => value.toFixed(2)}
-              onChange={(val) => laserSetLowerTolerance(val)}
+              onChange={(val) => setLowerTolerance(val)}
               defaultValue={0}
             />
           </Label>
@@ -84,7 +84,7 @@ export function Laser1ControlPage() {
               min={0}
               max={1}
               renderValue={(value) => value.toFixed(2)}
-              onChange={(val) => laserSetHigherTolerance(val)}
+              onChange={(val) => setHigherTolerance(val)}
               defaultValue={0}
             />
           </Label>

--- a/electron/src/machines/laser/laser1/Laser1Graph.tsx
+++ b/electron/src/machines/laser/laser1/Laser1Graph.tsx
@@ -10,12 +10,12 @@ import React from "react";
 import { useLaser1 } from "./useLaser1";
 
 export function Laser1GraphsPage() {
-  const { laserDiameter, laserState } = useLaser1();
+  const { diameter, state } = useLaser1();
 
   const syncHook = useGraphSync(30 * 60 * 1000, "diameter-group");
-  const targetDiameter = laserState?.data?.target_diameter ?? 0;
-  const lowerTolerance = laserState?.data?.lower_tolerance ?? 0;
-  const higherTolerance = laserState?.data?.higher_tolerance ?? 0;
+  const targetDiameter = state?.laser_state?.target_diameter ?? 0;
+  const lowerTolerance = state?.laser_state?.lower_tolerance ?? 0;
+  const higherTolerance = state?.laser_state?.higher_tolerance ?? 0;
 
   const config: GraphConfig = {
     title: "Diameter",
@@ -35,7 +35,7 @@ export function Laser1GraphsPage() {
         <AutoSyncedBigGraph
           syncHook={syncHook}
           newData={{
-            newData: laserDiameter,
+            newData: diameter,
             color: "#3b82f6",
             lines: [
               {

--- a/server/src/machines/laser/act.rs
+++ b/server/src/machines/laser/act.rs
@@ -17,7 +17,7 @@ use std::{
 /// # Description
 /// This method is called to perform periodic actions for the `LaserMachine`. Specifically:
 /// - It checks if the time elapsed since the last measurement emission exceeds 20 milliseconds.
-/// - If the condition is met, it asynchronously emits Laser data by calling `emit_laser_data` and updates the `last_measurement_emit` timestamp.
+/// - If the condition is met, it asynchronously emits live values at 60 FPS.
 ///
 /// The method ensures that the diameter value is updated approximately 60 times per second.
 ///
@@ -27,8 +27,7 @@ impl Actor for LaserMachine {
             // The live values are updated approximately 60 times per second
             if now.duration_since(self.last_measurement_emit) > Duration::from_secs_f64(1.0 / 60.0)
             {
-                self.emit_diameter();
-                self.emit_laser_state();
+                self.emit_live_values();
                 self.last_measurement_emit = now;
             }
         })

--- a/server/src/machines/laser/mod.rs
+++ b/server/src/machines/laser/mod.rs
@@ -1,5 +1,5 @@
 use crate::serial::devices::laser::Laser;
-use api::{DiameterEvent, LaserEvents, LaserMachineNamespace, LaserStateEvent};
+use api::{LaserEvents, LaserMachineNamespace, LaserState, LiveValuesEvent, StateEvent};
 use control_core::{machines::Machine, socketio::namespace::NamespaceCacheingLogic};
 use smol::lock::RwLock;
 use std::{sync::Arc, time::Instant};
@@ -26,7 +26,7 @@ impl Machine for LaserMachine {}
 
 impl LaserMachine {
     ///diameter in mm
-    pub fn emit_diameter(&mut self) {
+    pub fn emit_live_values(&mut self) {
         let diameter = smol::block_on(async {
             self.laser
                 .read()
@@ -35,32 +35,39 @@ impl LaserMachine {
                 .await
                 .map(|laser_data| laser_data.diameter.get::<millimeter>())
         });
-        let diameter_event = DiameterEvent {
+        let live_values = LiveValuesEvent {
             diameter: diameter.unwrap_or(0.0),
         };
         self.namespace
-            .emit(LaserEvents::Diameter(diameter_event.build()));
+            .emit(LaserEvents::LiveValues(live_values.build()));
     }
 
-    pub fn emit_laser_state(&mut self) {
-        let laser_state_event = LaserStateEvent {
-            higher_tolerance: self.laser_target.higher_tolerance.get::<millimeter>(),
-            lower_tolerance: self.laser_target.lower_tolerance.get::<millimeter>(),
-            target_diameter: self.laser_target.diameter.get::<millimeter>(),
+    pub fn emit_state(&mut self) {
+        let state = StateEvent {
+            laser_state: LaserState {
+                higher_tolerance: self.laser_target.higher_tolerance.get::<millimeter>(),
+                lower_tolerance: self.laser_target.lower_tolerance.get::<millimeter>(),
+                target_diameter: self.laser_target.diameter.get::<millimeter>(),
+            },
         };
 
         self.namespace
-            .emit(LaserEvents::LaserState(laser_state_event.build()));
+            .emit(LaserEvents::State(state.build()));
     }
 
-    pub fn target_set_higher_tolerance(&mut self, higher_tolerance: f64) {
+    pub fn set_higher_tolerance(&mut self, higher_tolerance: f64) {
         self.laser_target.higher_tolerance = Length::new::<millimeter>(higher_tolerance);
+        self.emit_state();
     }
-    pub fn target_set_lower_tolerance(&mut self, lower_tolerance: f64) {
+    
+    pub fn set_lower_tolerance(&mut self, lower_tolerance: f64) {
         self.laser_target.lower_tolerance = Length::new::<millimeter>(lower_tolerance);
+        self.emit_state();
     }
-    pub fn target_set_target_diameter(&mut self, target_diameter: f64) {
+    
+    pub fn set_target_diameter(&mut self, target_diameter: f64) {
         self.laser_target.diameter = Length::new::<millimeter>(target_diameter);
+        self.emit_state();
     }
 }
 #[derive(Debug, Clone)]

--- a/server/src/machines/laser/new.rs
+++ b/server/src/machines/laser/new.rs
@@ -41,11 +41,16 @@ impl MachineNewTrait for LaserMachine {
             lower_tolerance: Length::new::<millimeter>(0.05),
             diameter: Length::new::<millimeter>(1.75),
         };
-        Ok(Self {
+        let mut laser_machine = Self {
             laser,
             namespace: LaserMachineNamespace::new(params.socket_queue_tx.clone()),
             last_measurement_emit: Instant::now(),
             laser_target,
-        })
+        };
+        
+        // Emit initial state
+        laser_machine.emit_state();
+        
+        Ok(laser_machine)
     }
 }


### PR DESCRIPTION
fix #454 

This commit refactors the state management and event handling for the laser machine on both the frontend and backend. The changes clarify the distinction between infrequently changing state and frequently updated live values.

- **State and Event Consolidation:**
    - Renamed `DiameterEvent` to `LiveValuesEvent` and `LaserStateEvent` to `StateEvent` for better clarity.
    - The `StateEvent` now nests laser properties under a `laser_state` object.
    - Frontend hook `useLaser1` now manages a single, consolidated state object with optimistic updates using `immer`.

- **API and Naming Simplification:**
    - Simplified mutation names by removing the "Target" prefix (e.g., `TargetSetTargetDiameter` is now `SetTargetDiameter`).
    - Renamed variables and functions in the frontend for better readability (e.g., `laserDiameter` to `diameter`, `laserSet...` to `set...`).

- **Improved Backend Efficiency:**
    - The backend now emits the full state only when it changes, rather than on every tick.
    - Live values (diameter) are still emitted at 60 FPS.