### PR TITLE
fixed config for RT Kernel

### DIFF
--- a/nixos/os/configuration.nix
+++ b/nixos/os/configuration.nix
@@ -17,7 +17,7 @@
   };
   boot.loader.efi.canTouchEfiVariables = true;
 
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernelPackages = pkgs.linuxPackages-rt;
 
   boot.kernelParams = [
     # Graphical


### PR DESCRIPTION
fix #568
Now the Kernel actually boots with PREEMPT_RT as expected