### PR TITLE
refactor(extruder2): Consolidate state and event handling

### DIFF
--- a/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
@@ -16,38 +16,29 @@ import { StatusBadge } from "@/control/StatusBadge";
 
 export function Extruder2ControlPage() {
   const {
-    mode,
-    nozzleHeatingState,
+    state,
     nozzleTemperature,
     nozzlePower,
-
-    frontHeatingState,
     frontTemperature,
     frontPower,
-
-    backHeatingState,
     backTemperature,
     backPower,
-
-    middleHeatingState,
     middleTemperature,
     middlePower,
+    screwRpm,
+    pressure,
 
-    extruderSetMode,
-    heatingSetBackTemp,
-    heatingSetFrontTemp,
-    heatingSetMiddleTemp,
-    heatingSetNozzleTemp,
-    screwSetRegulation,
-    screwSetTargetPressure,
-    screwSetTargetRpm,
+    setExtruderMode,
+    setBackHeatingTemperature,
+    setFrontHeatingTemperature,
+    setMiddleHeatingTemperature,
+    setNozzleHeatingTemperature,
+    setInverterRegulation,
+    setInverterTargetPressure,
+    setInverterTargetRpm,
 
-    uses_rpm,
-    bar,
-    rpm,
-    targetBar,
-    targetRpm,
-    inverterState,
+    isLoading,
+    isDisabled,
   } = useExtruder2();
 
   return (
@@ -55,86 +46,88 @@ export function Extruder2ControlPage() {
       <ControlGrid>
         <HeatingZone
           title={"Heating Front"}
-          heatingState={frontHeatingState}
+          heatingState={state?.heating_states.front}
           heatingTimeSeries={frontTemperature}
           heatingPower={frontPower}
-          onChangeTargetTemp={heatingSetFrontTemp}
+          onChangeTargetTemp={setFrontHeatingTemperature}
           min={0}
           max={300}
         />
         <HeatingZone
           title={"Heating Middle"}
-          heatingState={middleHeatingState}
+          heatingState={state?.heating_states.middle}
           heatingTimeSeries={middleTemperature}
           heatingPower={middlePower}
-          onChangeTargetTemp={heatingSetMiddleTemp}
+          onChangeTargetTemp={setMiddleHeatingTemperature}
           min={0}
           max={300}
         />
         <HeatingZone
           title={"Heating Back"}
-          heatingState={backHeatingState}
+          heatingState={state?.heating_states.back}
           heatingTimeSeries={backTemperature}
           heatingPower={backPower}
-          onChangeTargetTemp={heatingSetBackTemp}
+          onChangeTargetTemp={setBackHeatingTemperature}
           min={0}
           max={300}
         />
         <HeatingZone
           title={"Heating Nozzle"}
-          heatingState={nozzleHeatingState}
+          heatingState={state?.heating_states.nozzle}
           heatingTimeSeries={nozzleTemperature}
           heatingPower={nozzlePower}
-          onChangeTargetTemp={heatingSetNozzleTemp}
+          onChangeTargetTemp={setNozzleHeatingTemperature}
           min={0}
           max={300}
         />
         <ControlCard className="bg-red" title="Screw Drive">
-          {inverterState?.fault_occurence == true && (
+          {state?.inverter_status_state.fault_occurence == true && (
             <StatusBadge variant="error">
               Inverter encountered an error!! Press the restart button in Config
             </StatusBadge>
           )}
-          {inverterState?.running == true &&
-            inverterState.fault_occurence == false && (
+          {state?.inverter_status_state.running == true &&
+            state.inverter_status_state.fault_occurence == false && (
               <StatusBadge variant="success">Running</StatusBadge>
             )}
-          {inverterState?.running == false &&
-            inverterState.fault_occurence == false && (
+          {state?.inverter_status_state.running == false &&
+            state.inverter_status_state.fault_occurence == false && (
               <StatusBadge variant="success">Healthy</StatusBadge>
             )}
 
           <Label label="Regulation">
             <SelectionGroupBoolean
-              value={uses_rpm}
+              value={state?.regulation_state.uses_rpm}
               optionTrue={{ children: "RPM" }}
               optionFalse={{ children: "Pressure" }}
-              onChange={screwSetRegulation}
+              onChange={setInverterRegulation}
+              disabled={isDisabled}
+              loading={isLoading}
             />
           </Label>
           <div className="flex flex-row flex-wrap gap-4">
             <Label label="Target Output RPM">
               <EditValue
-                value={targetRpm}
+                value={state?.screw_state.target_rpm}
                 defaultValue={0}
                 unit="rpm"
                 title="Target Output RPM"
                 min={0}
                 max={106}
                 renderValue={(value) => roundToDecimals(value, 0)}
-                onChange={screwSetTargetRpm}
+                onChange={setInverterTargetRpm}
               />
             </Label>
             <Label label="Target Pressure">
               <EditValue
-                value={targetBar}
+                value={state?.pressure_state.target_bar}
                 defaultValue={0}
                 unit="bar"
                 title="Target Pressure"
                 min={0.0}
                 max={150.0}
                 renderValue={(value) => roundToDecimals(value, 0)}
-                onChange={screwSetTargetPressure}
+                onChange={setInverterTargetPressure}
               />
             </Label>
           </div>
@@ -143,21 +136,21 @@ export function Extruder2ControlPage() {
               label="Rpm"
               unit="rpm"
               renderValue={(value) => roundToDecimals(value, 0)}
-              timeseries={rpm}
+              timeseries={screwRpm}
             />
 
             <TimeSeriesValueNumeric
               label="Pressure"
               unit="bar"
               renderValue={(value) => roundToDecimals(value, 0)}
-              timeseries={bar}
+              timeseries={pressure}
             />
           </div>
         </ControlCard>
 
         <ControlCard className="bg-red" title="Mode">
           <SelectionGroup<"Standby" | "Heat" | "Extrude">
-            value={mode}
+            value={state?.mode_state.mode}
             orientation="vertical"
             className="grid h-full grid-cols-2 gap-2"
             options={{
@@ -180,7 +173,9 @@ export function Extruder2ControlPage() {
                 className: "h-full",
               },
             }}
-            onChange={extruderSetMode}
+            onChange={setExtruderMode}
+            disabled={isDisabled}
+            loading={isLoading}
           />
         </ControlCard>
       </ControlGrid>

--- a/electron/src/machines/extruder/extruder2/Extruder2Graph.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2Graph.tsx
@@ -10,26 +10,17 @@ import { useExtruder2 } from "./useExtruder";
 
 export function Extruder2GraphsPage() {
   const {
-    nozzleHeatingState,
+    state,
     nozzleTemperature,
     nozzlePower,
-
-    frontHeatingState,
     frontTemperature,
     frontPower,
-
-    backHeatingState,
     backTemperature,
     backPower,
-
-    middleHeatingState,
     middleTemperature,
     middlePower,
-
-    bar,
-    rpm,
-    targetBar,
-    targetRpm,
+    pressure,
+    screwRpm,
   } = useExtruder2();
 
   const syncHook = useGraphSync(30 * 60 * 1000, "extruder-graphs");
@@ -49,11 +40,11 @@ export function Extruder2GraphsPage() {
             newData: nozzleTemperature,
             color: "#ef4444",
             lines:
-              nozzleHeatingState?.target_temperature !== undefined
+              state?.heating_states.nozzle?.target_temperature !== undefined
                 ? [
                     {
                       type: "target" as const,
-                      value: nozzleHeatingState.target_temperature,
+                      value: state.heating_states.nozzle.target_temperature,
                       color: "#ef4444",
                       show: true,
                     },
@@ -68,11 +59,11 @@ export function Extruder2GraphsPage() {
             newData: frontTemperature,
             color: "#f59e0b",
             lines:
-              frontHeatingState?.target_temperature !== undefined
+              state?.heating_states.front?.target_temperature !== undefined
                 ? [
                     {
                       type: "target" as const,
-                      value: frontHeatingState.target_temperature,
+                      value: state.heating_states.front.target_temperature,
                       color: "#f59e0b",
                       show: true,
                     },
@@ -87,11 +78,11 @@ export function Extruder2GraphsPage() {
             newData: middleTemperature,
             color: "#8b5cf6",
             lines:
-              middleHeatingState?.target_temperature !== undefined
+              state?.heating_states.middle?.target_temperature !== undefined
                 ? [
                     {
                       type: "target" as const,
-                      value: middleHeatingState.target_temperature,
+                      value: state.heating_states.middle.target_temperature,
                       color: "#8b5cf6",
                       show: true,
                     },
@@ -106,11 +97,11 @@ export function Extruder2GraphsPage() {
             newData: backTemperature,
             color: "#3b82f6",
             lines:
-              backHeatingState?.target_temperature !== undefined
+              state?.heating_states.back?.target_temperature !== undefined
                 ? [
                     {
                       type: "target" as const,
-                      value: backHeatingState.target_temperature,
+                      value: state.heating_states.back.target_temperature,
                       color: "#3b82f6",
                       show: true,
                     },
@@ -217,14 +208,14 @@ export function Extruder2GraphsPage() {
         <AutoSyncedBigGraph
           syncHook={syncHook}
           newData={{
-            newData: bar,
+            newData: pressure,
             color: "#3b82f6",
             lines:
-              targetBar !== undefined
+              state?.pressure_state.target_bar !== undefined
                 ? [
                     {
                       type: "target" as const,
-                      value: targetBar,
+                      value: state.pressure_state.target_bar,
                       color: "#3b82f6",
                       show: true,
                     },
@@ -258,14 +249,14 @@ export function Extruder2GraphsPage() {
         <AutoSyncedBigGraph
           syncHook={syncHook}
           newData={{
-            newData: rpm,
+            newData: screwRpm,
             color: "#8b5cf6",
             lines:
-              targetRpm !== undefined
+              state?.screw_state.target_rpm !== undefined
                 ? [
                     {
                       type: "target" as const,
-                      value: targetRpm,
+                      value: state.screw_state.target_rpm,
                       color: "#8b5cf6",
                       show: true,
                     },

--- a/electron/src/machines/extruder/extruder2/Extruder2Settings.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Page } from "@/components/Page";
 import { ControlCard } from "@/control/ControlCard";
 import { Label } from "@/control/Label";
@@ -9,50 +9,33 @@ import { useExtruder2 } from "./useExtruder";
 
 export function Extruder2SettingsPage() {
   const {
-    inverterSetRotation,
-    inverterReset,
-    rotationState,
-    extruderSetPressureLimit,
-    extruderSetPressureLimitIsEnabled,
-    pressureLimitState,
-    pressureLimitEnabledState,
-    pressurePidSettings,
-    setPressurePid,
+    state,
+    setInverterRotationDirection,
+    resetInverter,
+    setExtruderPressureLimit,
+    setExtruderPressureLimitEnabled,
+    setPressurePidKp,
+    setPressurePidKi,
+    setPressurePidKd,
   } = useExtruder2();
 
   const [showAdvanced, setShowAdvanced] = useState(false);
-
-  const [pid2, setPid2] = useState<{
-    kp: number;
-    ki: number;
-    kd: number;
-  } | null>(null);
-
-  useEffect(() => {
-    if (!pid2 && pressurePidSettings) {
-      setPid2(pressurePidSettings);
-    }
-  }, [pressurePidSettings, pid2]);
-
-  if (!pid2) {
-    return <div>Loading PID settings...</div>;
-  }
 
   return (
     <Page>
       <ControlCard className="bg-red" title="Inverter Settings">
         <Label label="Rotation Direction">
           <SelectionGroupBoolean
-            value={rotationState}
+            value={state?.rotation_state.forward}
             optionTrue={{ children: "Forward" }}
             optionFalse={{ children: "Backward" }}
-            onChange={inverterSetRotation}
+            onChange={setInverterRotationDirection}
           />
         </Label>
 
         <Label label="Reset Inverter">
           <button
-            onClick={inverterReset}
+            onClick={resetInverter}
             className="inline-block w-fit max-w-max rounded bg-red-600 px-4 py-4 text-base whitespace-nowrap text-white hover:bg-red-700"
             style={{ minWidth: "auto", width: "fit-content" }}
           >
@@ -64,22 +47,22 @@ export function Extruder2SettingsPage() {
       <ControlCard className="bg-red" title="Extruder Settings">
         <Label label="Nozzle Pressure Limit">
           <EditValue
-            value={pressureLimitState}
+            value={state?.extruder_settings_state.pressure_limit}
             defaultValue={0}
             unit="bar"
             title="Nozzle Pressure Limit"
             min={0}
             max={350}
             renderValue={(value) => roundToDecimals(value, 0)}
-            onChange={extruderSetPressureLimit}
+            onChange={setExtruderPressureLimit}
           />
         </Label>
         <Label label="Nozzle Pressure Limit Enabled">
           <SelectionGroupBoolean
-            value={pressureLimitEnabledState}
+            value={state?.extruder_settings_state.pressure_limit_enabled}
             optionTrue={{ children: "Enabled" }}
             optionFalse={{ children: "Disabled" }}
-            onChange={extruderSetPressureLimitIsEnabled}
+            onChange={setExtruderPressureLimitEnabled}
           />
         </Label>
         <Label label="Show Advanced PID Settings">
@@ -97,49 +80,40 @@ export function Extruder2SettingsPage() {
           <ControlCard title="Pressure PID Settings ">
             <Label label="Kp">
               <EditValue
-                value={pid2.kp}
+                value={state?.pid_settings.pressure.kp}
                 defaultValue={0}
                 min={0}
                 max={100}
                 step={0.01}
                 renderValue={(v) => roundToDecimals(v, 2)}
-                onChange={(v) => setPid2({ ...pid2, kp: v })}
+                onChange={setPressurePidKp}
                 title="Pressure PID KP"
               />
             </Label>
             <Label label="Ki">
               <EditValue
-                value={pid2.ki}
+                value={state?.pid_settings.pressure.ki}
                 defaultValue={0}
                 min={0}
                 max={100}
                 step={0.01}
                 renderValue={(v) => roundToDecimals(v, 2)}
-                onChange={(v) => setPid2({ ...pid2, ki: v })}
+                onChange={setPressurePidKi}
                 title="Pressure PID KI"
               />
             </Label>
             <Label label="Kd">
               <EditValue
-                value={pid2.kd}
+                value={state?.pid_settings.pressure.kd}
                 defaultValue={0}
                 min={0}
                 max={100}
                 step={0.01}
                 renderValue={(v) => roundToDecimals(v, 2)}
-                onChange={(v) => setPid2({ ...pid2, kd: v })}
+                onChange={setPressurePidKd}
                 title="Pressure PID KD"
               />
             </Label>
-
-            <div className="mt-2 flex justify-end">
-              <button
-                className="rounded bg-blue-600 px-4 py-2 text-white"
-                onClick={() => setPressurePid(pid2)}
-              >
-                Save Pressure PID
-              </button>
-            </div>
           </ControlCard>
         </>
       )}

--- a/electron/src/machines/extruder/extruder2/extruder2Namespace.ts
+++ b/electron/src/machines/extruder/extruder2/extruder2Namespace.ts
@@ -8,41 +8,175 @@ import {
   NamespaceId,
   createNamespaceHookImplementation,
   ThrottledStoreUpdater,
+  handleUnhandledEventError,
 } from "../../../client/socketioStore";
 import { MachineIdentificationUnique } from "@/machines/types";
-import {
-  createTimeSeries,
-  TimeSeries,
-  TimeSeriesValue,
-} from "@/lib/timeseries";
+import { createTimeSeries, TimeSeries } from "@/lib/timeseries";
+import { useMemo } from "react";
+
+// ========== Event Schema Definitions ==========
+
+/**
+ * Machine operation mode enum
+ */
+export const modeSchema = z.enum(["Standby", "Heat", "Extrude"]);
+export type Mode = z.infer<typeof modeSchema>;
+
+/**
+ * Consolidated live values event schema (60FPS data)
+ */
+export const liveValuesEventDataSchema = z.object({
+  screw_rpm: z.number(),
+  pressure: z.number(),
+  nozzle_temperature: z.number(),
+  front_temperature: z.number(),
+  back_temperature: z.number(),
+  middle_temperature: z.number(),
+  nozzle_power: z.number(),
+  front_power: z.number(),
+  back_power: z.number(),
+  middle_power: z.number(),
+});
+
+/**
+ * Rotation state schema
+ */
+export const rotationStateSchema = z.object({
+  forward: z.boolean(),
+});
+
+/**
+ * Mode state schema
+ */
+export const modeStateSchema = z.object({
+  mode: modeSchema,
+});
+
+/**
+ * Regulation state schema
+ */
+export const regulationStateSchema = z.object({
+  uses_rpm: z.boolean(),
+});
+
+/**
+ * Pressure state schema
+ */
+export const pressureStateSchema = z.object({
+  bar: z.number(),
+  target_bar: z.number(),
+});
+
+/**
+ * Screw state schema
+ */
+export const screwStateSchema = z.object({
+  rpm: z.number(),
+  target_rpm: z.number(),
+});
+
+/**
+ * Heating state schema
+ */
+export const heatingStateSchema = z.object({
+  temperature: z.number(),
+  target_temperature: z.number(),
+  wiring_error: z.boolean(),
+});
+
+/**
+ * Heating states schema
+ */
+export const heatingStatesSchema = z.object({
+  nozzle: heatingStateSchema,
+  front: heatingStateSchema,
+  back: heatingStateSchema,
+  middle: heatingStateSchema,
+});
+
+/**
+ * Extruder settings state schema
+ */
+export const extruderSettingsStateSchema = z.object({
+  pressure_limit: z.number(),
+  pressure_limit_enabled: z.boolean(),
+});
+
+/**
+ * Inverter status state schema
+ */
+export const inverterStatusStateSchema = z.object({
+  running: z.boolean(),
+  forward_running: z.boolean(),
+  reverse_running: z.boolean(),
+  up_to_frequency: z.boolean(),
+  overload_warning: z.boolean(),
+  no_function: z.boolean(),
+  output_frequency_detection: z.boolean(),
+  abc_fault: z.boolean(),
+  fault_occurence: z.boolean(),
+});
+
+/**
+ * PID settings schema
+ */
+export const pidSettingsSchema = z.object({
+  temperature: z.object({
+    ki: z.number(),
+    kp: z.number(),
+    kd: z.number(),
+  }),
+  pressure: z.object({
+    ki: z.number(),
+    kp: z.number(),
+    kd: z.number(),
+  }),
+});
+
+/**
+ * Consolidated state event schema (state changes only)
+ */
+export const stateEventDataSchema = z.object({
+  rotation_state: rotationStateSchema,
+  mode_state: modeStateSchema,
+  regulation_state: regulationStateSchema,
+  pressure_state: pressureStateSchema,
+  screw_state: screwStateSchema,
+  heating_states: heatingStatesSchema,
+  extruder_settings_state: extruderSettingsStateSchema,
+  inverter_status_state: inverterStatusStateSchema,
+  pid_settings: pidSettingsSchema,
+});
+
+// ========== Event Schemas with Wrappers ==========
+
+export const liveValuesEventSchema = eventSchema(liveValuesEventDataSchema);
+export const stateEventSchema = eventSchema(stateEventDataSchema);
+
+// ========== Type Inferences ==========
+
+export type StateEvent = z.infer<typeof stateEventSchema>;
+
+// Additional exports for backward compatibility
+export const SetRegulationSchema = z.object({
+  uses_rpm: z.boolean(),
+});
+
+export const mode = z.object({
+  mode: modeSchema,
+});
 
 export type Extruder2NamespaceStore = {
-  modeState: ModeStateEvent | null;
-  inverterState: InverterStatusEvent | null;
-  rotationState: InverterRotationEvent | null;
+  // Single state event from server
+  state: StateEvent | null;
 
-  heatingNozzleState: HeatingStateEvent | null;
-  heatingFrontState: HeatingStateEvent | null;
-  heatingBackState: HeatingStateEvent | null;
-  heatingMiddleState: HeatingStateEvent | null;
-
-  motorRpmState: MotorScrewStateEvent | null;
-  motorBarState: MotorPressureStateEvent | null;
-  motorRegulationState: MotorRegulationStateEvent | null;
-
-  extruderSettingsState: ExtruderSettingsStateEvent | null;
-
-  pressurePidSettings: PidSettingsEvent | null;
-  temperaturePidSettings: PidSettingsEvent | null;
-  // Metric Events (cached for 1 hour )
-  rpm: TimeSeries;
-  bar: TimeSeries;
-
+  // Time series data for live values
+  screwRpm: TimeSeries;
+  pressure: TimeSeries;
   nozzleTemperature: TimeSeries;
   frontTemperature: TimeSeries;
   backTemperature: TimeSeries;
   middleTemperature: TimeSeries;
-
   nozzlePower: TimeSeries;
   frontPower: TimeSeries;
   middlePower: TimeSeries;
@@ -54,6 +188,20 @@ const TWENTY_MILLISECOND = 20;
 const ONE_SECOND = 1000;
 const FIVE_SECOND = 5 * ONE_SECOND;
 const ONE_HOUR = 60 * 60 * ONE_SECOND;
+
+const { initialTimeSeries: screwRpm, insert: addScrewRpm } = createTimeSeries(
+  TWENTY_MILLISECOND,
+  ONE_SECOND,
+  FIVE_SECOND,
+  ONE_HOUR,
+);
+
+const { initialTimeSeries: pressure, insert: addPressure } = createTimeSeries(
+  TWENTY_MILLISECOND,
+  ONE_SECOND,
+  FIVE_SECOND,
+  ONE_HOUR,
+);
 
 const { initialTimeSeries: backTemperature, insert: addBackTemperature } =
   createTimeSeries(TWENTY_MILLISECOND, ONE_SECOND, FIVE_SECOND, ONE_HOUR);
@@ -83,20 +231,6 @@ const { initialTimeSeries: backPower, insert: addBackPower } = createTimeSeries(
   ONE_HOUR,
 );
 
-const { initialTimeSeries: rpm, insert: addRpm } = createTimeSeries(
-  TWENTY_MILLISECOND,
-  ONE_SECOND,
-  FIVE_SECOND,
-  ONE_HOUR,
-);
-
-const { initialTimeSeries: bar, insert: addBar } = createTimeSeries(
-  TWENTY_MILLISECOND,
-  ONE_SECOND,
-  FIVE_SECOND,
-  ONE_HOUR,
-);
-
 export function extruder2MessageHandler(
   store: StoreApi<Extruder2NamespaceStore>,
   throttledUpdater: ThrottledStoreUpdater<Extruder2NamespaceStore>,
@@ -112,169 +246,65 @@ export function extruder2MessageHandler(
     };
 
     try {
-      if (eventName == "PressurePidSettingsEvent") {
-        updateStore((state) => ({
-          ...state,
-          pressurePidSettings: pidSettingsEventSchema.parse(event),
-        }));
-      }
-
-      if (eventName == "ExtruderSettingsStateEvent") {
-        updateStore((state) => ({
-          ...state,
-          extruderSettingsState: extruderSettingsStateEventSchema.parse(event),
-        }));
-      }
-
-      if (eventName == "InverterStatusEvent") {
-        console.log(eventName);
-        updateStore((state) => ({
-          ...state,
-          inverterState: event as InverterStatusEvent,
-        }));
-      } else if (eventName == "RotationStateEvent") {
-        updateStore((state) => ({
-          ...state,
-          rotationState: event as InverterRotationEvent,
-        }));
-      } else if (eventName == "ModeStateEvent") {
-        updateStore((state) => ({
-          ...state,
-          modeState: event as ModeStateEvent,
-        }));
-      } else if (eventName == "FrontHeatingStateEvent") {
-        const heatingEvent = event as HeatingStateEvent;
-        const timeseriesValue: TimeSeriesValue = {
-          value: heatingEvent.data.temperature,
-          timestamp: event.ts,
-        };
+      if (eventName === "StateEvent") {
+        const stateEvent = stateEventSchema.parse(event);
+        console.log("StateEvent", stateEvent);
 
         updateStore((state) => ({
           ...state,
-          heatingFrontState: heatingEvent,
-          frontTemperature: addFrontTemperature(
-            state.frontTemperature,
-            timeseriesValue,
-          ),
+          state: stateEvent,
         }));
-      } else if (eventName == "NozzleHeatingStateEvent") {
-        const heatingEvent = event as HeatingStateEvent;
-        const timeseriesValue: TimeSeriesValue = {
-          value: heatingEvent.data.temperature,
-          timestamp: event.ts,
-        };
+      } else if (eventName === "LiveValuesEvent") {
+        const liveValuesEvent = liveValuesEventSchema.parse(event);
+        console.log("LiveValuesEvent", liveValuesEvent);
+
+        const timestamp = event.ts;
 
         updateStore((state) => ({
           ...state,
-          heatingNozzleState: heatingEvent,
-          nozzleTemperature: addNozzleTemperature(
-            state.nozzleTemperature,
-            timeseriesValue,
-          ),
+          screwRpm: addScrewRpm(state.screwRpm, {
+            value: liveValuesEvent.data.screw_rpm,
+            timestamp,
+          }),
+          pressure: addPressure(state.pressure, {
+            value: liveValuesEvent.data.pressure,
+            timestamp,
+          }),
+          nozzleTemperature: addNozzleTemperature(state.nozzleTemperature, {
+            value: liveValuesEvent.data.nozzle_temperature,
+            timestamp,
+          }),
+          frontTemperature: addFrontTemperature(state.frontTemperature, {
+            value: liveValuesEvent.data.front_temperature,
+            timestamp,
+          }),
+          backTemperature: addBackTemperature(state.backTemperature, {
+            value: liveValuesEvent.data.back_temperature,
+            timestamp,
+          }),
+          middleTemperature: addMiddleTemperature(state.middleTemperature, {
+            value: liveValuesEvent.data.middle_temperature,
+            timestamp,
+          }),
+          nozzlePower: addNozzlePower(state.nozzlePower, {
+            value: liveValuesEvent.data.nozzle_power,
+            timestamp,
+          }),
+          frontPower: addFrontPower(state.frontPower, {
+            value: liveValuesEvent.data.front_power,
+            timestamp,
+          }),
+          middlePower: addMiddlePower(state.middlePower, {
+            value: liveValuesEvent.data.middle_power,
+            timestamp,
+          }),
+          backPower: addBackPower(state.backPower, {
+            value: liveValuesEvent.data.back_power,
+            timestamp,
+          }),
         }));
-      } else if (eventName == "BackHeatingStateEvent") {
-        const heatingEvent = event as HeatingStateEvent;
-        const timeseriesValue: TimeSeriesValue = {
-          value: heatingEvent.data.temperature,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          heatingBackState: heatingEvent,
-          backTemperature: addBackTemperature(
-            state.backTemperature,
-            timeseriesValue,
-          ),
-        }));
-      } else if (eventName == "MiddleHeatingStateEvent") {
-        const heatingEvent = event as HeatingStateEvent;
-        const timeseriesValue: TimeSeriesValue = {
-          value: heatingEvent.data.temperature,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          heatingMiddleState: heatingEvent,
-          middleTemperature: addMiddleTemperature(
-            state.middleTemperature,
-            timeseriesValue,
-          ),
-        }));
-      } else if (eventName == "NozzleHeatingPowerEvent") {
-        const parsed = heatingPowerEventSchema.parse(event);
-        const timeseriesValue: TimeSeriesValue = {
-          value: parsed.data.wattage,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          nozzlePower: addNozzlePower(state.nozzlePower, timeseriesValue),
-        }));
-      } else if (eventName == "FrontHeatingPowerEvent") {
-        const parsed = heatingPowerEventSchema.parse(event);
-        const timeseriesValue: TimeSeriesValue = {
-          value: parsed.data.wattage,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          frontPower: addFrontPower(state.frontPower, timeseriesValue),
-        }));
-      } else if (eventName == "MiddleHeatingPowerEvent") {
-        const parsed = heatingPowerEventSchema.parse(event);
-        const timeseriesValue: TimeSeriesValue = {
-          value: parsed.data.wattage,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          middlePower: addMiddlePower(state.middlePower, timeseriesValue),
-        }));
-      } else if (eventName == "BackHeatingPowerEvent") {
-        const parsed = heatingPowerEventSchema.parse(event);
-        const timeseriesValue: TimeSeriesValue = {
-          value: parsed.data.wattage,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          backPower: addBackPower(state.backPower, timeseriesValue),
-        }));
-      } else if (eventName == "RegulationStateEvent") {
-        updateStore((state) => ({
-          ...state,
-          motorRegulationState: event as MotorRegulationStateEvent,
-        }));
-      } else if (eventName == "PressureStateEvent") {
-        const pressureEvent = event as MotorPressureStateEvent;
-        const timeseriesValue: TimeSeriesValue = {
-          value: pressureEvent.data.bar,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          motorBarState: pressureEvent,
-          bar: addBar(state.bar, timeseriesValue),
-        }));
-      } else if (eventName == "ScrewStateEvent") {
-        const screwEvent = event as MotorScrewStateEvent;
-        const timeseriesValue: TimeSeriesValue = {
-          value: screwEvent.data.rpm,
-          timestamp: event.ts,
-        };
-
-        updateStore((state) => ({
-          ...state,
-          motorRpmState: screwEvent,
-          rpm: addRpm(state.rpm, timeseriesValue),
-        }));
+      } else {
+        handleUnhandledEventError(eventName);
       }
     } catch (error) {
       console.error(`Unexpected error processing ${eventName} event:`, error);
@@ -287,26 +317,9 @@ export const createExtruder2NamespaceStore =
   (): StoreApi<Extruder2NamespaceStore> =>
     create<Extruder2NamespaceStore>(() => {
       return {
-        modeState: null,
-        inverterState: null,
-        rotationState: null,
-
-        heatingNozzleState: null,
-        heatingFrontState: null,
-        heatingBackState: null,
-        heatingMiddleState: null,
-
-        motorRpmState: null,
-        motorRegulationState: null,
-        motorBarState: null,
-        extruderSettingsState: null,
-
-        pressurePidSettings: null,
-        temperaturePidSettings: null,
-
-        rpm,
-        bar,
-
+        state: null,
+        screwRpm,
+        pressure,
         nozzleTemperature,
         frontTemperature,
         backTemperature,
@@ -328,164 +341,14 @@ export function useExtruder2Namespace(
   machine_identification_unique: MachineIdentificationUnique,
 ): Extruder2NamespaceStore {
   // Generate namespace ID from validated machine ID
-  const namespaceId: NamespaceId = {
-    type: "machine",
-    machine_identification_unique,
-  };
+  const namespaceId = useMemo<NamespaceId>(
+    () => ({
+      type: "machine",
+      machine_identification_unique,
+    }),
+    [machine_identification_unique],
+  );
 
   // Use the implementation with validated namespace ID
   return useExtruder2NamespaceImplementation(namespaceId);
 }
-
-export const modeSchema = z.enum(["Standby", "Heat", "Extrude"]);
-export const mode = z.object({
-  mode: modeSchema,
-});
-export const heatingTypeSchema = z.enum(["front", "back", "middle"]);
-
-export const SetRegulationSchema = z.object({
-  uses_rpm: z.boolean(),
-});
-
-// Data Schemas
-
-export const inverterStatusEventDataSchema = z.object({
-  // RUN (Inverter running)
-  running: z.boolean(),
-  // Forward running motor spins forward
-  forward_running: z.boolean(),
-  // Reverse running motor spins backwards
-  reverse_running: z.boolean(),
-  // Up to frequency, SU not completely sure what its for
-  up_to_frequency: z.boolean(),
-  // overload warning OL
-  overload_warning: z.boolean(),
-  // No function, its described that way in the datasheet
-  no_function: z.boolean(),
-  // FU Output Frequency Detection
-  output_frequency_detection: z.boolean(),
-  // ABC (Fault)
-  abc_fault: z.boolean(),
-  // is True when a fault occured
-  fault_occurence: z.boolean(),
-});
-
-export const modeStateEventDataSchema = z.object({
-  mode: modeSchema,
-});
-
-export const inverterRotationEventDataSchema = z.object({
-  forward: z.boolean(),
-});
-
-export const heatingStateDataSchema = z.object({
-  temperature: z.number(),
-  target_temperature: z.number(),
-  wiring_error: z.boolean(),
-});
-
-export const heatingTargetTemperatureDataSchema = z.object({
-  target_temperature: z.number(),
-});
-
-export const motorScrewStateEventDataSchema = z.object({
-  rpm: z.number(),
-  target_rpm: z.number(),
-});
-
-export const motorBarStateEventDataSchema = z.object({
-  bar: z.number(),
-  target_bar: z.number(),
-});
-
-export const motorRegulationEventDataSchema = z.object({
-  uses_rpm: z.boolean(),
-});
-
-export const extruderPressureLimitDataSchema = z.object({
-  pressure_limit: z.number(),
-});
-
-export const extruderPressureLimitEnabledDataSchema = z.object({
-  pressure_limit_enabled: z.boolean(),
-});
-
-export const extruderSettingsStateEventDataSchema = z.object({
-  pressure_limit: z.number(),
-  pressure_limit_enabled: z.boolean(),
-});
-
-export const pidSettingsEventDataSchema = z.object({
-  ki: z.number(),
-  kd: z.number(),
-  kp: z.number(),
-});
-
-// Event Schemas
-export const heatingTargetEventSchema = eventSchema(
-  heatingTargetTemperatureDataSchema,
-);
-
-export const motorScrewStateEventSchema = eventSchema(
-  motorScrewStateEventDataSchema,
-);
-
-export const motorPressureStateEventSchema = eventSchema(
-  motorBarStateEventDataSchema,
-);
-
-export const inverterRotationEventSchema = eventSchema(
-  inverterRotationEventDataSchema,
-);
-
-export const motorRegulationEventSchema = eventSchema(
-  motorRegulationEventDataSchema,
-);
-export const heatingStateEventSchema = eventSchema(heatingStateDataSchema);
-export const modeStateEventSchema = eventSchema(modeStateEventDataSchema);
-
-export const extruderSettingsStateEventSchema = eventSchema(
-  extruderSettingsStateEventDataSchema,
-);
-
-export const pidSettingsEventSchema = eventSchema(pidSettingsEventDataSchema);
-
-export const heatingPowerEventDataSchema = z.object({
-  wattage: z.number(),
-});
-
-export const heatingPowerEventSchema = eventSchema(heatingPowerEventDataSchema);
-
-export const inverterStatusEventSchema = eventSchema(
-  inverterStatusEventDataSchema,
-);
-
-// type defs
-export type MotorScrewStateEvent = z.infer<typeof motorScrewStateEventSchema>;
-export type MotorPressureStateEvent = z.infer<
-  typeof motorPressureStateEventSchema
->;
-export type InverterStatusEvent = z.infer<typeof inverterStatusEventSchema>;
-export type InverterRotationEvent = z.infer<typeof inverterRotationEventSchema>;
-
-export type MotorRegulationStateEvent = z.infer<
-  typeof motorRegulationEventSchema
->;
-export type ModeStateEvent = z.infer<typeof modeStateEventSchema>;
-export type HeatingPowerEvent = z.infer<typeof heatingPowerEventSchema>;
-export type HeatingStateEvent = z.infer<typeof heatingStateEventSchema>;
-
-export type HeatingType = z.infer<typeof heatingTypeSchema>;
-export type Heating = z.infer<typeof heatingStateDataSchema>;
-
-export type MotorPressure = z.infer<typeof motorBarStateEventDataSchema>;
-export type MotorRpm = z.infer<typeof motorScrewStateEventDataSchema>;
-export type Mode = z.infer<typeof modeSchema>;
-export type InverterStatus = z.infer<typeof inverterStatusEventDataSchema>;
-
-export type PidSettings = z.infer<typeof pidSettingsEventDataSchema>;
-export type PidSettingsEvent = z.infer<typeof pidSettingsEventSchema>;
-
-export type ExtruderSettingsStateEvent = z.infer<
-  typeof extruderSettingsStateEventSchema
->;

--- a/electron/src/machines/extruder/extruder2/useExtruder.ts
+++ b/electron/src/machines/extruder/extruder2/useExtruder.ts
@@ -5,22 +5,16 @@ import { MachineIdentificationUnique } from "@/machines/types";
 import { extruder2 } from "@/machines/properties";
 import { extruder2Route } from "@/routes/routes";
 import { z } from "zod";
-import {
-  Heating,
-  InverterStatus,
-  Mode,
-  useExtruder2Namespace,
-  PidSettings,
-} from "./extruder2Namespace";
+import { StateEvent, Mode, useExtruder2Namespace } from "./extruder2Namespace";
 import { useEffect, useMemo } from "react";
-import { TimeSeries } from "@/lib/timeseries";
+import { produce } from "immer";
 
 export function useExtruder2() {
   const { serial: serialString } = extruder2Route.useParams();
 
   // Memoize the machine identification to keep it stable between renders
   const machineIdentification: MachineIdentificationUnique = useMemo(() => {
-    const serial = parseInt(serialString); // Use 0 as fallback if NaN
+    const serial = parseInt(serialString);
 
     if (isNaN(serial)) {
       toastError(
@@ -41,529 +35,360 @@ export function useExtruder2() {
       machine_identification: extruder2.machine_identification,
       serial,
     };
-  }, [serialString]); // Only recreate when serialString changes
+  }, [serialString]);
 
-  const inverter = useInverter(machineIdentification);
-  const mode = useMode(machineIdentification);
-  const motor = useMotor(machineIdentification);
-  const heating = useHeatingTemperature(machineIdentification);
-  const heatingPower = useHeatingPower(machineIdentification);
-  const settings = useSettings(machineIdentification);
-  const pidSettings = usePidSettings(machineIdentification);
-
-  return {
-    ...inverter,
-    ...mode,
-    ...motor,
-    ...heating,
-    ...settings,
-    ...heatingPower,
-    ...pidSettings,
-  };
-}
-
-export function useHeatingPower(
-  machine_identification_unique: MachineIdentificationUnique,
-): {
-  nozzlePower: TimeSeries;
-  frontPower: TimeSeries;
-  middlePower: TimeSeries;
-  backPower: TimeSeries;
-} {
-  const { nozzlePower, frontPower, middlePower, backPower } =
-    useExtruder2Namespace(machine_identification_unique);
-
-  return { nozzlePower, frontPower, middlePower, backPower };
-}
-
-export function useSettings(
-  machine_identification_unique: MachineIdentificationUnique,
-): {
-  extruderSetPressureLimit: (pressure_limit: number) => void;
-  extruderSetPressureLimitIsEnabled: (
-    pressure_limit_is_enabled: boolean,
-  ) => void;
-  pressureLimitState: number | undefined;
-  pressureLimitEnabledState: boolean | undefined;
-} {
-  const pressureLimitState = useStateOptimistic();
-  const pressureLimitEnabledState = useStateOptimistic();
-  // Define schemas
-  const pressureLimitSchema = z.object({
-    ExtruderSetPressureLimit: z.number(),
-  });
-  const pressureLimitEnabledSchema = z.object({
-    ExtruderSetPressureLimitIsEnabled: z.boolean(),
-  });
-
-  // Create mutation hooks
-  const { request: pressureLimit } = useMachineMutation(pressureLimitSchema);
-  const { request: pressureLimitIsEnabled } = useMachineMutation(
-    pressureLimitEnabledSchema,
-  );
-
-  const { extruderSettingsState } = useExtruder2Namespace(
-    machine_identification_unique,
-  );
-
-  // Set pressure limit value
-  const extruderSetPressureLimit = async (pressure: number) => {
-    pressureLimitState.setOptimistic(pressure);
-    pressureLimit({
-      machine_identification_unique,
-      data: { ExtruderSetPressureLimit: pressure },
-    });
-  };
-
-  // Enable/disable pressure limit
-  const extruderSetPressureLimitIsEnabled = (enabled: boolean) => {
-    pressureLimitEnabledState.setOptimistic(enabled);
-    pressureLimitIsEnabled({
-      machine_identification_unique,
-      data: { ExtruderSetPressureLimitIsEnabled: enabled },
-    });
-  };
-
-  useEffect(() => {
-    if (extruderSettingsState?.data) {
-      pressureLimitState.setReal(extruderSettingsState.data.pressure_limit);
-      pressureLimitEnabledState.setReal(
-        extruderSettingsState.data.pressure_limit,
-      );
-    }
-  }, [
-    extruderSettingsState?.data.pressure_limit,
-    extruderSettingsState?.data.pressure_limit_enabled,
-  ]);
-
-  return {
-    extruderSetPressureLimit,
-    extruderSetPressureLimitIsEnabled,
-    pressureLimitState: extruderSettingsState?.data.pressure_limit,
-    pressureLimitEnabledState:
-      extruderSettingsState?.data.pressure_limit_enabled,
-  };
-}
-
-export function useInverter(
-  machine_identification_unique: MachineIdentificationUnique,
-): {
-  inverterSetRotation: (forward: boolean) => void;
-  rotationState: boolean | undefined;
-  inverterReset: () => void;
-  inverterState: InverterStatus | undefined;
-} {
-  const state = useStateOptimistic();
-
-  const schema = z.object({ InverterRotationSetDirection: z.boolean() });
-  const { request: requestRotation } = useMachineMutation(schema);
-  const inverterSetRotation = async (forward: boolean) => {
-    state.setOptimistic(forward);
-    requestRotation({
-      machine_identification_unique,
-      data: { InverterRotationSetDirection: forward },
-    });
-  };
-
-  const inverterSchema = z.object({
-    InverterReset: z.boolean(), // this represents a zero-argument tuple variant
-  });
-
-  const { request: requestReset } = useMachineMutation(inverterSchema);
-  const inverterReset = async () => {
-    requestReset({
-      machine_identification_unique,
-      data: { InverterReset: true }, // key is the enum variant, value is empty tuple
-    });
-  };
-
-  const { rotationState, inverterState } = useExtruder2Namespace(
-    machine_identification_unique,
-  );
-
-  useEffect(() => {
-    if (rotationState?.data) {
-      state.setReal(rotationState.data.forward);
-    }
-  }, [rotationState?.data.forward]);
-
-  return {
-    inverterSetRotation,
-    rotationState: rotationState?.data.forward,
-    inverterReset,
-    inverterState: inverterState?.data,
-  };
-}
-
-export function useMode(
-  machine_identification_unique: MachineIdentificationUnique,
-): {
-  mode: Mode | undefined;
-  extruderSetMode: (value: Mode) => void;
-  modeIsLoading: boolean;
-  modeIsDisabled: boolean;
-} {
-  const state = useStateOptimistic<Mode>();
-
-  // Write path
-  const schema = z.object({
-    ExtruderSetMode: z.enum(["Heat", "Extrude", "Standby"]),
-  });
-
-  const { request } = useMachineMutation(schema);
-
-  const extruderSetMode = async (value: Mode) => {
-    state.setOptimistic(value);
-    request({
-      machine_identification_unique,
-      data: { ExtruderSetMode: value },
-    })
-      .then((response) => {
-        if (!response.success) state.resetToReal();
-      })
-      .catch(() => state.resetToReal());
-  };
-
-  // Read path
-  const { modeState } = useExtruder2Namespace(machine_identification_unique);
-  useEffect(() => {
-    if (modeState?.data) {
-      state.setReal(modeState.data.mode);
-    }
-  }, [modeState?.data.mode]);
-
-  return {
-    mode: state.value,
-    extruderSetMode,
-    modeIsLoading: state.isOptimistic || !state.isInitialized,
-    modeIsDisabled: state.isOptimistic || !state.isInitialized,
-  };
-}
-
-export function useMotor(
-  machine_identification_unique: MachineIdentificationUnique,
-): {
-  uses_rpm: boolean | undefined;
-  rpm: TimeSeries;
-  targetRpm: number | undefined;
-  bar: TimeSeries;
-  targetBar: number | undefined;
-  screwSetTargetRpm: (rpm: number) => void;
-  screwSetRegulation: (usesRpm: boolean) => void;
-  screwSetTargetPressure: (bar: number) => void;
-} {
-  const SetTargetRpmSchema = z.object({
-    InverterSetTargetRpm: z.number(),
-  });
-
-  const SetRegulationSchema = z.object({
-    InverterSetRegulation: z.boolean(),
-  });
-
-  const SetTargetPressureSchema = z.object({
-    InverterSetTargetPressure: z.number(),
-  });
-
-  const { motorRpmState, motorBarState, motorRegulationState, rpm, bar } =
-    useExtruder2Namespace(machine_identification_unique);
-
-  const rpmState = useStateOptimistic<number>();
-  const rpmTargetState = useStateOptimistic<number>();
-
-  const regulationState = useStateOptimistic<boolean>();
-  const { request: regulationRequest } =
-    useMachineMutation(SetRegulationSchema);
-
-  const screwSetRegulation = async (value: boolean) => {
-    regulationState.setOptimistic(value);
-    regulationRequest({
-      machine_identification_unique,
-      data: { InverterSetRegulation: value },
-    })
-      .then((response) => {
-        if (!response.success) regulationState.resetToReal();
-      })
-      .catch(() => regulationState.resetToReal());
-  };
-
-  const { request: reqestTargetRpm } = useMachineMutation(SetTargetRpmSchema);
-  const screwSetTargetRpm = async (value: number) => {
-    rpmTargetState.setOptimistic(value);
-    reqestTargetRpm({
-      machine_identification_unique,
-      data: { InverterSetTargetRpm: value },
-    })
-      .then((response) => {
-        if (!response.success) rpmTargetState.resetToReal();
-      })
-      .catch(() => rpmTargetState.resetToReal());
-  };
-
-  const pressureState = useStateOptimistic<number>();
-  const targetPressureState = useStateOptimistic<number>();
-
-  const { request: targetPressureRequest } = useMachineMutation(
-    SetTargetPressureSchema,
-  );
-
-  const screwSetTargetPressure = async (value: number) => {
-    targetPressureState.setOptimistic(value);
-    targetPressureRequest({
-      machine_identification_unique,
-      data: { InverterSetTargetPressure: value },
-    })
-      .then((response) => {
-        if (!response.success) targetPressureState.resetToReal();
-      })
-      .catch(() => targetPressureState.resetToReal());
-  };
-
-  useEffect(() => {
-    if (motorRpmState?.data) {
-      rpmState.setReal(motorRpmState.data.rpm);
-      rpmTargetState.setReal(motorRpmState.data.target_rpm);
-    }
-
-    if (motorBarState?.data) {
-      pressureState.setReal(motorBarState.data.bar);
-      targetPressureState.setReal(motorBarState.data.target_bar);
-    }
-
-    if (motorRegulationState?.data) {
-      regulationState.setReal(motorRegulationState.data.uses_rpm);
-    }
-  }, [
-    motorRpmState?.data.rpm,
-    motorRpmState?.data.target_rpm,
-    motorBarState?.data.bar,
-    motorBarState?.data.target_bar,
-    motorRegulationState?.data.uses_rpm,
-  ]);
-
-  return {
-    rpm: rpm,
-    uses_rpm: regulationState.value,
-    targetRpm: rpmTargetState.value,
-    targetBar: targetPressureState.value,
-    bar: bar,
-
-    screwSetTargetRpm,
-    screwSetTargetPressure,
-    screwSetRegulation,
-  };
-}
-
-export function usePidSettings(
-  machine_identification_unique: MachineIdentificationUnique,
-): {
-  pressurePidSettings: PidSettings | undefined;
-  setPressurePid: (settings: PidSettings) => void;
-} {
-  const { pressurePidSettings } = useExtruder2Namespace(
-    machine_identification_unique,
-  );
-
-  const pressurePidSettingsState = useStateOptimistic<PidSettings>();
-
-  const SetPressurePidSchema = z.object({
-    SetPressurePidSettings: z.object({
-      ki: z.number(),
-      kp: z.number(),
-      kd: z.number(),
-    }),
-  });
-
-  const { request: PressurePidSettingsRequest } =
-    useMachineMutation(SetPressurePidSchema);
-
-  const setPressurePid = async (value: PidSettings) => {
-    pressurePidSettingsState.setOptimistic(value);
-    PressurePidSettingsRequest({
-      machine_identification_unique,
-      data: { SetPressurePidSettings: value },
-    })
-      .then((response) => {
-        if (!response.success) pressurePidSettingsState.resetToReal();
-      })
-      .catch(() => pressurePidSettingsState.resetToReal());
-  };
-
-  useEffect(() => {
-    if (pressurePidSettings?.data) {
-      pressurePidSettingsState.setReal(pressurePidSettings?.data);
-    }
-  });
-
-  return {
-    pressurePidSettings: pressurePidSettingsState.value,
-    setPressurePid,
-  };
-}
-
-export function useHeatingTemperature(
-  machine_identification_unique: MachineIdentificationUnique,
-): {
-  heatingSetNozzleTemp: (value: number) => void;
-  heatingSetFrontTemp: (value: number) => void;
-  heatingSetBackTemp: (value: number) => void;
-  heatingSetMiddleTemp: (value: number) => void;
-
-  nozzleHeatingTarget: number | undefined;
-  frontHeatingTarget: number | undefined;
-  backHeatingTarget: number | undefined;
-  middleHeatingTarget: number | undefined;
-
-  nozzleHeatingState: Heating | undefined;
-  frontHeatingState: Heating | undefined;
-  backHeatingState: Heating | undefined;
-  middleHeatingState: Heating | undefined;
-
-  nozzleTemperature: TimeSeries;
-  frontTemperature: TimeSeries;
-  backTemperature: TimeSeries;
-  middleTemperature: TimeSeries;
-} {
-  const nozzleHeatingTargetState = useStateOptimistic<number>();
-  const frontHeatingTargetState = useStateOptimistic<number>();
-  const backHeatingTargetState = useStateOptimistic<number>();
-  const middleHeatingTargetState = useStateOptimistic<number>();
-
-  const SetNozzleHeatingSchema = z.object({
-    NozzleSetHeatingTemperature: z.number(),
-  });
-
-  const SetFrontHeatingSchema = z.object({
-    FrontHeatingSetTargetTemperature: z.number(),
-  });
-
-  const SetBackHeatingSchema = z.object({
-    BackHeatingSetTargetTemperature: z.number(),
-  });
-
-  const SetMiddleHeatingSchema = z.object({
-    MiddleSetHeatingTemperature: z.number(),
-  });
-
-  const { request: HeatingNozzleRequest } = useMachineMutation(
-    SetNozzleHeatingSchema,
-  );
-
-  const heatingSetNozzleTemp = async (value: number) => {
-    frontHeatingTargetState.setOptimistic(value);
-    HeatingNozzleRequest({
-      machine_identification_unique,
-      data: { NozzleSetHeatingTemperature: value },
-    })
-      .then((response) => {
-        if (!response.success) nozzleHeatingTargetState.resetToReal();
-      })
-      .catch(() => nozzleHeatingTargetState.resetToReal());
-  };
-
-  const { request: HeatiingFrontRequest } = useMachineMutation(
-    SetFrontHeatingSchema,
-  );
-
-  const heatingSetFrontTemp = async (value: number) => {
-    frontHeatingTargetState.setOptimistic(value);
-    HeatiingFrontRequest({
-      machine_identification_unique,
-      data: { FrontHeatingSetTargetTemperature: value },
-    })
-      .then((response) => {
-        if (!response.success) frontHeatingTargetState.resetToReal();
-      })
-      .catch(() => frontHeatingTargetState.resetToReal());
-  };
-
-  const { request: HeatingBackRequest } =
-    useMachineMutation(SetBackHeatingSchema);
-
-  const heatingSetBackTemp = async (value: number) => {
-    backHeatingTargetState.setOptimistic(value);
-    HeatingBackRequest({
-      machine_identification_unique,
-      data: { BackHeatingSetTargetTemperature: value },
-    })
-      .then((response) => {
-        if (!response.success) backHeatingTargetState.resetToReal();
-      })
-      .catch(() => backHeatingTargetState.resetToReal());
-  };
-
-  const { request: HeatingMiddleRequest } = useMachineMutation(
-    SetMiddleHeatingSchema,
-  );
-
-  const heatingSetMiddleTemp = async (value: number) => {
-    middleHeatingTargetState.setOptimistic(value);
-    HeatingMiddleRequest({
-      machine_identification_unique,
-      data: { MiddleSetHeatingTemperature: value },
-    })
-      .then((response) => {
-        if (!response.success) middleHeatingTargetState.resetToReal();
-      })
-      .catch(() => middleHeatingTargetState.resetToReal());
-  };
-
-  // Read path
+  // Get consolidated state and live values from namespace
   const {
-    heatingFrontState,
-    heatingBackState,
-    heatingMiddleState,
-    heatingNozzleState,
+    state,
+    screwRpm,
+    pressure,
+    nozzleTemperature,
     frontTemperature,
     backTemperature,
     middleTemperature,
-    nozzleTemperature,
-  } = useExtruder2Namespace(machine_identification_unique);
+    nozzlePower,
+    frontPower,
+    middlePower,
+    backPower,
+  } = useExtruder2Namespace(machineIdentification);
 
+  // Single optimistic state for all state management
+  const stateOptimistic = useStateOptimistic<StateEvent>();
+
+  // Update optimistic state when real state changes
   useEffect(() => {
-    if (heatingFrontState?.data) {
-      frontHeatingTargetState.setReal(
-        heatingFrontState.data.target_temperature,
-      );
+    if (state) {
+      stateOptimistic.setReal(state);
     }
-    if (heatingBackState?.data) {
-      backHeatingTargetState.setReal(heatingBackState.data.target_temperature);
+  }, [state, stateOptimistic]);
+
+  // Helper function for optimistic updates using produce
+  const updateStateOptimistically = (
+    producer: (current: StateEvent) => void,
+    serverRequest: () => void,
+  ) => {
+    const currentState = stateOptimistic.value;
+    if (currentState) {
+      stateOptimistic.setOptimistic(produce(currentState, producer));
     }
-    if (heatingMiddleState?.data) {
-      middleHeatingTargetState.setReal(
-        heatingMiddleState.data.target_temperature,
-      );
-    }
-    if (heatingNozzleState?.data) {
-      nozzleHeatingTargetState.setReal(
-        heatingNozzleState.data.target_temperature,
-      );
-    }
-  }, [
-    frontHeatingTargetState,
-    backHeatingTargetState,
-    middleHeatingTargetState,
-    nozzleHeatingTargetState,
-  ]);
+    serverRequest();
+  };
+
+  // Action functions with verb-first names
+  const setInverterRotationDirection = (forward: boolean) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.rotation_state.forward = forward;
+      },
+      () =>
+        requestInverterRotationDirection({
+          machine_identification_unique: machineIdentification,
+          data: { SetInverterRotationDirection: forward },
+        }),
+    );
+  };
+
+  const setExtruderMode = (mode: Mode) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.mode_state.mode = mode;
+      },
+      () =>
+        requestExtruderMode({
+          machine_identification_unique: machineIdentification,
+          data: { SetExtruderMode: mode },
+        }),
+    );
+  };
+
+  const setInverterRegulation = (usesRpm: boolean) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.regulation_state.uses_rpm = usesRpm;
+      },
+      () =>
+        requestInverterRegulation({
+          machine_identification_unique: machineIdentification,
+          data: { SetInverterRegulation: usesRpm },
+        }),
+    );
+  };
+
+  const setInverterTargetRpm = (rpm: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.screw_state.target_rpm = rpm;
+      },
+      () =>
+        requestInverterTargetRpm({
+          machine_identification_unique: machineIdentification,
+          data: { SetInverterTargetRpm: rpm },
+        }),
+    );
+  };
+
+  const setInverterTargetPressure = (pressure: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.pressure_state.target_bar = pressure;
+      },
+      () =>
+        requestInverterTargetPressure({
+          machine_identification_unique: machineIdentification,
+          data: { SetInverterTargetPressure: pressure },
+        }),
+    );
+  };
+
+  const setNozzleHeatingTemperature = (temperature: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.heating_states.nozzle.target_temperature = temperature;
+      },
+      () =>
+        requestNozzleHeatingTemperature({
+          machine_identification_unique: machineIdentification,
+          data: { SetNozzleHeatingTemperature: temperature },
+        }),
+    );
+  };
+
+  const setFrontHeatingTemperature = (temperature: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.heating_states.front.target_temperature = temperature;
+      },
+      () =>
+        requestFrontHeatingTemperature({
+          machine_identification_unique: machineIdentification,
+          data: { SetFrontHeatingTargetTemperature: temperature },
+        }),
+    );
+  };
+
+  const setBackHeatingTemperature = (temperature: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.heating_states.back.target_temperature = temperature;
+      },
+      () =>
+        requestBackHeatingTemperature({
+          machine_identification_unique: machineIdentification,
+          data: { SetBackHeatingTargetTemperature: temperature },
+        }),
+    );
+  };
+
+  const setMiddleHeatingTemperature = (temperature: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.heating_states.middle.target_temperature = temperature;
+      },
+      () =>
+        requestMiddleHeatingTemperature({
+          machine_identification_unique: machineIdentification,
+          data: { SetMiddleHeatingTemperature: temperature },
+        }),
+    );
+  };
+
+  const setExtruderPressureLimit = (pressureLimit: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.extruder_settings_state.pressure_limit = pressureLimit;
+      },
+      () =>
+        requestExtruderPressureLimit({
+          machine_identification_unique: machineIdentification,
+          data: { SetExtruderPressureLimit: pressureLimit },
+        }),
+    );
+  };
+
+  const setExtruderPressureLimitEnabled = (enabled: boolean) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.extruder_settings_state.pressure_limit_enabled = enabled;
+      },
+      () =>
+        requestExtruderPressureLimitEnabled({
+          machine_identification_unique: machineIdentification,
+          data: { SetExtruderPressureLimitIsEnabled: enabled },
+        }),
+    );
+  };
+
+  const setPressurePidKp = (kp: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.pid_settings.pressure.kp = kp;
+      },
+      () => {
+        const currentState = stateOptimistic.value;
+        if (currentState) {
+          const settings = produce(
+            currentState.data.pid_settings.pressure,
+            (draft) => {
+              draft.kp = kp;
+            },
+          );
+          requestPressurePidSettings({
+            machine_identification_unique: machineIdentification,
+            data: { SetPressurePidSettings: settings },
+          });
+        }
+      },
+    );
+  };
+
+  const setPressurePidKi = (ki: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.pid_settings.pressure.ki = ki;
+      },
+      () => {
+        const currentState = stateOptimistic.value;
+        if (currentState) {
+          const settings = produce(
+            currentState.data.pid_settings.pressure,
+            (draft) => {
+              draft.ki = ki;
+            },
+          );
+          requestPressurePidSettings({
+            machine_identification_unique: machineIdentification,
+            data: { SetPressurePidSettings: settings },
+          });
+        }
+      },
+    );
+  };
+
+  const setPressurePidKd = (kd: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.pid_settings.pressure.kd = kd;
+      },
+      () => {
+        const currentState = stateOptimistic.value;
+        if (currentState) {
+          const settings = produce(
+            currentState.data.pid_settings.pressure,
+            (draft) => {
+              draft.kd = kd;
+            },
+          );
+          requestPressurePidSettings({
+            machine_identification_unique: machineIdentification,
+            data: { SetPressurePidSettings: settings },
+          });
+        }
+      },
+    );
+  };
+
+  const resetInverter = () => {
+    // No optimistic update needed for reset
+    requestResetInverter({
+      machine_identification_unique: machineIdentification,
+      data: { ResetInverter: true },
+    });
+  };
+
+  // Mutation hooks
+  const { request: requestInverterRotationDirection } = useMachineMutation(
+    z.object({ SetInverterRotationDirection: z.boolean() }),
+  );
+
+  const { request: requestExtruderMode } = useMachineMutation(
+    z.object({ SetExtruderMode: z.enum(["Heat", "Extrude", "Standby"]) }),
+  );
+
+  const { request: requestInverterRegulation } = useMachineMutation(
+    z.object({ SetInverterRegulation: z.boolean() }),
+  );
+
+  const { request: requestInverterTargetRpm } = useMachineMutation(
+    z.object({ SetInverterTargetRpm: z.number() }),
+  );
+
+  const { request: requestInverterTargetPressure } = useMachineMutation(
+    z.object({ SetInverterTargetPressure: z.number() }),
+  );
+
+  const { request: requestNozzleHeatingTemperature } = useMachineMutation(
+    z.object({ SetNozzleHeatingTemperature: z.number() }),
+  );
+
+  const { request: requestFrontHeatingTemperature } = useMachineMutation(
+    z.object({ SetFrontHeatingTargetTemperature: z.number() }),
+  );
+
+  const { request: requestBackHeatingTemperature } = useMachineMutation(
+    z.object({ SetBackHeatingTargetTemperature: z.number() }),
+  );
+
+  const { request: requestMiddleHeatingTemperature } = useMachineMutation(
+    z.object({ SetMiddleHeatingTemperature: z.number() }),
+  );
+
+  const { request: requestExtruderPressureLimit } = useMachineMutation(
+    z.object({ SetExtruderPressureLimit: z.number() }),
+  );
+
+  const { request: requestExtruderPressureLimitEnabled } = useMachineMutation(
+    z.object({ SetExtruderPressureLimitIsEnabled: z.boolean() }),
+  );
+
+  const { request: requestPressurePidSettings } = useMachineMutation(
+    z.object({
+      SetPressurePidSettings: z.object({
+        ki: z.number(),
+        kp: z.number(),
+        kd: z.number(),
+      }),
+    }),
+  );
+
+  const { request: requestResetInverter } = useMachineMutation(
+    z.object({ ResetInverter: z.boolean() }),
+  );
 
   return {
-    heatingSetNozzleTemp,
-    heatingSetFrontTemp,
-    heatingSetBackTemp,
-    heatingSetMiddleTemp,
+    // Consolidated state
+    state: stateOptimistic.value?.data,
 
-    nozzleHeatingTarget: nozzleHeatingTargetState.value,
-    frontHeatingTarget: frontHeatingTargetState.value,
-    backHeatingTarget: backHeatingTargetState.value,
-    middleHeatingTarget: middleHeatingTargetState.value,
-
-    nozzleHeatingState: heatingNozzleState?.data,
-    frontHeatingState: heatingFrontState?.data,
-    backHeatingState: heatingBackState?.data,
-    middleHeatingState: heatingMiddleState?.data,
-
+    // Individual live values (TimeSeries)
+    screwRpm,
+    pressure,
     nozzleTemperature,
     frontTemperature,
     backTemperature,
     middleTemperature,
+    nozzlePower,
+    frontPower,
+    middlePower,
+    backPower,
+
+    // Loading states
+    isLoading: stateOptimistic.isOptimistic,
+    isDisabled: !stateOptimistic.isInitialized,
+
+    // Action functions (verb-first)
+    setInverterRotationDirection,
+    setExtruderMode,
+    setInverterRegulation,
+    setInverterTargetRpm,
+    setInverterTargetPressure,
+    setNozzleHeatingTemperature,
+    setFrontHeatingTemperature,
+    setBackHeatingTemperature,
+    setMiddleHeatingTemperature,
+    setExtruderPressureLimit,
+    setExtruderPressureLimitEnabled,
+    setPressurePidKp,
+    setPressurePidKi,
+    setPressurePidKd,
+    resetInverter,
   };
 }

