### PR TITLE
Add reverse prop to `SelectionGroupBoolean`

### DIFF
--- a/electron/src/control/SelectionGroup.tsx
+++ b/electron/src/control/SelectionGroup.tsx
@@ -82,6 +82,7 @@ type SelectionGroupBooleanProps = {
   loading?: boolean;
   optionTrue: Option;
   optionFalse: Option;
+  reverse?: boolean;
 };
 
 export function SelectionGroupBoolean({
@@ -91,16 +92,24 @@ export function SelectionGroupBoolean({
   loading,
   optionTrue,
   optionFalse,
+  reverse,
 }: SelectionGroupBooleanProps) {
   return (
     <SelectionGroup<"on" | "off">
       value={value ? "on" : "off"}
       disabled={disabled}
       loading={loading}
-      options={{
-        off: optionFalse,
-        on: optionTrue,
-      }}
+      options={
+        reverse
+          ? {
+              on: optionFalse,
+              off: optionTrue,
+            }
+          : {
+              off: optionFalse,
+              on: optionTrue,
+            }
+      }
       onChange={(value) => onChange?.(value === "on")}
     />
   );

--- a/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
@@ -140,6 +140,7 @@ export function Extruder2ControlPage() {
               onChange={setInverterRegulation}
               disabled={isDisabled}
               loading={isLoading}
+              reverse
             />
           </Label>
           <div className="flex flex-row flex-wrap gap-4">


### PR DESCRIPTION
This change introduces a `reverse` property to the `SelectionGroupBoolean` component to allow for more flexible UI representation.

- When `reverse` is set to true, the `optionTrue` and `optionFalse` props are swapped.
- This allows the visual "on" state to correspond to a `false` value and vice-versa.
- The prop is implemented on the Inverter Regulation control on the Extruder2 page.