### PR TITLE
refactor: Run EtherCAT initialization in a separate thread

### DIFF
--- a/server/src/ethercat/init.rs
+++ b/server/src/ethercat/init.rs
@@ -1,7 +1,7 @@
 use super::setup::setup_loop;
 use crate::{
     app_state::AppState,
-    panic::PanicDetails,
+    panic::{PanicDetails, send_panic},
     socketio::main_namespace::{
         MainNamespaceEvents, ethercat_interface_discovery_event::EthercatInterfaceDiscoveryEvent,
     },
@@ -17,51 +17,66 @@ pub fn init_ethercat(
     thread_panic_tx: Sender<PanicDetails>,
     app_state: Arc<AppState>,
 ) -> Result<(), anyhow::Error> {
-    // Notify client via socketio
+    let thread_panic_tx_clone = thread_panic_tx.clone();
     let app_state_clone = app_state.clone();
-    let _ = smol::block_on(async move {
-        let main_namespace = &mut app_state_clone
-            .socketio_setup
-            .namespaces
-            .write()
-            .await
-            .main_namespace;
-        let event = EthercatInterfaceDiscoveryEvent::Discovering(true).build();
-        main_namespace.emit(MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(event));
-    });
 
-    // tries to find a suitable interface in a loop
-    let interface = smol::block_on(async {
-        loop {
-            match discover_ethercat_interface().await {
-                Ok(interface) => {
-                    tracing::info!("Found working interface: {}", interface);
-                    break interface;
+    std::thread::Builder::new()
+        .name("init_ethercat".to_string())
+        .spawn(move || {
+            send_panic(thread_panic_tx_clone.clone());
+
+            // Notify client via socketio
+            let app_state_socketio = app_state_clone.clone();
+            let _ = smol::block_on(async move {
+                let main_namespace = &mut app_state_socketio
+                    .socketio_setup
+                    .namespaces
+                    .write()
+                    .await
+                    .main_namespace;
+                let event = EthercatInterfaceDiscoveryEvent::Discovering(true).build();
+                main_namespace.emit(MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(event));
+            });
+
+            // tries to find a suitable interface in a loop
+            let interface = smol::block_on(async {
+                loop {
+                    match discover_ethercat_interface().await {
+                        Ok(interface) => {
+                            tracing::info!("Found working interface: {}", interface);
+                            break interface;
+                        }
+                        Err(_) => {
+                            tracing::warn!("No working interface found, retrying...");
+                            // wait 1 seconds before retrying
+                            smol::Timer::after(std::time::Duration::from_secs(1)).await;
+                        }
+                    }
                 }
-                Err(_) => {
-                    tracing::warn!("No working interface found, retrying...");
-                    // wait 1 seconds before retrying
-                    smol::Timer::after(std::time::Duration::from_secs(1)).await;
-                }
+            });
+
+            // Notify client via socketio
+            let interface_clone = interface.clone();
+            let app_state_socketio = app_state_clone.clone();
+            let _ = smol::block_on(async move {
+                let main_namespace = &mut app_state_socketio
+                    .socketio_setup
+                    .namespaces
+                    .write()
+                    .await
+                    .main_namespace;
+                let event = EthercatInterfaceDiscoveryEvent::Done(interface_clone).build();
+                main_namespace.emit(MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(event));
+            });
+
+            if let Err(e) = smol::block_on(setup_loop(
+                thread_panic_tx_clone,
+                &interface,
+                app_state_clone,
+            )) {
+                tracing::error!("EtherCAT setup failed: {:?}", e);
             }
-        }
-    });
-
-    // Notify client via socketio
-    let interface_clone = interface.clone();
-    let app_state_clone = app_state.clone();
-    let _ = smol::block_on(async move {
-        let main_namespace = &mut app_state_clone
-            .socketio_setup
-            .namespaces
-            .write()
-            .await
-            .main_namespace;
-        let event = EthercatInterfaceDiscoveryEvent::Done(interface_clone).build();
-        main_namespace.emit(MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(event));
-    });
-
-    smol::block_on(setup_loop(thread_panic_tx, &interface, app_state.clone()))?;
+        })?;
 
     Ok(())
 }

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -2,11 +2,10 @@ use crate::app_state::AppState;
 use crate::panic::{PanicDetails, send_panic};
 use bitvec::prelude::*;
 use control_core::helpers::loop_trottle::LoopThrottle;
-use control_core::helpers::retry::retry_conditionally_async;
 use smol::channel::Sender;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, instrument, trace_span};
+use tracing::{instrument, trace_span};
 
 pub fn init_loop(
     thread_panic_tx: Sender<PanicDetails>,

--- a/server/src/machines/laser/act.rs
+++ b/server/src/machines/laser/act.rs
@@ -22,10 +22,9 @@ use std::{
 /// The method ensures that the diameter value is updated approximately 60 times per second.
 ///
 impl Actor for LaserMachine {
-    fn act(&mut self, _now_ts: Instant) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+    fn act(&mut self, now: Instant) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            let now = Instant::now();
-            // The diameter value is updated approximately 60 times per second
+            // The live values are updated approximately 60 times per second
             if now.duration_since(self.last_measurement_emit) > Duration::from_secs_f64(1.0 / 60.0)
             {
                 self.emit_diameter();


### PR DESCRIPTION
repopen of #460
fix #459  

This change refactors the EtherCAT initialization process to be non-blocking by moving it into its own dedicated thread.

- The `init_ethercat` function now spawns a named thread ("init_ethercat") to handle interface discovery and the setup loop.
- This prevents the main application from blocking during startup while searching for a valid EtherCAT interface.
- The initialization order in `main.rs` has been slightly adjusted.
- A minor optimization was made to the laser machine actor to avoid redundant `Instant::now()` calls.