--- a/server/src/machines/extruder1/act.rs
+++ b/server/src/machines/extruder1/act.rs
@@ -33,40 +33,9 @@ impl Actor for ExtruderV2 {
 
             if now.duration_since(self.last_measurement_emit) > Duration::from_secs_f64(1.0 / 60.0)
             {
-                // channel 1
-                self.emit_heating(
-                    self.temperature_controller_back.heating.clone(),
-                    super::HeatingType::Back,
-                );
-                self.emit_heating(
-                    self.temperature_controller_front.heating.clone(),
-                    super::HeatingType::Front,
-                );
-                self.emit_heating(
-                    self.temperature_controller_middle.heating.clone(),
-                    super::HeatingType::Middle,
-                );
-                self.emit_heating(
-                    self.temperature_controller_nozzle.heating.clone(),
-                    super::HeatingType::Nozzle,
-                );
-
-                self.emit_heating_element_power(super::HeatingType::Nozzle);
-                self.emit_heating_element_power(super::HeatingType::Front);
-                self.emit_heating_element_power(super::HeatingType::Middle);
-                self.emit_heating_element_power(super::HeatingType::Back);
-
-                self.emit_regulation();
-                self.emit_mode_state();
-                self.emit_rotation_state();
-                self.emit_inverter_status();
-
-                self.emit_pressure_pid_settings();
-
-                self.emit_bar();
-                self.emit_rpm();
-                self.emit_extruder_settings();
-
+                // Emit live values at 60 FPS
+                self.emit_live_values();
+                
                 self.last_measurement_emit = now;
             }
         })


### PR DESCRIPTION
fix #453 

This patch refactors the state management for the Extruder v2 on both the frontend and backend to use a more centralized and robust model.

- **Backend (Rust):**
  - Replaced numerous individual events with two primary events: `StateEvent` for configuration and less frequent state, and `LiveValuesEvent` for high-frequency telemetry.
  - State-mutating API calls now emit the entire updated `StateEvent`.

- **Frontend (TypeScript):**
  - Replaced multiple specialized hooks (`useInverter`, `useMode`, `useMotor`, etc.) with a single, comprehensive `useExtruder2` hook.
  - Centralized all client-side state, including optimistic updates, into the new `useExtruder2` hook.
  - UI components are updated to consume all data and actions from the single hook, simplifying data flow.
  - Renamed action functions to a consistent verb-first convention (e.g., `extruderSetMode` -> `setExtruderMode`).