### PR TITLE
596 extend total power output tile

### DIFF
--- a/electron/src/control/units.tsx
+++ b/electron/src/control/units.tsx
@@ -31,6 +31,8 @@ export function getUnitIcon(unit: Unit): IconName {
       return "lu:Zap";
     case "A":
       return "lu:Zap";
+    case "kWh":
+      return "lu:Zap";
     default:
       return "lu:ChartNoAxesColumn";
   }
@@ -64,6 +66,8 @@ export function renderUnitSymbol(unit: Unit | undefined): string {
       return "V";
     case "A":
       return "A";
+    case "kWh":
+      return "kWh";
     default:
       return "";
   }
@@ -119,6 +123,8 @@ export function renderUnitSymbolLong(unit: Unit): string {
       return "volts";
     case "A":
       return "amperes";
+    case "kWh":
+      return "kilowatt-hours";
     default:
       return "";
   }
@@ -138,6 +144,7 @@ export const units = [
   "W",
   "V",
   "A",
+  "kWh",
 ] as const;
 
 export type Unit = (typeof units)[number];

--- a/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
@@ -230,13 +230,13 @@ export function Extruder2ControlPage() {
           <TimeSeriesValueNumeric
             label="Total Power"
             unit="W"
-            renderValue={(value) => roundToDecimals(value, 1)}
+            renderValue={(value) => roundToDecimals(value, 0)}
             timeseries={combinedPower}
           />
           <TimeSeriesValueNumeric
             label="Motor Power"
             unit="W"
-            renderValue={(value) => roundToDecimals(value, 1)}
+            renderValue={(value) => roundToDecimals(value, 0)}
             timeseries={motorPower}
           />
           <TimeSeriesValueNumeric
@@ -245,14 +245,12 @@ export function Extruder2ControlPage() {
             renderValue={(value) => roundToDecimals(value, 1)}
             timeseries={motorCurrent}
           />
-          <Label label="Total Energy">
-            <div className="flex flex-row items-center gap-4">
-              <span className="font-mono text-4xl font-bold">
-                {roundToDecimals(totalEnergyKWh ?? 0, 3)}
-              </span>
-              <span>kWh</span>
-            </div>
-          </Label>
+          <TimeSeriesValueNumeric
+            label="Total Energy"
+            unit="kWh"
+            renderValue={(value) => roundToDecimals(value, 3)}
+            timeseries={totalEnergyKWh}
+          />
         </ControlCard>
       </ControlGrid>
     </Page>

--- a/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
@@ -30,7 +30,9 @@ export function Extruder2ControlPage() {
 
     motorScrewRpm,
     motorPower,
+    motorCurrent,
     combinedPower,
+    totalEnergyKWh,
 
     setExtruderMode,
     setBackHeatingTemperature,
@@ -224,13 +226,33 @@ export function Extruder2ControlPage() {
           />
         </ControlCard>
 
-        <ControlCard className="bg-blue" title="Total Power Consumption">
+        <ControlCard className="bg-blue" title="Power Consumption">
           <TimeSeriesValueNumeric
-            label=""
+            label="Total Power"
             unit="W"
             renderValue={(value) => roundToDecimals(value, 1)}
             timeseries={combinedPower}
           />
+          <TimeSeriesValueNumeric
+            label="Motor Power"
+            unit="W"
+            renderValue={(value) => roundToDecimals(value, 1)}
+            timeseries={motorPower}
+          />
+          <TimeSeriesValueNumeric
+            label="Motor Current"
+            unit="A"
+            renderValue={(value) => roundToDecimals(value, 1)}
+            timeseries={motorCurrent}
+          />
+          <Label label="Total Energy">
+            <div className="flex flex-row items-center gap-4">
+              <span className="font-mono text-4xl font-bold">
+                {roundToDecimals(totalEnergyKWh ?? 0, 3)}
+              </span>
+              <span>kWh</span>
+            </div>
+          </Label>
         </ControlCard>
       </ControlGrid>
     </Page>

--- a/electron/src/machines/extruder/extruder2/extruder2Namespace.ts
+++ b/electron/src/machines/extruder/extruder2/extruder2Namespace.ts
@@ -204,7 +204,7 @@ export type Extruder2NamespaceStore = {
 
   // Total energy consumption time series in kWh
   totalEnergyKWh: TimeSeries;
-  
+
   // Internal tracking for cumulative energy calculation
   cumulativeEnergyKWh: number;
   lastEnergyTimestamp: number | null;

--- a/electron/src/machines/extruder/extruder2/useExtruder.ts
+++ b/electron/src/machines/extruder/extruder2/useExtruder.ts
@@ -57,6 +57,7 @@ export function useExtruder2() {
     middlePower,
     backPower,
     combinedPower,
+    totalEnergyKWh,
   } = useExtruder2Namespace(machineIdentification);
 
   // Single optimistic state for all state management
@@ -385,6 +386,9 @@ export function useExtruder2() {
     middlePower,
     backPower,
     combinedPower,
+
+    // Derived cumulative energy
+    totalEnergyKWh,
 
     // Loading states
     isLoading: stateOptimistic.isOptimistic,


### PR DESCRIPTION
This pull request adds support for tracking and displaying total energy consumption (in kilowatt-hours, kWh) for the extruder machine control page. It introduces a new time series for cumulative energy, updates the UI to show energy and related metrics, and expands unit handling to include kWh.