### PR TITLE
Use Cargo Clippy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "typescript.inlayHints.enumMemberValues.enabled": false,
-     "git.detectSubmodules": true,
-     "git.detectSubmodulesLimit": 10,
+    "git.detectSubmodules": true,
+    "git.detectSubmodulesLimit": 10,
+    "rust-analyzer.check.command": "clippy",
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,23 @@ members = [
     "ethercat-hal",
     "ethercat-hal-derive",
     "control-core",
-    "ethercat-eeprom-dump", "control-core-derive",
+    "ethercat-eeprom-dump",
+    "control-core-derive",
 ]
 exclude = []
 resolver = "2"
+
+[workspace.lints.clippy]
+# Individual lints (priority 0)
+
+# don't lint poissbilities for let chains because they were introduces after Rust 1.86
+collapsible_if = "allow"
+
+# Lint groups (priority -1)
+suspicious = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+style = { level = "warn", priority = -1 }
+pendantic = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }

--- a/control-core-derive/Cargo.toml
+++ b/control-core-derive/Cargo.toml
@@ -3,6 +3,9 @@ name = "control_core_derive"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/control-core/Cargo.toml
+++ b/control-core/Cargo.toml
@@ -3,6 +3,9 @@ name = "control_core"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.99"
 axum = "0.8.4"
@@ -10,7 +13,7 @@ ethercat_hal = { path = "../ethercat-hal" }
 ethercrab = "0.6"
 interfaces = "0.0.9"
 serde = "1.0.219"
-serde_json =  "1.0.143"
+serde_json = "1.0.143"
 serialport = "4.7.3"
 smol = "2.0.2"
 socketioxide = "0.17.2"

--- a/control-core/src/controllers/first_degree_motion/acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/acceleration_speed_controller.rs
@@ -22,7 +22,7 @@ pub struct AccelerationSpeedController {
 }
 
 impl AccelerationSpeedController {
-    pub fn new(
+    pub const fn new(
         min_speed: Option<f64>,
         max_speed: Option<f64>,
         min_acceleration: f64,
@@ -98,16 +98,16 @@ impl AccelerationSpeedController {
         new_speed
     }
 
-    pub fn reset(&mut self, initial_speed: f64) {
+    pub const fn reset(&mut self, initial_speed: f64) {
         self.last_speed = initial_speed;
         self.last_t = None; // Reset the last update time
     }
 
-    pub fn set_max_acceleration(&mut self, acceleration: f64) {
+    pub const fn set_max_acceleration(&mut self, acceleration: f64) {
         self.max_acceleration = acceleration;
     }
 
-    fn apply_speed_limits(&self, speed: f64) -> f64 {
+    const fn apply_speed_limits(&self, speed: f64) -> f64 {
         let mut limited_speed = speed;
 
         if let Some(min) = self.min_speed {
@@ -121,23 +121,23 @@ impl AccelerationSpeedController {
         limited_speed
     }
 
-    pub fn get_min_speed(&self) -> Option<f64> {
+    pub const fn get_min_speed(&self) -> Option<f64> {
         self.min_speed
     }
 
-    pub fn get_max_speed(&self) -> Option<f64> {
+    pub const fn get_max_speed(&self) -> Option<f64> {
         self.max_speed
     }
 
-    pub fn set_min_speed(&mut self, min_speed: Option<f64>) {
+    pub const fn set_min_speed(&mut self, min_speed: Option<f64>) {
         self.min_speed = min_speed;
     }
 
-    pub fn set_max_speed(&mut self, max_speed: Option<f64>) {
+    pub const fn set_max_speed(&mut self, max_speed: Option<f64>) {
         self.max_speed = max_speed;
     }
 
-    pub fn set_min_acceleration(&mut self, deceleration: f64) {
+    pub const fn set_min_acceleration(&mut self, deceleration: f64) {
         self.min_acceleration = deceleration;
     }
 }

--- a/control-core/src/controllers/first_degree_motion/angular_acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/angular_acceleration_speed_controller.rs
@@ -53,7 +53,7 @@ impl AngularAccelerationSpeedController {
     pub fn update(&mut self, target_speed: AngularVelocity, t: Instant) -> AngularVelocity {
         let target_speed = target_speed.get::<radian_per_second>();
         let new_speed = self.controller.update(target_speed, t);
-        return AngularVelocity::new::<radian_per_second>(new_speed);
+        AngularVelocity::new::<radian_per_second>(new_speed)
     }
 
     pub fn reset(&mut self, initial_speed: AngularVelocity) {
@@ -73,13 +73,13 @@ impl AngularAccelerationSpeedController {
     pub fn get_min_speed(&self) -> Option<AngularVelocity> {
         self.controller
             .get_min_speed()
-            .map(|s| AngularVelocity::new::<radian_per_second>(s))
+            .map(AngularVelocity::new::<radian_per_second>)
     }
 
     pub fn get_max_speed(&self) -> Option<AngularVelocity> {
         self.controller
             .get_max_speed()
-            .map(|s| AngularVelocity::new::<radian_per_second>(s))
+            .map(AngularVelocity::new::<radian_per_second>)
     }
 
     pub fn set_min_speed(&mut self, min_speed: Option<AngularVelocity>) {

--- a/control-core/src/controllers/first_degree_motion/linear_acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/linear_acceleration_speed_controller.rs
@@ -48,7 +48,7 @@ impl LinearAccelerationLimitingController {
     pub fn update(&mut self, target_speed: Velocity, t: Instant) -> Velocity {
         let target_speed = target_speed.get::<meter_per_second>();
         let new_speed = self.controller.update(target_speed, t);
-        return Velocity::new::<meter_per_second>(new_speed);
+        Velocity::new::<meter_per_second>(new_speed)
     }
     pub fn reset(&mut self, initial_speed: Velocity) {
         let initial_speed = initial_speed.get::<meter_per_second>();
@@ -65,12 +65,12 @@ impl LinearAccelerationLimitingController {
     pub fn get_min_speed(&self) -> Option<Velocity> {
         self.controller
             .get_min_speed()
-            .map(|s| Velocity::new::<meter_per_second>(s))
+            .map(Velocity::new::<meter_per_second>)
     }
     pub fn get_max_speed(&self) -> Option<Velocity> {
         self.controller
             .get_max_speed()
-            .map(|s| Velocity::new::<meter_per_second>(s))
+            .map(Velocity::new::<meter_per_second>)
     }
     pub fn set_min_speed(&mut self, min_speed: Option<Velocity>) {
         self.controller

--- a/control-core/src/controllers/pid.rs
+++ b/control-core/src/controllers/pid.rs
@@ -21,7 +21,7 @@ pub struct PidController {
 }
 
 impl PidController {
-    pub fn new(kp: f64, ki: f64, kd: f64) -> Self {
+    pub const fn new(kp: f64, ki: f64, kd: f64) -> Self {
         Self {
             kp,
             ki,
@@ -33,27 +33,27 @@ impl PidController {
         }
     }
 
-    pub fn configure(&mut self, ki: f64, kp: f64, kd: f64) {
+    pub const fn configure(&mut self, ki: f64, kp: f64, kd: f64) {
         self.reset();
         self.kp = kp;
         self.ki = ki;
         self.kd = kd;
     }
 
-    pub fn get_kp(&self) -> f64 {
+    pub const fn get_kp(&self) -> f64 {
         self.kp
     }
 
-    pub fn get_ki(&self) -> f64 {
+    pub const fn get_ki(&self) -> f64 {
         self.ki
     }
 
-    pub fn get_kd(&self) -> f64 {
+    pub const fn get_kd(&self) -> f64 {
         self.kd
     }
 
     pub fn update(&mut self, error: f64, t: Instant) -> f64 {
-        let signal = match self.last {
+        match self.last {
             // First update
             None => {
                 // Calculate error
@@ -78,11 +78,11 @@ impl PidController {
 
                 // Calculate errors
                 let ep = error;
-                let ei = self.ei + ep * dt;
+                let ei = ep.mul_add(dt, self.ei);
                 let ed = (ep - self.ep) / dt;
 
                 // Calculate signal
-                let signal = self.kp * ep + self.ki * ei + self.kd * ed;
+                let signal = self.kd.mul_add(ed, self.kp.mul_add(ep, self.ki * ei));
 
                 // Set values
                 self.ep = ep;
@@ -92,12 +92,10 @@ impl PidController {
 
                 signal
             }
-        };
-
-        signal
+        }
     }
 
-    pub fn reset(&mut self) {
+    pub const fn reset(&mut self) {
         self.ep = 0.0;
         self.ei = 0.0;
         self.ed = 0.0;

--- a/control-core/src/controllers/second_degree_motion/angular_acceleration_position_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/angular_acceleration_position_controller.rs
@@ -102,16 +102,12 @@ impl AngularAccelerationPositionController {
 
     /// Get the minimum angle position limit
     pub fn get_min_position(&self) -> Option<Angle> {
-        self.controller
-            .get_min_position()
-            .map(|angle| Angle::new::<radian>(angle))
+        self.controller.get_min_position().map(Angle::new::<radian>)
     }
 
     /// Get the maximum angle position limit
     pub fn get_max_position(&self) -> Option<Angle> {
-        self.controller
-            .get_max_position()
-            .map(|angle| Angle::new::<radian>(angle))
+        self.controller.get_max_position().map(Angle::new::<radian>)
     }
 
     /// Set the minimum angle position limit

--- a/control-core/src/controllers/second_degree_motion/angular_jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/angular_jerk_speed_controller.rs
@@ -236,7 +236,7 @@ impl AngularJerkSpeedController {
     pub fn get_min_speed(&self) -> Option<AngularVelocity> {
         self.controller
             .get_min_speed()
-            .map(|speed| AngularVelocity::new::<radian_per_second>(speed))
+            .map(AngularVelocity::new::<radian_per_second>)
     }
 
     /// Get the maximum angular velocity limit
@@ -248,7 +248,7 @@ impl AngularJerkSpeedController {
     pub fn get_max_speed(&self) -> Option<AngularVelocity> {
         self.controller
             .get_max_speed()
-            .map(|speed| AngularVelocity::new::<radian_per_second>(speed))
+            .map(AngularVelocity::new::<radian_per_second>)
     }
 
     /// Set the minimum angular velocity limit

--- a/control-core/src/controllers/second_degree_motion/jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/jerk_speed_controller.rs
@@ -88,7 +88,7 @@ impl JerkSpeedController {
         )
         .expect("Failed to create AccelerationPositionController");
 
-        JerkSpeedController { base_controller }
+        Self { base_controller }
     }
 
     /// Create a new speed controller with simple symmetric limits
@@ -183,7 +183,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Current speed as a floating-point value
-    pub fn get_speed(&self) -> f64 {
+    pub const fn get_speed(&self) -> f64 {
         self.base_controller.get_position()
     }
 
@@ -193,7 +193,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Current acceleration as a floating-point value
-    pub fn get_acceleration(&self) -> f64 {
+    pub const fn get_acceleration(&self) -> f64 {
         self.base_controller.get_speed()
     }
 
@@ -203,7 +203,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Current jerk as a floating-point value
-    pub fn get_jerk(&self) -> f64 {
+    pub const fn get_jerk(&self) -> f64 {
         self.base_controller.get_acceleration()
     }
 
@@ -213,7 +213,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Target speed as a floating-point value
-    pub fn get_target_speed(&self) -> f64 {
+    pub const fn get_target_speed(&self) -> f64 {
         self.base_controller.get_target_position()
     }
 
@@ -223,7 +223,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Minimum speed limit as an Option<f64>, None if no limit is set
-    pub fn get_min_speed(&self) -> Option<f64> {
+    pub const fn get_min_speed(&self) -> Option<f64> {
         self.base_controller.get_min_position()
     }
 
@@ -233,7 +233,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Maximum speed limit as an Option<f64>, None if no limit is set
-    pub fn get_max_speed(&self) -> Option<f64> {
+    pub const fn get_max_speed(&self) -> Option<f64> {
         self.base_controller.get_max_position()
     }
 

--- a/control-core/src/controllers/second_degree_motion/linear_acceleration_position_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/linear_acceleration_position_controller.rs
@@ -205,9 +205,7 @@ impl LinearAccelerationPositionController {
     /// # Returns
     /// Minimum position limit as an Option<Length>, None if no limit is set
     pub fn get_min_position(&self) -> Option<Length> {
-        self.controller
-            .get_min_position()
-            .map(|length| Length::new::<meter>(length))
+        self.controller.get_min_position().map(Length::new::<meter>)
     }
 
     /// Get the maximum position limit
@@ -217,9 +215,7 @@ impl LinearAccelerationPositionController {
     /// # Returns  
     /// Maximum position limit as an Option<Length>, None if no limit is set
     pub fn get_max_position(&self) -> Option<Length> {
-        self.controller
-            .get_max_position()
-            .map(|length| Length::new::<meter>(length))
+        self.controller.get_max_position().map(Length::new::<meter>)
     }
 
     /// Set the minimum position limit

--- a/control-core/src/controllers/second_degree_motion/linear_jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/linear_jerk_speed_controller.rs
@@ -195,14 +195,14 @@ impl LinearJerkSpeedController {
     pub fn get_min_speed(&self) -> Option<Velocity> {
         self.controller
             .get_min_speed()
-            .map(|speed| Velocity::new::<meter_per_second>(speed))
+            .map(Velocity::new::<meter_per_second>)
     }
 
     /// Get the maximum velocity limit
     pub fn get_max_speed(&self) -> Option<Velocity> {
         self.controller
             .get_max_speed()
-            .map(|speed| Velocity::new::<meter_per_second>(speed))
+            .map(Velocity::new::<meter_per_second>)
     }
 
     /// Set the minimum velocity limit

--- a/control-core/src/converters/angle_converter.rs
+++ b/control-core/src/converters/angle_converter.rs
@@ -1,8 +1,6 @@
-use std::f32::consts::PI;
-
 use uom::si::angle::radian;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AngleConverter {
     pub flip_x: bool, // true to flip X-axis (mirror horizontally)
     pub flip_y: bool, // true to flip Y-axis (mirror vertically)
@@ -11,7 +9,7 @@ pub struct AngleConverter {
 
 impl AngleConverter {
     /// Create a custom coordinate system
-    pub fn new(flip_x: bool, flip_y: bool, is_cw: bool) -> Self {
+    pub const fn new(flip_x: bool, flip_y: bool, is_cw: bool) -> Self {
         Self {
             flip_x,
             flip_y,
@@ -20,47 +18,47 @@ impl AngleConverter {
     }
 
     /// Standard mathematical coordinate system (CCW positive, 0° at positive X)
-    pub fn mathematical() -> Self {
+    pub const fn mathematical() -> Self {
         Self::new(false, false, false)
     }
 
     /// Screen/graphics coordinate system (CW positive, 0° at positive X, Y-flipped)
-    pub fn screen() -> Self {
+    pub const fn screen() -> Self {
         Self::new(false, true, false)
     }
 
     /// System where 0° points up, clockwise positive
-    pub fn y_up_cw() -> Self {
+    pub const fn y_up_cw() -> Self {
         Self::new(false, false, true)
     }
 
     /// System where 0° points down, counter-clockwise positive
-    pub fn y_down_ccw() -> Self {
+    pub const fn y_down_ccw() -> Self {
         Self::new(false, true, true)
     }
 
     /// System where 0° points left, clockwise positive
-    pub fn x_left_cw() -> Self {
+    pub const fn x_left_cw() -> Self {
         Self::new(true, false, false)
     }
 
     /// System where 0° points right, counter-clockwise positive (same as mathematical)
-    pub fn x_right_ccw() -> Self {
+    pub const fn x_right_ccw() -> Self {
         Self::mathematical()
     }
 
     /// System where 0° points up, counter-clockwise positive
-    pub fn y_up_ccw() -> Self {
+    pub const fn y_up_ccw() -> Self {
         Self::new(false, false, false)
     }
 
     /// System where 0° points down, clockwise positive
-    pub fn y_down_cw() -> Self {
+    pub const fn y_down_cw() -> Self {
         Self::new(false, true, false)
     }
 
     /// System where 0° points left, counter-clockwise positive
-    pub fn x_left_ccw() -> Self {
+    pub const fn x_left_ccw() -> Self {
         Self::new(true, false, true)
     }
 
@@ -75,7 +73,7 @@ impl AngleConverter {
             (false, false) => {}                      // No change
             (true, false) => result = 180.0 - result, // X-flip: mirror across Y-axis
             (false, true) => result = -result,        // Y-flip: mirror across X-axis
-            (true, true) => result = 180.0 + result,  // Both flips: 180° rotation
+            (true, true) => result += 180.0,          // Both flips: 180° rotation
         }
 
         // Handle rotation direction
@@ -102,7 +100,7 @@ impl AngleConverter {
             (false, false) => {}                      // No change
             (true, false) => result = 180.0 - result, // X-flip: mirror across Y-axis
             (false, true) => result = -result,        // Y-flip: mirror across X-axis
-            (true, true) => result = result - 180.0,  // Both flips: inverse 180° rotation
+            (true, true) => result -= 180.0,          // Both flips: inverse 180° rotation
         }
 
         self.normalize_angle(result)
@@ -110,16 +108,16 @@ impl AngleConverter {
 
     /// Convert angle in radians from mathematical system to this system (f32)
     pub fn radians_encode(&self, math_angle_radians: f32) -> f32 {
-        let degrees = math_angle_radians * 180.0 / PI;
+        let degrees = math_angle_radians.to_degrees();
         let converted_degrees = self.degrees_encode(degrees);
-        converted_degrees * PI / 180.0
+        converted_degrees.to_radians()
     }
 
     /// Convert angle in radians from this system to mathematical system (f32)
     pub fn radians_decode(&self, system_angle_radians: f32) -> f32 {
-        let degrees = system_angle_radians * 180.0 / PI;
+        let degrees = system_angle_radians.to_degrees();
         let converted_degrees = self.degrees_decode(degrees);
-        converted_degrees * PI / 180.0
+        converted_degrees.to_radians()
     }
 
     /// Convert angle from mathematical system to this system (f64)
@@ -133,7 +131,7 @@ impl AngleConverter {
             (false, false) => {}                      // No change
             (true, false) => result = 180.0 - result, // X-flip: mirror across Y-axis
             (false, true) => result = -result,        // Y-flip: mirror across X-axis
-            (true, true) => result = 180.0 + result,  // Both flips: 180° rotation
+            (true, true) => result += 180.0,          // Both flips: 180° rotation
         }
 
         // Handle rotation direction
@@ -160,7 +158,7 @@ impl AngleConverter {
             (false, false) => {}                      // No change
             (true, false) => result = 180.0 - result, // X-flip: mirror across Y-axis
             (false, true) => result = -result,        // Y-flip: mirror across X-axis
-            (true, true) => result = result - 180.0,  // Both flips: inverse 180° rotation
+            (true, true) => result -= 180.0,          // Both flips: inverse 180° rotation
         }
 
         self.normalize_angle_f64(result)
@@ -168,16 +166,16 @@ impl AngleConverter {
 
     /// Convert angle in radians from mathematical system to this system (f64)
     pub fn radians_encode_f64(&self, math_angle_radians: f64) -> f64 {
-        let degrees = math_angle_radians * 180.0 / std::f64::consts::PI;
+        let degrees = math_angle_radians.to_degrees();
         let converted_degrees = self.degrees_encode_f64(degrees);
-        converted_degrees * std::f64::consts::PI / 180.0
+        converted_degrees.to_radians()
     }
 
     /// Convert angle in radians from this system to mathematical system (f64)
     pub fn radians_decode_f64(&self, system_angle_radians: f64) -> f64 {
-        let degrees = system_angle_radians * 180.0 / std::f64::consts::PI;
+        let degrees = system_angle_radians.to_degrees();
         let converted_degrees = self.degrees_decode_f64(degrees);
-        converted_degrees * std::f64::consts::PI / 180.0
+        converted_degrees.to_radians()
     }
 
     /// Normalize angle to [0, 360) range (f32)
@@ -205,7 +203,7 @@ pub struct AngleConverterUom {
 }
 
 impl AngleConverterUom {
-    pub fn new(angle_converter: AngleConverter) -> Self {
+    pub const fn new(angle_converter: AngleConverter) -> Self {
         Self { angle_converter }
     }
 

--- a/control-core/src/converters/angle_converter.rs
+++ b/control-core/src/converters/angle_converter.rs
@@ -238,6 +238,8 @@ impl AngleConverterUom {
 
 #[cfg(test)]
 mod tests {
+    use std::f32::consts::PI;
+
     use super::*;
 
     #[test]

--- a/control-core/src/converters/angular_step_converter.rs
+++ b/control-core/src/converters/angular_step_converter.rs
@@ -18,7 +18,7 @@ pub struct AngularStepConverter {
 
 impl AngularStepConverter {
     /// Create a new converter with the specified steps per revolution
-    pub fn new(steps_per_revolution: i16) -> Self {
+    pub const fn new(steps_per_revolution: i16) -> Self {
         Self {
             steps_per_revolution,
         }

--- a/control-core/src/converters/linear_step_converter.rs
+++ b/control-core/src/converters/linear_step_converter.rs
@@ -60,7 +60,7 @@ impl LinearStepConverter {
     }
 
     /// Get the steps per revolution
-    pub fn steps_per_revolution(&self) -> i16 {
+    pub const fn steps_per_revolution(&self) -> i16 {
         self.angular_step_converter.steps_per_revolution
     }
 }

--- a/control-core/src/ethercat/eeprom_identification.rs
+++ b/control-core/src/ethercat/eeprom_identification.rs
@@ -45,7 +45,12 @@ pub struct MachineIdentificationAddresses {
 }
 
 impl MachineIdentificationAddresses {
-    pub fn new(vendor_word: u16, serial_word: u16, machine_word: u16, device_word: u16) -> Self {
+    pub const fn new(
+        vendor_word: u16,
+        serial_word: u16,
+        machine_word: u16,
+        device_word: u16,
+    ) -> Self {
         Self {
             vendor_word,
             serial_word,
@@ -75,7 +80,7 @@ pub async fn read_device_identifications<'maindevice>(
 ) -> Vec<Result<DeviceMachineIdentification, Error>> {
     let mut result = Vec::new();
     for subdevice in subdevices.iter() {
-        let identification = machine_device_identification(&subdevice, maindevice).await;
+        let identification = machine_device_identification(subdevice, maindevice).await;
         result.push(identification);
     }
     result
@@ -226,7 +231,7 @@ pub fn get_identification_addresses<'maindevice>(
     subdevice_identity: &SubDeviceIdentity,
     subdevice_name: &str,
 ) -> Result<MachineIdentificationAddresses, Error> {
-    let identity_tuple = subdevice_identity_to_tuple(&subdevice_identity);
+    let identity_tuple = subdevice_identity_to_tuple(subdevice_identity);
 
     Ok(match identity_tuple {
         EK1100_IDENTITY_A => MachineIdentificationAddresses::default(),
@@ -276,8 +281,8 @@ async fn u16dump<'maindevice>(
         words.push(subdevice.eeprom_read(maindevice, word).await?);
     }
 
-    print!(
-        "EEPROM dump for {} from 0x{:04x} to 0x{:04x}\n",
+    println!(
+        "EEPROM dump for {} from 0x{:04x} to 0x{:04x}",
         subdevice.name(),
         start_byte / 2,
         end_byte / 2
@@ -292,7 +297,7 @@ fn u16print(start_byte: u16, end_byte: u16, data: Vec<u16>) {
     let table_start_word = start_byte & 0xfff0;
     let table_end_word = (end_byte & 0xfff0_u16) + 0x10_u16;
 
-    let rows = table_end_word - table_start_word >> 4;
+    let rows = (table_end_word - table_start_word) >> 4;
 
     for row in 0..rows {
         print!("0x{:04x} | ", (table_start_word + row * 0x10) / 2);
@@ -309,7 +314,7 @@ fn u16print(start_byte: u16, end_byte: u16, data: Vec<u16>) {
                 }
             }
         }
-        print!("\n");
+        println!();
     }
 }
 

--- a/control-core/src/ethercat/interface_discovery.rs
+++ b/control-core/src/ethercat/interface_discovery.rs
@@ -42,7 +42,7 @@ pub async fn discover_ethercat_interface() -> Result<String, anyhow::Error> {
 
     // Get eligible interfaces
     let mut interfaces = Interface::get_all()
-        .or_else(|e| Err(anyhow::anyhow!("Failed to get network interfaces: {}", e)))?
+        .map_err(|e| anyhow::anyhow!("Failed to get network interfaces: {}", e))?
         .into_iter()
         .filter(|iface| {
             iface.is_up()
@@ -90,10 +90,7 @@ pub async fn discover_ethercat_interface() -> Result<String, anyhow::Error> {
     // Wait for all tasks to complete and collect successful results
     let successful_interfaces: Vec<String> = tasks
         .into_iter()
-        .filter_map(|task| match task.join().expect("Should join thread") {
-            Some(name) => Some(name),
-            None => None,
-        })
+        .filter_map(|task| task.join().expect("Should join thread"))
         .collect();
 
     // Return the first successful interface (they're sorted by name)

--- a/control-core/src/helpers/hasher_serializer.rs
+++ b/control-core/src/helpers/hasher_serializer.rs
@@ -25,12 +25,12 @@ impl serde::ser::Error for HashSerializerError {
     where
         T: Display,
     {
-        HashSerializerError {}
+        Self {}
     }
 }
 
 pub struct HashSerializer<'a, H: Hasher>(&'a mut H);
-impl<'a, H: Hasher> SerializeSeq for HashSerializer<'a, H> {
+impl<H: Hasher> SerializeSeq for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
 
@@ -46,7 +46,7 @@ impl<'a, H: Hasher> SerializeSeq for HashSerializer<'a, H> {
     }
 }
 
-impl<'a, H: Hasher> SerializeTuple for HashSerializer<'a, H> {
+impl<H: Hasher> SerializeTuple for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
 
@@ -62,7 +62,7 @@ impl<'a, H: Hasher> SerializeTuple for HashSerializer<'a, H> {
     }
 }
 
-impl<'a, H: Hasher> SerializeTupleStruct for HashSerializer<'a, H> {
+impl<H: Hasher> SerializeTupleStruct for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
 
@@ -78,7 +78,7 @@ impl<'a, H: Hasher> SerializeTupleStruct for HashSerializer<'a, H> {
     }
 }
 
-impl<'a, H: Hasher> SerializeTupleVariant for HashSerializer<'a, H> {
+impl<H: Hasher> SerializeTupleVariant for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
 
@@ -94,7 +94,7 @@ impl<'a, H: Hasher> SerializeTupleVariant for HashSerializer<'a, H> {
     }
 }
 
-impl<'a, H: Hasher> SerializeMap for HashSerializer<'a, H> {
+impl<H: Hasher> SerializeMap for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
 
@@ -117,7 +117,7 @@ impl<'a, H: Hasher> SerializeMap for HashSerializer<'a, H> {
     }
 }
 
-impl<'a, H: Hasher> SerializeStruct for HashSerializer<'a, H> {
+impl<H: Hasher> SerializeStruct for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
 
@@ -135,7 +135,7 @@ impl<'a, H: Hasher> SerializeStruct for HashSerializer<'a, H> {
     }
 }
 
-impl<'a, H: Hasher> SerializeStructVariant for HashSerializer<'a, H> {
+impl<H: Hasher> SerializeStructVariant for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
 
@@ -152,7 +152,7 @@ impl<'a, H: Hasher> SerializeStructVariant for HashSerializer<'a, H> {
     }
 }
 
-impl<'a, H: Hasher> Serializer for HashSerializer<'a, H> {
+impl<H: Hasher> Serializer for HashSerializer<'_, H> {
     type Ok = ();
     type Error = HashSerializerError;
     type SerializeSeq = Self;
@@ -345,7 +345,7 @@ pub fn check_hash_different<T: Serialize>(a: T, b: T) -> bool {
     let hash = hash_with_serde_model(a, hasher);
     let hasher = DefaultHasher::new();
     let hash_old = hash_with_serde_model(b, hasher);
-    return hash != hash_old;
+    hash != hash_old
 }
 
 #[test]

--- a/control-core/src/helpers/interpolation.rs
+++ b/control-core/src/helpers/interpolation.rs
@@ -63,11 +63,11 @@ pub fn scale<T>(normalized_value: f64, new_min: T, new_max: T) -> T
 where
     T: Into<f64> + From<f64>,
 {
-    let normalized_value: f64 = normalized_value.into();
+    let normalized_value: f64 = normalized_value;
     let new_min: f64 = new_min.into();
     let new_max: f64 = new_max.into();
 
-    let result = normalized_value * (new_max - new_min) + new_min;
+    let result = normalized_value.mul_add(new_max - new_min, new_min);
     T::from(result)
 }
 
@@ -128,11 +128,11 @@ where
     // If we are under X we scale linearly from 0 to y
     // If we are over X we scale linearly from y to 1
     if value_f64 < x_f64 {
-        return normalize(value_f64, 0.0, x_f64) * y_f64;
+        normalize(value_f64, 0.0, x_f64) * y_f64
     } else if value_f64 > x_f64 {
-        return normalize(value_f64, x_f64, 1.0) * (1.0 - y_f64) + y_f64;
+        normalize(value_f64, x_f64, 1.0).mul_add(1.0 - y_f64, y_f64)
     } else {
-        return y_f64;
+        y_f64
     }
 }
 
@@ -273,7 +273,7 @@ pub fn interpolate_exponential(normalized_value: f64, steepness: f64) -> f64 {
         return normalized_value;
     }
     let numerator = steepness.exp().powf(normalized_value) - 1.0;
-    let denominator = steepness.exp() - 1.0;
+    let denominator = steepness.exp_m1();
 
     clip(numerator / denominator)
 }
@@ -414,7 +414,7 @@ pub fn interpolate_inflected_exponential(x: f64, steepness: f64) -> f64 {
 
         // Use standard exponential interpolation
         let result = interpolate_exponential(x_norm, steepness);
-        0.5 + 0.5 * result
+        0.5f64.mul_add(result, 0.5)
     }
 }
 

--- a/control-core/src/helpers/moving_time_window.rs
+++ b/control-core/src/helpers/moving_time_window.rs
@@ -11,37 +11,37 @@ pub trait DivideByCount {
 
 impl DivideByCount for f64 {
     fn divide_by_count(self, count: usize) -> Self {
-        self / (count as f64)
+        self / (count as Self)
     }
 }
 
 impl DivideByCount for f32 {
     fn divide_by_count(self, count: usize) -> Self {
-        self / (count as f32)
+        self / (count as Self)
     }
 }
 
 impl DivideByCount for i32 {
     fn divide_by_count(self, count: usize) -> Self {
-        self / (count as i32)
+        self / (count as Self)
     }
 }
 
 impl DivideByCount for i64 {
     fn divide_by_count(self, count: usize) -> Self {
-        self / (count as i64)
+        self / (count as Self)
     }
 }
 
 impl DivideByCount for u32 {
     fn divide_by_count(self, count: usize) -> Self {
-        self / (count as u32)
+        self / (count as Self)
     }
 }
 
 impl DivideByCount for u64 {
     fn divide_by_count(self, count: usize) -> Self {
-        self / (count as u64)
+        self / (count as Self)
     }
 }
 

--- a/control-core/src/machines/identification.rs
+++ b/control-core/src/machines/identification.rs
@@ -12,7 +12,7 @@ pub struct MachineIdentificationUnique {
 
 impl MachineIdentificationUnique {
     /// Check if values are non-zero
-    pub fn is_valid(&self) -> bool {
+    pub const fn is_valid(&self) -> bool {
         self.machine_identification.is_valid() && self.serial != 0
     }
 }
@@ -36,12 +36,12 @@ pub struct MachineIdentification {
 
 impl MachineIdentification {
     /// Check if values are non-zero
-    pub fn is_valid(&self) -> bool {
+    pub const fn is_valid(&self) -> bool {
         self.vendor != 0 && self.machine != 0
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeviceMachineIdentification {
     pub machine_identification_unique: MachineIdentificationUnique,
     pub role: u16,
@@ -49,7 +49,7 @@ pub struct DeviceMachineIdentification {
 
 impl DeviceMachineIdentification {
     /// Check if values are non-zero
-    pub fn is_valid(&self) -> bool {
+    pub const fn is_valid(&self) -> bool {
         self.machine_identification_unique.is_valid()
             && self
                 .machine_identification_unique
@@ -59,7 +59,7 @@ impl DeviceMachineIdentification {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeviceIdentification {
     pub device_machine_identification: Option<DeviceMachineIdentification>,
     pub device_hardware_identification: DeviceHardwareIdentification,
@@ -67,14 +67,14 @@ pub struct DeviceIdentification {
 
 impl From<DeviceIdentificationIdentified> for DeviceIdentification {
     fn from(value: DeviceIdentificationIdentified) -> Self {
-        DeviceIdentification {
+        Self {
             device_machine_identification: Some(value.device_machine_identification),
             device_hardware_identification: value.device_hardware_identification,
         }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeviceIdentificationIdentified {
     pub device_machine_identification: DeviceMachineIdentification,
     pub device_hardware_identification: DeviceHardwareIdentification,
@@ -90,24 +90,24 @@ impl TryFrom<DeviceIdentification> for DeviceIdentificationIdentified {
                 module_path!()
             ))?;
 
-        Ok(DeviceIdentificationIdentified {
+        Ok(Self {
             device_machine_identification,
             device_hardware_identification: value.device_hardware_identification,
         })
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum DeviceHardwareIdentification {
     Ethercat(DeviceHardwareIdentificationEthercat),
     Serial(DeviceHardwareIdentificationSerial),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeviceHardwareIdentificationEthercat {
     pub subdevice_index: usize,
 }
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeviceHardwareIdentificationSerial {
     pub path: String,
 }

--- a/control-core/src/machines/manager.rs
+++ b/control-core/src/machines/manager.rs
@@ -31,6 +31,12 @@ pub struct MachineManager {
         HashMap<MachineIdentificationUnique, Result<Arc<Mutex<dyn Machine>>, anyhow::Error>>,
 }
 
+impl Default for MachineManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MachineManager {
     pub fn new() -> Self {
         Self {
@@ -45,7 +51,7 @@ impl MachineManager {
         machine_registry: &MachineRegistry,
         hardware: &MachineNewHardwareEthercat,
         socket_queue_tx: Sender<(SocketRef, Arc<GenericEvent>)>,
-        machine_manager: Weak<RwLock<MachineManager>>,
+        machine_manager: Weak<RwLock<Self>>,
     ) {
         // empty ethercat machines
         self.ethercat_machines.clear();
@@ -99,7 +105,7 @@ impl MachineManager {
         device: Arc<RwLock<dyn SerialDevice>>,
         machine_registry: &MachineRegistry,
         socket_queue_tx: Sender<(SocketRef, Arc<GenericEvent>)>,
-        machine_manager: Weak<RwLock<MachineManager>>,
+        machine_manager: Weak<RwLock<Self>>,
     ) {
         let hardware = MachineNewHardwareSerial { device };
 
@@ -113,7 +119,7 @@ impl MachineManager {
             device_group: &vec![device_identification_identified.clone()],
             hardware: &MachineNewHardware::Serial(&hardware),
             socket_queue_tx,
-            machine_manager: machine_manager.clone(),
+            machine_manager,
         });
 
         tracing::info!("Adding serial machine {:?}", new_machine);
@@ -163,7 +169,7 @@ impl MachineManager {
             }
         };
         let machine_weak = Arc::downgrade(machine);
-        return Some(machine_weak);
+        Some(machine_weak)
     }
 
     pub fn get_serial_weak(
@@ -184,7 +190,7 @@ impl MachineManager {
             }
         };
         let machine_weak = Arc::downgrade(machine);
-        return Some(machine_weak);
+        Some(machine_weak)
     }
 }
 

--- a/control-core/src/machines/mod.rs
+++ b/control-core/src/machines/mod.rs
@@ -61,7 +61,7 @@ pub struct ConnectedMachine<T: GetStrongCount> {
     pub machine: T,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ConnectedMachineData {
     pub machine_identification_unique: MachineIdentificationUnique,
     pub is_available: bool,

--- a/control-core/src/machines/new.rs
+++ b/control-core/src/machines/new.rs
@@ -16,9 +16,7 @@ use std::{
 use crate::socketio::event::GenericEvent;
 
 pub trait MachineNewTrait {
-    fn new<'maindevice, 'subdevices>(
-        params: &MachineNewParams<'maindevice, 'subdevices, '_, '_, '_, '_, '_>,
-    ) -> Result<Self, Error>
+    fn new(params: &MachineNewParams<'_, '_, '_, '_, '_, '_, '_>) -> Result<Self, Error>
     where
         Self: Sized;
 }

--- a/control-core/src/machines/registry.rs
+++ b/control-core/src/machines/registry.rs
@@ -10,6 +10,12 @@ pub struct MachineRegistry {
     type_map: HashMap<TypeId, (MachineIdentification, MachineNewClosure)>,
 }
 
+impl Default for MachineRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MachineRegistry {
     pub fn new() -> Self {
         Self {

--- a/control-core/src/modbus/mod.rs
+++ b/control-core/src/modbus/mod.rs
@@ -62,17 +62,17 @@ impl From<ModbusExceptionCode> for u8 {
 impl From<u8> for ModbusExceptionCode {
     fn from(value: u8) -> Self {
         match value {
-            0 => ModbusExceptionCode::None,
-            1 => ModbusExceptionCode::IllegalFunction,
-            2 => ModbusExceptionCode::IllegalDataAddress,
-            3 => ModbusExceptionCode::IllegalDataValue,
-            4 => ModbusExceptionCode::SlaveDeviceFailure,
-            5 => ModbusExceptionCode::Acknowledge,
-            6 => ModbusExceptionCode::SlaveDeviceBusy,
-            8 => ModbusExceptionCode::MemoryParityError,
-            10 => ModbusExceptionCode::GatewayPathUnavailable,
-            11 => ModbusExceptionCode::GatewayTargetDeviceFailedToRespond,
-            other => ModbusExceptionCode::Unknown(other),
+            0 => Self::None,
+            1 => Self::IllegalFunction,
+            2 => Self::IllegalDataAddress,
+            3 => Self::IllegalDataValue,
+            4 => Self::SlaveDeviceFailure,
+            5 => Self::Acknowledge,
+            6 => Self::SlaveDeviceBusy,
+            8 => Self::MemoryParityError,
+            10 => Self::GatewayPathUnavailable,
+            11 => Self::GatewayTargetDeviceFailedToRespond,
+            other => Self::Unknown(other),
         }
     }
 }
@@ -97,10 +97,10 @@ impl TryFrom<u8> for ModbusFunctionCode {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0x03 => Ok(ModbusFunctionCode::ReadHoldingRegister),
-            0x04 => Ok(ModbusFunctionCode::ReadInputRegister),
-            0x06 => Ok(ModbusFunctionCode::PresetHoldingRegister),
-            0x08 => Ok(ModbusFunctionCode::DiagnoseFunction),
+            0x03 => Ok(Self::ReadHoldingRegister),
+            0x04 => Ok(Self::ReadInputRegister),
+            0x06 => Ok(Self::PresetHoldingRegister),
+            0x08 => Ok(Self::DiagnoseFunction),
             _ => Err(anyhow::anyhow!("Error: Modbus Function Code doesnt exist!")),
         }
     }
@@ -119,7 +119,7 @@ impl From<ModbusFunctionCode> for u8 {
 
 impl From<ModbusRequest> for Vec<u8> {
     fn from(request: ModbusRequest) -> Self {
-        let mut buffer = Vec::new();
+        let mut buffer = Self::new();
 
         buffer.push(request.slave_id);
         buffer.push(request.function_code.into()); // convert functioncode into u8 and push it
@@ -132,7 +132,7 @@ impl From<ModbusRequest> for Vec<u8> {
         // convert u16 value to le_bytes and add it to the end of the frame
         buffer.extend_from_slice(&result_crc.to_le_bytes());
 
-        return buffer;
+        buffer
     }
 }
 /// Reads data from a Modbus device via a serial port.
@@ -153,7 +153,7 @@ pub fn receive_data_modbus(port: &mut dyn SerialPort) -> Result<Option<Vec<u8>>,
 }
 
 /// Computes Modbus CRC-16 using `crc` crate.
-pub fn modbus_crc16(data: &[u8]) -> u16 {
+pub const fn modbus_crc16(data: &[u8]) -> u16 {
     let modbus: Crc<u16> = Crc::<u16>::new(&CRC_16_MODBUS);
     modbus.checksum(data)
 }
@@ -204,23 +204,17 @@ fn extract_crc(raw_data: &Vec<u8>) -> Result<u16, Error> {
 }
 impl TryFrom<Vec<u8>> for ModbusResponse {
     type Error = anyhow::Error;
-    fn try_from(value: Vec<u8>) -> Result<ModbusResponse, Error> {
-        let crc = match extract_crc(&value) {
-            Ok(crc_value) => crc_value,
-            Err(err) => return Err(err),
-        };
+    fn try_from(value: Vec<u8>) -> Result<Self, Error> {
+        let crc = extract_crc(&value)?;
 
         let function_code_res = ModbusFunctionCode::try_from(value[1]);
-        let function_code = match function_code_res {
-            Ok(code) => code,
-            Err(err) => return Err(err),
-        };
+        let function_code = function_code_res?;
 
-        Ok(ModbusResponse {
+        Ok(Self {
             slave_id: value[0],
-            function_code: function_code,
+            function_code,
             data: value[2..value.len() - 2].to_vec(), // get data without the crc
-            crc: crc,
+            crc,
         })
     }
 }
@@ -232,23 +226,23 @@ impl TryFrom<Vec<u8>> for ModbusResponse {
 /// machine_operation_delay_nano: Delay for the given operation in nanoseconds as specified by the slaves datasheet (example: mitsubishi csfr84 has 12ms for read write in RAM)
 /// baudrate: bits per second
 /// message_size: size of original message in bytes
-pub fn calculate_modbus_rtu_timeout(
+pub const fn calculate_modbus_rtu_timeout(
     bits: u8,
     machine_operation_delay_nano: Duration,
     baudrate: u32,
     message_size: usize,
 ) -> Duration {
     let nanoseconds_per_bit: u64 = (1000000 / baudrate) as u64;
-    let nanoseconds_per_byte: u64 = bits as u64 * nanoseconds_per_bit as u64;
+    let nanoseconds_per_byte: u64 = bits as u64 * nanoseconds_per_bit;
 
     let transmission_timeout: u64 = nanoseconds_per_byte * message_size as u64;
-    let silent_time: u64 = (nanoseconds_per_byte * (35)) / 10 as u64; // silent_time is 3.5x of character length,which is 11 bit for 8E1
+    let silent_time: u64 = (nanoseconds_per_byte * (35)) / 10_u64; // silent_time is 3.5x of character length,which is 11 bit for 8E1
 
     let mut full_timeout: u64 = transmission_timeout;
     full_timeout += machine_operation_delay_nano.as_nanos() as u64;
     full_timeout += silent_time;
 
-    return Duration::from_nanos(full_timeout);
+    Duration::from_nanos(full_timeout)
 }
 
 #[cfg(test)]

--- a/control-core/src/modbus/modbus_serial_interface.rs
+++ b/control-core/src/modbus/modbus_serial_interface.rs
@@ -66,7 +66,7 @@ impl ModbusSerialInterface {
         }
     }
 
-    pub fn is_initialized(&self) -> bool {
+    pub const fn is_initialized(&self) -> bool {
         !matches!(self.state, State::Uninitialized)
     }
 
@@ -199,7 +199,7 @@ impl ModbusSerialInterface {
         Some(Duration::from_nanos(total_timeout))
     }
 
-    pub fn get_response(&self) -> Option<&ModbusResponse> {
+    pub const fn get_response(&self) -> Option<&ModbusResponse> {
         self.response.as_ref()
     }
 

--- a/control-core/src/rest/mutation.rs
+++ b/control-core/src/rest/mutation.rs
@@ -11,13 +11,13 @@ pub struct MutationResponse {
 }
 
 impl MutationResponse {
-    pub fn success() -> Self {
+    pub const fn success() -> Self {
         Self {
             success: true,
             error: None,
         }
     }
-    pub fn error(error: String) -> Self {
+    pub const fn error(error: String) -> Self {
         Self {
             success: false,
             error: Some(error),

--- a/control-core/src/serial/mod.rs
+++ b/control-core/src/serial/mod.rs
@@ -30,7 +30,7 @@ pub struct SerialDeviceNewParams {
     pub device_thread_panic_tx: Sender<SerialDeviceRemoval<String>>,
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct SerialDeviceIdentification {
     pub vendor_id: u16,
     pub product_id: u16,

--- a/control-core/src/serial/registry.rs
+++ b/control-core/src/serial/registry.rs
@@ -20,6 +20,12 @@ pub struct SerialDeviceRegistry {
     pub type_map: HashMap<TypeId, (SerialDeviceIdentification, SerialDeviceNewClosure)>,
 }
 
+impl Default for SerialDeviceRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SerialDeviceRegistry {
     pub fn new() -> Self {
         Self {

--- a/control-core/src/serial/serial_detection.rs
+++ b/control-core/src/serial/serial_detection.rs
@@ -82,15 +82,12 @@ impl<'serialdeviceregistry> SerialDetection<'serialdeviceregistry> {
         let mut usb_ports: Vec<(String, UsbPortInfo)> = Vec::new();
 
         for port in port_list {
-            match &port.port_type {
-                SerialPortType::UsbPort(usb_info) => {
-                    usb_ports.push((port.port_name.to_string(), usb_info.clone()));
-                }
-                _ => {}
+            if let SerialPortType::UsbPort(usb_info) = &port.port_type {
+                usb_ports.push((port.port_name.to_string(), usb_info.clone()));
             };
         }
 
-        return usb_ports;
+        usb_ports
     }
 
     pub async fn check_ports(&mut self) -> CheckPortsResult {

--- a/control-core/src/socketio/namespace_id.rs
+++ b/control-core/src/socketio/namespace_id.rs
@@ -17,8 +17,8 @@ impl Serialize for NamespaceId {
         S: Serializer,
     {
         match self {
-            NamespaceId::Main => serializer.serialize_str("/main"),
-            NamespaceId::Machine(id) => {
+            Self::Main => serializer.serialize_str("/main"),
+            Self::Machine(id) => {
                 let path = format!(
                     "/machine/{}/{}/{}",
                     id.machine_identification.vendor, id.machine_identification.machine, id.serial
@@ -36,7 +36,7 @@ impl<'de> Deserialize<'de> for NamespaceId {
     {
         struct NamespaceIdVisitor;
 
-        impl<'de> Visitor<'de> for NamespaceIdVisitor {
+        impl Visitor<'_> for NamespaceIdVisitor {
             type Value = NamespaceId;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -85,7 +85,7 @@ impl FromStr for NamespaceId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == "/main" {
-            return Ok(NamespaceId::Main);
+            return Ok(Self::Main);
         }
 
         if let Some(machine_path) = s.strip_prefix("/machine/") {
@@ -101,7 +101,7 @@ impl FromStr for NamespaceId {
                     .parse::<u16>()
                     .map_err(|_| "Invalid serial id".to_string())?;
 
-                return Ok(NamespaceId::Machine(MachineIdentificationUnique {
+                return Ok(Self::Machine(MachineIdentificationUnique {
                     machine_identification: MachineIdentification { vendor, machine },
                     serial,
                 }));
@@ -116,8 +116,8 @@ impl FromStr for NamespaceId {
 impl fmt::Display for NamespaceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NamespaceId::Main => write!(f, "/main"),
-            NamespaceId::Machine(id) => {
+            Self::Main => write!(f, "/main"),
+            Self::Machine(id) => {
                 write!(
                     f,
                     "/machine/{}/{}/{}",

--- a/control-core/src/transmission/fixed.rs
+++ b/control-core/src/transmission/fixed.rs
@@ -21,7 +21,7 @@ impl FixedTransmission {
     /// # Returns
     ///
     /// A new instance of FixedTransmission.
-    pub fn new(ratio: f64) -> Self {
+    pub const fn new(ratio: f64) -> Self {
         Self { ratio }
     }
 }

--- a/ethercat-eeprom-dump/Cargo.toml
+++ b/ethercat-eeprom-dump/Cargo.toml
@@ -3,6 +3,9 @@ name = "ethercat-eeprom-dump"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
 ethercrab = "0.6.0"

--- a/ethercat-eeprom-dump/src/ls.rs
+++ b/ethercat-eeprom-dump/src/ls.rs
@@ -34,7 +34,7 @@ pub fn ls(
         let driver = device_from_subdevice_identity(&identity);
         let identification_adresses = get_identification_addresses(&identity, device.name());
         let identification = match identification_adresses {
-            Ok(_) => block_on(machine_device_identification(&device, &maindevice)),
+            Ok(_) => block_on(machine_device_identification(&device, maindevice)),
             Err(_) => Err(anyhow!("")),
         };
 
@@ -122,7 +122,7 @@ pub fn ls(
     print_markdown_table(&table, true);
 
     // Put group into op state
-    match block_on(group.into_op(&maindevice)) {
+    match block_on(group.into_op(maindevice)) {
         Ok(_) => println!("Successfully put group into OP state"),
         Err(e) => println!("Failed to put group into OP state: {}", e),
     }

--- a/ethercat-eeprom-dump/src/print.rs
+++ b/ethercat-eeprom-dump/src/print.rs
@@ -52,7 +52,7 @@ pub fn print_markdown_table(table: &Vec<Vec<String>>, header_line: bool) {
         if row_idx == 0 && header_line && table.len() > 1 {
             print!("|");
             for (i, width) in col_widths.iter().enumerate() {
-                print!("{}:{}", "", "-".repeat(*width + 1));
+                print!(":{}", "-".repeat(*width + 1));
                 if i < max_cols - 1 {
                     print!("|");
                 }
@@ -107,7 +107,13 @@ pub fn print_buffer(buffer: &[u8]) {
         // Add ASCII representation
         let ascii: String = chunk
             .iter()
-            .map(|&b| if b >= 32 && b <= 126 { b as char } else { '.' })
+            .map(|&b| {
+                if (32..=126).contains(&b) {
+                    b as char
+                } else {
+                    '.'
+                }
+            })
             .collect();
         row.push(ascii);
 

--- a/ethercat-hal-derive/Cargo.toml
+++ b/ethercat-hal-derive/Cargo.toml
@@ -3,6 +3,9 @@ name = "ethercat_hal_derive"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/ethercat-hal/Cargo.toml
+++ b/ethercat-hal/Cargo.toml
@@ -3,6 +3,9 @@ name = "ethercat_hal"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.99"
 ethercrab = "0.6"

--- a/ethercat-hal/src/coe.rs
+++ b/ethercat-hal/src/coe.rs
@@ -40,9 +40,9 @@ where
     ///     }
     /// }
     /// ```
-    fn write_config<'maindevice>(
+    fn write_config(
         &mut self,
-        device: &EthercrabSubDevicePreoperational<'maindevice>,
+        device: &EthercrabSubDevicePreoperational<'_>,
         config: &C,
     ) -> impl Future<Output = Result<(), anyhow::Error>> + Send;
 

--- a/ethercat-hal/src/devices/el1002.rs
+++ b/ethercat-hal/src/devices/el1002.rs
@@ -52,10 +52,10 @@ pub enum EL1002Port {
 }
 
 impl EL1002Port {
-    pub fn to_bit_index(&self) -> usize {
+    pub const fn to_bit_index(&self) -> usize {
         match self {
-            EL1002Port::DI1 => 0,
-            EL1002Port::DI2 => 1,
+            Self::DI1 => 0,
+            Self::DI2 => 1,
         }
     }
 }
@@ -85,14 +85,14 @@ pub enum EL1002PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL1002TxPdo, ()> for EL1002PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL1002TxPdo {
         match self {
-            EL1002PredefinedPdoAssignment::All => EL1002TxPdo {
+            Self::All => EL1002TxPdo {
                 channel1: Some(BoolPdoObject::default()),
                 channel2: Some(BoolPdoObject::default()),
             },
         }
     }
 
-    fn rxpdo_assignment(&self) -> () {
+    fn rxpdo_assignment(&self) {
         unreachable!()
     }
 }

--- a/ethercat-hal/src/devices/el1008.rs
+++ b/ethercat-hal/src/devices/el1008.rs
@@ -65,16 +65,16 @@ pub enum EL1008Port {
 }
 
 impl EL1008Port {
-    pub fn to_bit_index(&self) -> usize {
+    pub const fn to_bit_index(&self) -> usize {
         match self {
-            EL1008Port::DI1 => 0,
-            EL1008Port::DI2 => 1,
-            EL1008Port::DI3 => 2,
-            EL1008Port::DI4 => 3,
-            EL1008Port::DI5 => 4,
-            EL1008Port::DI6 => 5,
-            EL1008Port::DI7 => 6,
-            EL1008Port::DI8 => 7,
+            Self::DI1 => 0,
+            Self::DI2 => 1,
+            Self::DI3 => 2,
+            Self::DI4 => 3,
+            Self::DI5 => 4,
+            Self::DI6 => 5,
+            Self::DI7 => 6,
+            Self::DI8 => 7,
         }
     }
 }
@@ -122,7 +122,7 @@ pub enum EL1008PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL1008TxPdo, ()> for EL1008PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL1008TxPdo {
         match self {
-            EL1008PredefinedPdoAssignment::All => EL1008TxPdo {
+            Self::All => EL1008TxPdo {
                 channel1: Some(BoolPdoObject::default()),
                 channel2: Some(BoolPdoObject::default()),
                 channel3: Some(BoolPdoObject::default()),
@@ -135,7 +135,7 @@ impl PredefinedPdoAssignment<EL1008TxPdo, ()> for EL1008PredefinedPdoAssignment 
         }
     }
 
-    fn rxpdo_assignment(&self) -> () {
+    fn rxpdo_assignment(&self) {
         unreachable!()
     }
 }

--- a/ethercat-hal/src/devices/el2002.rs
+++ b/ethercat-hal/src/devices/el2002.rs
@@ -35,10 +35,10 @@ impl DigitalOutputDevice<EL2002Port> for EL2002 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2002Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
             }
             EL2002Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
             }
         }
     }
@@ -46,8 +46,8 @@ impl DigitalOutputDevice<EL2002Port> for EL2002 {
     fn get_output(&self, port: EL2002Port) -> DigitalOutputOutput {
         let expect_text = "All channels should be Some(_)";
         DigitalOutputOutput(match port {
-            EL2002Port::DO1 => self.rxpdo.channel1.as_ref().expect(&expect_text).value,
-            EL2002Port::DO2 => self.rxpdo.channel2.as_ref().expect(&expect_text).value,
+            EL2002Port::DO1 => self.rxpdo.channel1.as_ref().expect(expect_text).value,
+            EL2002Port::DO2 => self.rxpdo.channel2.as_ref().expect(expect_text).value,
         })
     }
 }

--- a/ethercat-hal/src/devices/el2004.rs
+++ b/ethercat-hal/src/devices/el2004.rs
@@ -33,16 +33,16 @@ impl DigitalOutputDevice<EL2004Port> for EL2004 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2004Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
             }
             EL2004Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
             }
             EL2004Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
             }
             EL2004Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
             }
         }
     }
@@ -50,10 +50,10 @@ impl DigitalOutputDevice<EL2004Port> for EL2004 {
     fn get_output(&self, port: EL2004Port) -> DigitalOutputOutput {
         let expect_text = "All channels should be Some(_)";
         DigitalOutputOutput(match port {
-            EL2004Port::DO1 => self.rxpdo.channel1.as_ref().expect(&expect_text).value,
-            EL2004Port::DO2 => self.rxpdo.channel2.as_ref().expect(&expect_text).value,
-            EL2004Port::DO3 => self.rxpdo.channel3.as_ref().expect(&expect_text).value,
-            EL2004Port::DO4 => self.rxpdo.channel4.as_ref().expect(&expect_text).value,
+            EL2004Port::DO1 => self.rxpdo.channel1.as_ref().expect(expect_text).value,
+            EL2004Port::DO2 => self.rxpdo.channel2.as_ref().expect(expect_text).value,
+            EL2004Port::DO3 => self.rxpdo.channel3.as_ref().expect(expect_text).value,
+            EL2004Port::DO4 => self.rxpdo.channel4.as_ref().expect(expect_text).value,
         })
     }
 }

--- a/ethercat-hal/src/devices/el2008.rs
+++ b/ethercat-hal/src/devices/el2008.rs
@@ -35,28 +35,28 @@ impl DigitalOutputDevice<EL2008Port> for EL2008 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2008Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
             }
             EL2008Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
             }
             EL2008Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
             }
             EL2008Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
             }
             EL2008Port::DO5 => {
-                self.rxpdo.channel5.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into()
             }
             EL2008Port::DO6 => {
-                self.rxpdo.channel6.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into()
             }
             EL2008Port::DO7 => {
-                self.rxpdo.channel7.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into()
             }
             EL2008Port::DO8 => {
-                self.rxpdo.channel8.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into()
             }
         }
     }
@@ -64,14 +64,14 @@ impl DigitalOutputDevice<EL2008Port> for EL2008 {
     fn get_output(&self, port: EL2008Port) -> DigitalOutputOutput {
         let expect_text = "All channels should be Some(_)";
         DigitalOutputOutput(match port {
-            EL2008Port::DO1 => self.rxpdo.channel1.as_ref().expect(&expect_text).value,
-            EL2008Port::DO2 => self.rxpdo.channel2.as_ref().expect(&expect_text).value,
-            EL2008Port::DO3 => self.rxpdo.channel3.as_ref().expect(&expect_text).value,
-            EL2008Port::DO4 => self.rxpdo.channel4.as_ref().expect(&expect_text).value,
-            EL2008Port::DO5 => self.rxpdo.channel5.as_ref().expect(&expect_text).value,
-            EL2008Port::DO6 => self.rxpdo.channel6.as_ref().expect(&expect_text).value,
-            EL2008Port::DO7 => self.rxpdo.channel7.as_ref().expect(&expect_text).value,
-            EL2008Port::DO8 => self.rxpdo.channel8.as_ref().expect(&expect_text).value,
+            EL2008Port::DO1 => self.rxpdo.channel1.as_ref().expect(expect_text).value,
+            EL2008Port::DO2 => self.rxpdo.channel2.as_ref().expect(expect_text).value,
+            EL2008Port::DO3 => self.rxpdo.channel3.as_ref().expect(expect_text).value,
+            EL2008Port::DO4 => self.rxpdo.channel4.as_ref().expect(expect_text).value,
+            EL2008Port::DO5 => self.rxpdo.channel5.as_ref().expect(expect_text).value,
+            EL2008Port::DO6 => self.rxpdo.channel6.as_ref().expect(expect_text).value,
+            EL2008Port::DO7 => self.rxpdo.channel7.as_ref().expect(expect_text).value,
+            EL2008Port::DO8 => self.rxpdo.channel8.as_ref().expect(expect_text).value,
         })
     }
 }

--- a/ethercat-hal/src/devices/el2024.rs
+++ b/ethercat-hal/src/devices/el2024.rs
@@ -36,16 +36,16 @@ impl DigitalOutputDevice<EL2024Port> for EL2024 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2024Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
             }
             EL2024Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
             }
             EL2024Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
             }
             EL2024Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
             }
         }
     }
@@ -53,10 +53,10 @@ impl DigitalOutputDevice<EL2024Port> for EL2024 {
     fn get_output(&self, port: EL2024Port) -> DigitalOutputOutput {
         let expect_text = "All channels should be Some(_)";
         DigitalOutputOutput(match port {
-            EL2024Port::DO1 => self.rxpdo.channel1.as_ref().expect(&expect_text).value,
-            EL2024Port::DO2 => self.rxpdo.channel2.as_ref().expect(&expect_text).value,
-            EL2024Port::DO3 => self.rxpdo.channel3.as_ref().expect(&expect_text).value,
-            EL2024Port::DO4 => self.rxpdo.channel4.as_ref().expect(&expect_text).value,
+            EL2024Port::DO1 => self.rxpdo.channel1.as_ref().expect(expect_text).value,
+            EL2024Port::DO2 => self.rxpdo.channel2.as_ref().expect(expect_text).value,
+            EL2024Port::DO3 => self.rxpdo.channel3.as_ref().expect(expect_text).value,
+            EL2024Port::DO4 => self.rxpdo.channel4.as_ref().expect(expect_text).value,
         })
     }
 }

--- a/ethercat-hal/src/devices/el2521.rs
+++ b/ethercat-hal/src/devices/el2521.rs
@@ -37,7 +37,7 @@ impl NewEthercatDevice for EL2521 {
         let txpdo = configuration.pdo_assignment.txpdo_assignment();
         let rxpdo = configuration.pdo_assignment.rxpdo_assignment();
         Self {
-            configuration: configuration,
+            configuration,
             txpdo,
             rxpdo,
             is_used: false,
@@ -354,7 +354,7 @@ pub enum EL2521PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL2521TxPdo, EL2521RxPdo> for EL2521PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL2521TxPdo {
         match self {
-            EL2521PredefinedPdoAssignment::EnhancedOperatingMode32Bit => EL2521TxPdo {
+            Self::EnhancedOperatingMode32Bit => EL2521TxPdo {
                 pto_status: Some(PtoStatus::default()),
                 enc_status: Some(EncStatus::default()),
             },
@@ -363,7 +363,7 @@ impl PredefinedPdoAssignment<EL2521TxPdo, EL2521RxPdo> for EL2521PredefinedPdoAs
 
     fn rxpdo_assignment(&self) -> EL2521RxPdo {
         match self {
-            EL2521PredefinedPdoAssignment::EnhancedOperatingMode32Bit => EL2521RxPdo {
+            Self::EnhancedOperatingMode32Bit => EL2521RxPdo {
                 pto_control: Some(PtoControl::default()),
                 pto_target: Some(PtoTarget::default()),
                 enc_control: Some(EncControl::default()),

--- a/ethercat-hal/src/devices/el2522.rs
+++ b/ethercat-hal/src/devices/el2522.rs
@@ -37,7 +37,7 @@ impl NewEthercatDevice for EL2522 {
         let txpdo = configuration.pdo_assignment.txpdo_assignment();
         let rxpdo = configuration.pdo_assignment.rxpdo_assignment();
         Self {
-            configuration: configuration,
+            configuration,
             txpdo,
             rxpdo,
             is_used: false,
@@ -104,7 +104,7 @@ impl PulseTrainOutputDevice<EL2522Port> for EL2522 {
 }
 
 impl EL2522 {
-    fn get_txpdo(&self, port: EL2522Port) -> (&PtoStatus, &EncStatus) {
+    const fn get_txpdo(&self, port: EL2522Port) -> (&PtoStatus, &EncStatus) {
         match port {
             EL2522Port::PTO1 => (
                 self.txpdo.pto_status_channel1.as_ref().unwrap(),
@@ -117,7 +117,7 @@ impl EL2522 {
         }
     }
 
-    fn get_rxpdo(&self, port: EL2522Port) -> (&PtoControl, &PtoTarget, &EncControl) {
+    const fn get_rxpdo(&self, port: EL2522Port) -> (&PtoControl, &PtoTarget, &EncControl) {
         match port {
             EL2522Port::PTO1 => (
                 self.rxpdo.pto_control_channel1.as_ref().unwrap(),
@@ -131,7 +131,7 @@ impl EL2522 {
             ),
         }
     }
-    fn get_rxpdo_mut(
+    const fn get_rxpdo_mut(
         &mut self,
         port: EL2522Port,
     ) -> (&mut PtoControl, &mut PtoTarget, &mut EncControl) {
@@ -478,7 +478,7 @@ pub enum EL2522PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL2522TxPdo, EL2522RxPdo> for EL2522PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL2522TxPdo {
         match self {
-            EL2522PredefinedPdoAssignment::Standart32Bit => EL2522TxPdo {
+            Self::Standart32Bit => EL2522TxPdo {
                 pto_status_channel1: Some(PtoStatus::default()),
                 pto_status_channel2: Some(PtoStatus::default()),
                 enc_status_channel1: Some(EncStatus::default()),
@@ -489,7 +489,7 @@ impl PredefinedPdoAssignment<EL2522TxPdo, EL2522RxPdo> for EL2522PredefinedPdoAs
 
     fn rxpdo_assignment(&self) -> EL2522RxPdo {
         match self {
-            EL2522PredefinedPdoAssignment::Standart32Bit => EL2522RxPdo {
+            Self::Standart32Bit => EL2522RxPdo {
                 pto_control_channel1: Some(PtoControl::default()),
                 pto_target_channel1: Some(PtoTarget::default()),
                 enc_control_channel1: Some(EncControl::default()),

--- a/ethercat-hal/src/devices/el2634.rs
+++ b/ethercat-hal/src/devices/el2634.rs
@@ -35,28 +35,20 @@ impl DigitalOutputDevice<EL2634Port> for EL2634 {
     fn set_output(&mut self, port: EL2634Port, value: DigitalOutputOutput) {
         let expect_text = "All channels should be Some(_)";
         match port {
-            EL2634Port::R1 => {
-                self.rxpdo.channel1.as_mut().expect(&expect_text).value = value.into()
-            }
-            EL2634Port::R2 => {
-                self.rxpdo.channel2.as_mut().expect(&expect_text).value = value.into()
-            }
-            EL2634Port::R3 => {
-                self.rxpdo.channel3.as_mut().expect(&expect_text).value = value.into()
-            }
-            EL2634Port::R4 => {
-                self.rxpdo.channel4.as_mut().expect(&expect_text).value = value.into()
-            }
+            EL2634Port::R1 => self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into(),
+            EL2634Port::R2 => self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into(),
+            EL2634Port::R3 => self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into(),
+            EL2634Port::R4 => self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into(),
         }
     }
 
     fn get_output(&self, port: EL2634Port) -> DigitalOutputOutput {
         let expect_text = "All channels should be Some(_)";
         DigitalOutputOutput(match port {
-            EL2634Port::R1 => self.rxpdo.channel1.as_ref().expect(&expect_text).value,
-            EL2634Port::R2 => self.rxpdo.channel2.as_ref().expect(&expect_text).value,
-            EL2634Port::R3 => self.rxpdo.channel3.as_ref().expect(&expect_text).value,
-            EL2634Port::R4 => self.rxpdo.channel4.as_ref().expect(&expect_text).value,
+            EL2634Port::R1 => self.rxpdo.channel1.as_ref().expect(expect_text).value,
+            EL2634Port::R2 => self.rxpdo.channel2.as_ref().expect(expect_text).value,
+            EL2634Port::R3 => self.rxpdo.channel3.as_ref().expect(expect_text).value,
+            EL2634Port::R4 => self.rxpdo.channel4.as_ref().expect(expect_text).value,
         })
     }
 }

--- a/ethercat-hal/src/devices/el2809.rs
+++ b/ethercat-hal/src/devices/el2809.rs
@@ -36,52 +36,52 @@ impl DigitalOutputDevice<EL2809Port> for EL2809 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2809Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO5 => {
-                self.rxpdo.channel5.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO6 => {
-                self.rxpdo.channel6.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO7 => {
-                self.rxpdo.channel7.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO8 => {
-                self.rxpdo.channel8.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO9 => {
-                self.rxpdo.channel9.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel9.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO10 => {
-                self.rxpdo.channel10.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel10.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO11 => {
-                self.rxpdo.channel11.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel11.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO12 => {
-                self.rxpdo.channel12.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel12.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO13 => {
-                self.rxpdo.channel13.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel13.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO14 => {
-                self.rxpdo.channel14.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel14.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO15 => {
-                self.rxpdo.channel15.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel15.as_mut().expect(expect_text).value = value.into()
             }
             EL2809Port::DO16 => {
-                self.rxpdo.channel16.as_mut().expect(&expect_text).value = value.into()
+                self.rxpdo.channel16.as_mut().expect(expect_text).value = value.into()
             }
         }
     }
@@ -89,22 +89,22 @@ impl DigitalOutputDevice<EL2809Port> for EL2809 {
     fn get_output(&self, port: EL2809Port) -> DigitalOutputOutput {
         let expect_text = "All channels should be Some(_)";
         DigitalOutputOutput(match port {
-            EL2809Port::DO1 => self.rxpdo.channel1.as_ref().expect(&expect_text).value,
-            EL2809Port::DO2 => self.rxpdo.channel2.as_ref().expect(&expect_text).value,
-            EL2809Port::DO3 => self.rxpdo.channel3.as_ref().expect(&expect_text).value,
-            EL2809Port::DO4 => self.rxpdo.channel4.as_ref().expect(&expect_text).value,
-            EL2809Port::DO5 => self.rxpdo.channel5.as_ref().expect(&expect_text).value,
-            EL2809Port::DO6 => self.rxpdo.channel6.as_ref().expect(&expect_text).value,
-            EL2809Port::DO7 => self.rxpdo.channel7.as_ref().expect(&expect_text).value,
-            EL2809Port::DO8 => self.rxpdo.channel8.as_ref().expect(&expect_text).value,
-            EL2809Port::DO9 => self.rxpdo.channel9.as_ref().expect(&expect_text).value,
-            EL2809Port::DO10 => self.rxpdo.channel10.as_ref().expect(&expect_text).value,
-            EL2809Port::DO11 => self.rxpdo.channel11.as_ref().expect(&expect_text).value,
-            EL2809Port::DO12 => self.rxpdo.channel12.as_ref().expect(&expect_text).value,
-            EL2809Port::DO13 => self.rxpdo.channel13.as_ref().expect(&expect_text).value,
-            EL2809Port::DO14 => self.rxpdo.channel14.as_ref().expect(&expect_text).value,
-            EL2809Port::DO15 => self.rxpdo.channel15.as_ref().expect(&expect_text).value,
-            EL2809Port::DO16 => self.rxpdo.channel16.as_ref().expect(&expect_text).value,
+            EL2809Port::DO1 => self.rxpdo.channel1.as_ref().expect(expect_text).value,
+            EL2809Port::DO2 => self.rxpdo.channel2.as_ref().expect(expect_text).value,
+            EL2809Port::DO3 => self.rxpdo.channel3.as_ref().expect(expect_text).value,
+            EL2809Port::DO4 => self.rxpdo.channel4.as_ref().expect(expect_text).value,
+            EL2809Port::DO5 => self.rxpdo.channel5.as_ref().expect(expect_text).value,
+            EL2809Port::DO6 => self.rxpdo.channel6.as_ref().expect(expect_text).value,
+            EL2809Port::DO7 => self.rxpdo.channel7.as_ref().expect(expect_text).value,
+            EL2809Port::DO8 => self.rxpdo.channel8.as_ref().expect(expect_text).value,
+            EL2809Port::DO9 => self.rxpdo.channel9.as_ref().expect(expect_text).value,
+            EL2809Port::DO10 => self.rxpdo.channel10.as_ref().expect(expect_text).value,
+            EL2809Port::DO11 => self.rxpdo.channel11.as_ref().expect(expect_text).value,
+            EL2809Port::DO12 => self.rxpdo.channel12.as_ref().expect(expect_text).value,
+            EL2809Port::DO13 => self.rxpdo.channel13.as_ref().expect(expect_text).value,
+            EL2809Port::DO14 => self.rxpdo.channel14.as_ref().expect(expect_text).value,
+            EL2809Port::DO15 => self.rxpdo.channel15.as_ref().expect(expect_text).value,
+            EL2809Port::DO16 => self.rxpdo.channel16.as_ref().expect(expect_text).value,
         })
     }
 }

--- a/ethercat-hal/src/devices/el3001.rs
+++ b/ethercat-hal/src/devices/el3001.rs
@@ -155,11 +155,11 @@ pub enum EL3001PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL3001TxPdo, EL3001RxPdo> for EL3001PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL3001TxPdo {
         match self {
-            EL3001PredefinedPdoAssignment::Standard => EL3001TxPdo {
+            Self::Standard => EL3001TxPdo {
                 ai_standard: Some(AiStandard::default()),
                 ai_compact: None,
             },
-            EL3001PredefinedPdoAssignment::Compact => EL3001TxPdo {
+            Self::Compact => EL3001TxPdo {
                 ai_standard: None,
                 ai_compact: Some(AiCompact::default()),
             },
@@ -168,8 +168,8 @@ impl PredefinedPdoAssignment<EL3001TxPdo, EL3001RxPdo> for EL3001PredefinedPdoAs
 
     fn rxpdo_assignment(&self) -> EL3001RxPdo {
         match self {
-            EL3001PredefinedPdoAssignment::Standard => EL3001RxPdo {},
-            EL3001PredefinedPdoAssignment::Compact => EL3001RxPdo {},
+            Self::Standard => EL3001RxPdo {},
+            Self::Compact => EL3001RxPdo {},
         }
     }
 }

--- a/ethercat-hal/src/devices/el3021.rs
+++ b/ethercat-hal/src/devices/el3021.rs
@@ -175,11 +175,11 @@ pub enum EL3021PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL3021TxPdo, EL3021RxPdo> for EL3021PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL3021TxPdo {
         match self {
-            EL3021PredefinedPdoAssignment::Standard => EL3021TxPdo {
+            Self::Standard => EL3021TxPdo {
                 ai_standard_channel1: Some(AiStandard::default()),
                 ai_compact_channel1: None,
             },
-            EL3021PredefinedPdoAssignment::Compact => EL3021TxPdo {
+            Self::Compact => EL3021TxPdo {
                 ai_standard_channel1: None,
                 ai_compact_channel1: Some(AiCompact::default()),
             },
@@ -188,8 +188,8 @@ impl PredefinedPdoAssignment<EL3021TxPdo, EL3021RxPdo> for EL3021PredefinedPdoAs
 
     fn rxpdo_assignment(&self) -> EL3021RxPdo {
         match self {
-            EL3021PredefinedPdoAssignment::Standard => EL3021RxPdo {},
-            EL3021PredefinedPdoAssignment::Compact => EL3021RxPdo {},
+            Self::Standard => EL3021RxPdo {},
+            Self::Compact => EL3021RxPdo {},
         }
     }
 }

--- a/ethercat-hal/src/devices/el3024.rs
+++ b/ethercat-hal/src/devices/el3024.rs
@@ -246,7 +246,7 @@ pub enum EL3024PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL3024TxPdo, EL3024RxPdo> for EL3024PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL3024TxPdo {
         match self {
-            EL3024PredefinedPdoAssignment::Standard => EL3024TxPdo {
+            Self::Standard => EL3024TxPdo {
                 ai_standard_channel1: Some(AiStandard::default()),
                 ai_compact_channel1: None,
                 ai_standard_channel2: Some(AiStandard::default()),
@@ -256,7 +256,7 @@ impl PredefinedPdoAssignment<EL3024TxPdo, EL3024RxPdo> for EL3024PredefinedPdoAs
                 ai_standard_channel4: Some(AiStandard::default()),
                 ai_compact_channel4: None,
             },
-            EL3024PredefinedPdoAssignment::Compact => EL3024TxPdo {
+            Self::Compact => EL3024TxPdo {
                 ai_standard_channel1: None,
                 ai_compact_channel1: Some(AiCompact::default()),
                 ai_standard_channel2: None,
@@ -271,8 +271,8 @@ impl PredefinedPdoAssignment<EL3024TxPdo, EL3024RxPdo> for EL3024PredefinedPdoAs
 
     fn rxpdo_assignment(&self) -> EL3024RxPdo {
         match self {
-            EL3024PredefinedPdoAssignment::Standard => EL3024RxPdo {},
-            EL3024PredefinedPdoAssignment::Compact => EL3024RxPdo {},
+            Self::Standard => EL3024RxPdo {},
+            Self::Compact => EL3024RxPdo {},
         }
     }
 }

--- a/ethercat-hal/src/devices/el3062_0030.rs
+++ b/ethercat-hal/src/devices/el3062_0030.rs
@@ -185,13 +185,13 @@ impl PredefinedPdoAssignment<EL3062_0030TxPdo, EL3062_0030RxPdo>
 {
     fn txpdo_assignment(&self) -> EL3062_0030TxPdo {
         match self {
-            EL3062_0030PredefinedPdoAssignment::Standard => EL3062_0030TxPdo {
+            Self::Standard => EL3062_0030TxPdo {
                 ai_standard_channel1: Some(AiStandard::default()),
                 ai_compact_channel1: None,
                 ai_standard_channel2: Some(AiStandard::default()),
                 ai_compact_channel2: None,
             },
-            EL3062_0030PredefinedPdoAssignment::Compact => EL3062_0030TxPdo {
+            Self::Compact => EL3062_0030TxPdo {
                 ai_standard_channel1: None,
                 ai_compact_channel1: Some(AiCompact::default()),
                 ai_standard_channel2: None,
@@ -202,8 +202,8 @@ impl PredefinedPdoAssignment<EL3062_0030TxPdo, EL3062_0030RxPdo>
 
     fn rxpdo_assignment(&self) -> EL3062_0030RxPdo {
         match self {
-            EL3062_0030PredefinedPdoAssignment::Standard => EL3062_0030RxPdo {},
-            EL3062_0030PredefinedPdoAssignment::Compact => EL3062_0030RxPdo {},
+            Self::Standard => EL3062_0030RxPdo {},
+            Self::Compact => EL3062_0030RxPdo {},
         }
     }
 }

--- a/ethercat-hal/src/devices/el3204.rs
+++ b/ethercat-hal/src/devices/el3204.rs
@@ -38,10 +38,10 @@ impl TemperatureInputDevice<EL3204Port> for EL3204 {
     fn get_input(&self, port: EL3204Port) -> TemperatureInputInput {
         let expect_text = "All channels should be Some(_)";
         let channel = match port {
-            EL3204Port::T1 => self.txpdo.channel1.as_ref().expect(&expect_text),
-            EL3204Port::T2 => self.txpdo.channel2.as_ref().expect(&expect_text),
-            EL3204Port::T3 => self.txpdo.channel3.as_ref().expect(&expect_text),
-            EL3204Port::T4 => self.txpdo.channel4.as_ref().expect(&expect_text),
+            EL3204Port::T1 => self.txpdo.channel1.as_ref().expect(expect_text),
+            EL3204Port::T2 => self.txpdo.channel2.as_ref().expect(expect_text),
+            EL3204Port::T3 => self.txpdo.channel3.as_ref().expect(expect_text),
+            EL3204Port::T4 => self.txpdo.channel4.as_ref().expect(expect_text),
         };
         TemperatureInputInput {
             temperature: channel.temperature,
@@ -65,12 +65,12 @@ pub enum EL3204Port {
 }
 
 impl EL3204Port {
-    pub fn to_byte_offset(&self) -> usize {
+    pub const fn to_byte_offset(&self) -> usize {
         match self {
-            EL3204Port::T1 => 0,
-            EL3204Port::T2 => 4,
-            EL3204Port::T3 => 8,
-            EL3204Port::T4 => 12,
+            Self::T1 => 0,
+            Self::T2 => 4,
+            Self::T3 => 8,
+            Self::T4 => 12,
         }
     }
 }

--- a/ethercat-hal/src/devices/el4002.rs
+++ b/ethercat-hal/src/devices/el4002.rs
@@ -139,7 +139,7 @@ pub struct EL4002TxPdo {}
 impl PredefinedPdoAssignment<EL4002TxPdo, EL4002RxPdo> for EL4002PredefinedPdoAssignment {
     fn rxpdo_assignment(&self) -> EL4002RxPdo {
         match self {
-            EL4002PredefinedPdoAssignment::Standard => EL4002RxPdo {
+            Self::Standard => EL4002RxPdo {
                 ao_channel1: Some(AnalogOutput::default()),
                 ao_channel2: Some(AnalogOutput::default()),
             },

--- a/ethercat-hal/src/devices/el7031/pdo.rs
+++ b/ethercat-hal/src/devices/el7031/pdo.rs
@@ -81,8 +81,9 @@ pub struct EL7031RxPdo {
     pub pos_control_2: Option<PosControl2>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EL7031PredefinedPdoAssignment {
+    #[default]
     VelocityControlCompact,
     VelocityControlCompactWithInfoData,
     VelocityControl,
@@ -97,7 +98,7 @@ pub enum EL7031PredefinedPdoAssignment {
 impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAssignment {
     fn txpdo_assignment(&self) -> EL7031TxPdo {
         match self {
-            EL7031PredefinedPdoAssignment::VelocityControlCompact => EL7031TxPdo {
+            Self::VelocityControlCompact => EL7031TxPdo {
                 enc_status_compact: Some(EncStatusCompact::default()),
                 enc_status: None,
                 enc_timestamp_compact: None,
@@ -108,7 +109,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::VelocityControlCompactWithInfoData => EL7031TxPdo {
+            Self::VelocityControlCompactWithInfoData => EL7031TxPdo {
                 enc_status_compact: Some(EncStatusCompact::default()),
                 enc_status: None,
                 enc_timestamp_compact: None,
@@ -119,7 +120,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::VelocityControl => EL7031TxPdo {
+            Self::VelocityControl => EL7031TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -130,7 +131,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::PositionControl => EL7031TxPdo {
+            Self::PositionControl => EL7031TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -141,7 +142,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterfaceCompact => EL7031TxPdo {
+            Self::PositionInterfaceCompact => EL7031TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -152,7 +153,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterface => EL7031TxPdo {
+            Self::PositionInterface => EL7031TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -163,7 +164,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterfaceWithInfoData => EL7031TxPdo {
+            Self::PositionInterfaceWithInfoData => EL7031TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -174,7 +175,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterfaceAutoStart => EL7031TxPdo {
+            Self::PositionInterfaceAutoStart => EL7031TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -185,7 +186,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 stm_internal_position: None,
                 stm_external_position: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterfaceAutoStartWithInfoData => EL7031TxPdo {
+            Self::PositionInterfaceAutoStartWithInfoData => EL7031TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -201,18 +202,19 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
 
     fn rxpdo_assignment(&self) -> EL7031RxPdo {
         match self {
-            EL7031PredefinedPdoAssignment::VelocityControlCompact
-            | EL7031PredefinedPdoAssignment::VelocityControlCompactWithInfoData => EL7031RxPdo {
-                enc_control_compact: Some(EncControlCompact::default()),
-                enc_control: None,
-                stm_control: Some(StmControl::default()),
-                stm_position: None,
-                stm_velocity: Some(StmVelocity::default()),
-                pos_control_compact: None,
-                pos_control: None,
-                pos_control_2: None,
-            },
-            EL7031PredefinedPdoAssignment::VelocityControl => EL7031RxPdo {
+            Self::VelocityControlCompact | Self::VelocityControlCompactWithInfoData => {
+                EL7031RxPdo {
+                    enc_control_compact: Some(EncControlCompact::default()),
+                    enc_control: None,
+                    stm_control: Some(StmControl::default()),
+                    stm_position: None,
+                    stm_velocity: Some(StmVelocity::default()),
+                    pos_control_compact: None,
+                    pos_control: None,
+                    pos_control_2: None,
+                }
+            }
+            Self::VelocityControl => EL7031RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -222,7 +224,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 pos_control: None,
                 pos_control_2: None,
             },
-            EL7031PredefinedPdoAssignment::PositionControl => EL7031RxPdo {
+            Self::PositionControl => EL7031RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -232,7 +234,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 pos_control: None,
                 pos_control_2: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterfaceCompact => EL7031RxPdo {
+            Self::PositionInterfaceCompact => EL7031RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -242,8 +244,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 pos_control: None,
                 pos_control_2: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterface
-            | EL7031PredefinedPdoAssignment::PositionInterfaceWithInfoData => EL7031RxPdo {
+            Self::PositionInterface | Self::PositionInterfaceWithInfoData => EL7031RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -253,8 +254,7 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 pos_control: Some(PosControl::default()),
                 pos_control_2: None,
             },
-            EL7031PredefinedPdoAssignment::PositionInterfaceAutoStart
-            | EL7031PredefinedPdoAssignment::PositionInterfaceAutoStartWithInfoData => {
+            Self::PositionInterfaceAutoStart | Self::PositionInterfaceAutoStartWithInfoData => {
                 EL7031RxPdo {
                     enc_control_compact: None,
                     enc_control: Some(EncControl::default()),
@@ -267,12 +267,6 @@ impl PredefinedPdoAssignment<EL7031TxPdo, EL7031RxPdo> for EL7031PredefinedPdoAs
                 }
             }
         }
-    }
-}
-
-impl Default for EL7031PredefinedPdoAssignment {
-    fn default() -> Self {
-        EL7031PredefinedPdoAssignment::VelocityControlCompact
     }
 }
 

--- a/ethercat-hal/src/devices/el7031_0030/coe.rs
+++ b/ethercat-hal/src/devices/el7031_0030/coe.rs
@@ -278,8 +278,9 @@ impl StmFeatures {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EL7031_0030DigitalInputEmulation {
+    #[default]
     Off,
     /// Uin > Limit 1 (threshold)
     Threshold1,
@@ -299,24 +300,18 @@ pub enum EL7031_0030DigitalInputEmulation {
     Hysteresis2,
 }
 
-impl Default for EL7031_0030DigitalInputEmulation {
-    fn default() -> Self {
-        EL7031_0030DigitalInputEmulation::Off
-    }
-}
-
 impl TryFrom<u8> for EL7031_0030DigitalInputEmulation {
     type Error = anyhow::Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(EL7031_0030DigitalInputEmulation::Off),
-            1 => Ok(EL7031_0030DigitalInputEmulation::Threshold1),
-            2 => Ok(EL7031_0030DigitalInputEmulation::Threshold2),
-            3 => Ok(EL7031_0030DigitalInputEmulation::Band1),
-            4 => Ok(EL7031_0030DigitalInputEmulation::Band2),
-            5 => Ok(EL7031_0030DigitalInputEmulation::Hysteresis1),
-            6 => Ok(EL7031_0030DigitalInputEmulation::Hysteresis2),
+            0 => Ok(Self::Off),
+            1 => Ok(Self::Threshold1),
+            2 => Ok(Self::Threshold2),
+            3 => Ok(Self::Band1),
+            4 => Ok(Self::Band2),
+            5 => Ok(Self::Hysteresis1),
+            6 => Ok(Self::Hysteresis2),
             _ => Err(anyhow::anyhow!(
                 "Invalid value for EL7031_0030DigitalInputEmulation: {}",
                 value

--- a/ethercat-hal/src/devices/el7031_0030/pdo.rs
+++ b/ethercat-hal/src/devices/el7031_0030/pdo.rs
@@ -81,11 +81,12 @@ pub struct EL7031_0030RxPdo {
     pub pos_control_2: Option<PosControl2>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EL7031_0030PredefinedPdoAssignment {
     VelocityControlCompact,
     VelocityControlCompactWithInfoData,
     VelocityControl,
+    #[default]
     PositionControl,
     PositionInterfaceCompact,
     PositionInterface,
@@ -99,7 +100,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
 {
     fn txpdo_assignment(&self) -> EL7031_0030TxPdo {
         match self {
-            EL7031_0030PredefinedPdoAssignment::VelocityControlCompact => EL7031_0030TxPdo {
+            Self::VelocityControlCompact => EL7031_0030TxPdo {
                 enc_status_compact: Some(EncStatusCompact::default()),
                 enc_status: None,
                 enc_timestamp_compact: None,
@@ -115,25 +116,23 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 ai_standard_channel_2: Some(AiStandard::default()),
                 ai_compact_channel_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::VelocityControlCompactWithInfoData => {
-                EL7031_0030TxPdo {
-                    enc_status_compact: Some(EncStatusCompact::default()),
-                    enc_status: None,
-                    enc_timestamp_compact: None,
-                    stm_status: Some(StmStatus::default()),
-                    stm_synchron_info_data: Some(StmSynchronInfoData::default()),
-                    pos_status_compact: None,
-                    pos_status: None,
-                    stm_internal_position: None,
-                    stm_external_position: None,
-                    pos_actual_position_lag: None,
-                    ai_standard_channel_1: Some(AiStandard::default()),
-                    ai_compact_channel_1: None,
-                    ai_standard_channel_2: Some(AiStandard::default()),
-                    ai_compact_channel_2: None,
-                }
-            }
-            EL7031_0030PredefinedPdoAssignment::VelocityControl => EL7031_0030TxPdo {
+            Self::VelocityControlCompactWithInfoData => EL7031_0030TxPdo {
+                enc_status_compact: Some(EncStatusCompact::default()),
+                enc_status: None,
+                enc_timestamp_compact: None,
+                stm_status: Some(StmStatus::default()),
+                stm_synchron_info_data: Some(StmSynchronInfoData::default()),
+                pos_status_compact: None,
+                pos_status: None,
+                stm_internal_position: None,
+                stm_external_position: None,
+                pos_actual_position_lag: None,
+                ai_standard_channel_1: Some(AiStandard::default()),
+                ai_compact_channel_1: None,
+                ai_standard_channel_2: Some(AiStandard::default()),
+                ai_compact_channel_2: None,
+            },
+            Self::VelocityControl => EL7031_0030TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -149,7 +148,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 ai_standard_channel_2: Some(AiStandard::default()),
                 ai_compact_channel_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionControl => EL7031_0030TxPdo {
+            Self::PositionControl => EL7031_0030TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -165,7 +164,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 ai_standard_channel_2: Some(AiStandard::default()),
                 ai_compact_channel_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionInterfaceCompact => EL7031_0030TxPdo {
+            Self::PositionInterfaceCompact => EL7031_0030TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -181,7 +180,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 ai_standard_channel_2: Some(AiStandard::default()),
                 ai_compact_channel_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionInterface => EL7031_0030TxPdo {
+            Self::PositionInterface => EL7031_0030TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -197,7 +196,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 ai_standard_channel_2: Some(AiStandard::default()),
                 ai_compact_channel_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionInterfaceWithInfoData => EL7031_0030TxPdo {
+            Self::PositionInterfaceWithInfoData => EL7031_0030TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -213,7 +212,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 ai_standard_channel_2: Some(AiStandard::default()),
                 ai_compact_channel_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionInterfaceAutoStart => EL7031_0030TxPdo {
+            Self::PositionInterfaceAutoStart => EL7031_0030TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -229,31 +228,28 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 ai_standard_channel_2: Some(AiStandard::default()),
                 ai_compact_channel_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionInterfaceAutoStartWithInfoData => {
-                EL7031_0030TxPdo {
-                    enc_status_compact: None,
-                    enc_status: Some(EncStatus::default()),
-                    enc_timestamp_compact: None,
-                    stm_status: Some(StmStatus::default()),
-                    stm_synchron_info_data: Some(StmSynchronInfoData::default()),
-                    pos_status_compact: None,
-                    pos_status: Some(PosStatus::default()),
-                    stm_internal_position: None,
-                    stm_external_position: None,
-                    pos_actual_position_lag: None,
-                    ai_standard_channel_1: Some(AiStandard::default()),
-                    ai_compact_channel_1: None,
-                    ai_standard_channel_2: Some(AiStandard::default()),
-                    ai_compact_channel_2: None,
-                }
-            }
+            Self::PositionInterfaceAutoStartWithInfoData => EL7031_0030TxPdo {
+                enc_status_compact: None,
+                enc_status: Some(EncStatus::default()),
+                enc_timestamp_compact: None,
+                stm_status: Some(StmStatus::default()),
+                stm_synchron_info_data: Some(StmSynchronInfoData::default()),
+                pos_status_compact: None,
+                pos_status: Some(PosStatus::default()),
+                stm_internal_position: None,
+                stm_external_position: None,
+                pos_actual_position_lag: None,
+                ai_standard_channel_1: Some(AiStandard::default()),
+                ai_compact_channel_1: None,
+                ai_standard_channel_2: Some(AiStandard::default()),
+                ai_compact_channel_2: None,
+            },
         }
     }
 
     fn rxpdo_assignment(&self) -> EL7031_0030RxPdo {
         match self {
-            EL7031_0030PredefinedPdoAssignment::VelocityControlCompact
-            | EL7031_0030PredefinedPdoAssignment::VelocityControlCompactWithInfoData => {
+            Self::VelocityControlCompact | Self::VelocityControlCompactWithInfoData => {
                 EL7031_0030RxPdo {
                     enc_control_compact: Some(EncControlCompact::default()),
                     enc_control: None,
@@ -265,7 +261,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                     pos_control_2: None,
                 }
             }
-            EL7031_0030PredefinedPdoAssignment::VelocityControl => EL7031_0030RxPdo {
+            Self::VelocityControl => EL7031_0030RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -275,7 +271,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 pos_control: None,
                 pos_control_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionControl => EL7031_0030RxPdo {
+            Self::PositionControl => EL7031_0030RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -285,7 +281,7 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 pos_control: None,
                 pos_control_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionInterfaceCompact => EL7031_0030RxPdo {
+            Self::PositionInterfaceCompact => EL7031_0030RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -295,21 +291,17 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 pos_control: None,
                 pos_control_2: None,
             },
-            EL7031_0030PredefinedPdoAssignment::PositionInterface
-            | EL7031_0030PredefinedPdoAssignment::PositionInterfaceWithInfoData => {
-                EL7031_0030RxPdo {
-                    enc_control_compact: None,
-                    enc_control: Some(EncControl::default()),
-                    stm_control: Some(StmControl::default()),
-                    stm_position: None,
-                    stm_velocity: None,
-                    pos_control_compact: None,
-                    pos_control: Some(PosControl::default()),
-                    pos_control_2: None,
-                }
-            }
-            EL7031_0030PredefinedPdoAssignment::PositionInterfaceAutoStart
-            | EL7031_0030PredefinedPdoAssignment::PositionInterfaceAutoStartWithInfoData => {
+            Self::PositionInterface | Self::PositionInterfaceWithInfoData => EL7031_0030RxPdo {
+                enc_control_compact: None,
+                enc_control: Some(EncControl::default()),
+                stm_control: Some(StmControl::default()),
+                stm_position: None,
+                stm_velocity: None,
+                pos_control_compact: None,
+                pos_control: Some(PosControl::default()),
+                pos_control_2: None,
+            },
+            Self::PositionInterfaceAutoStart | Self::PositionInterfaceAutoStartWithInfoData => {
                 EL7031_0030RxPdo {
                     enc_control_compact: None,
                     enc_control: Some(EncControl::default()),
@@ -322,12 +314,6 @@ impl PredefinedPdoAssignment<EL7031_0030TxPdo, EL7031_0030RxPdo>
                 }
             }
         }
-    }
-}
-
-impl Default for EL7031_0030PredefinedPdoAssignment {
-    fn default() -> Self {
-        EL7031_0030PredefinedPdoAssignment::PositionControl
     }
 }
 

--- a/ethercat-hal/src/devices/el7041_0052/mod.rs
+++ b/ethercat-hal/src/devices/el7041_0052/mod.rs
@@ -32,7 +32,7 @@ pub struct EL7041_0052 {
 impl NewEthercatDevice for EL7041_0052 {
     fn new() -> Self {
         let configuration = EL7041_0052Configuration::default();
-        EL7041_0052 {
+        Self {
             txpdo: configuration.pdo_assignment.txpdo_assignment(),
             rxpdo: configuration.pdo_assignment.rxpdo_assignment(),
             is_used: false,
@@ -148,12 +148,10 @@ impl StepperVelocityEL70x1Device<EL7041_0052Port> for EL7041_0052 {
                 }
                 Ok(())
             }
-            _ => {
-                return Err(anyhow!(
-                    "Port {:?} is not supported for stepper velocity",
-                    port
-                ));
-            }
+            _ => Err(anyhow!(
+                "Port {:?} is not supported for stepper velocity",
+                port
+            )),
         }
     }
 
@@ -188,12 +186,10 @@ impl StepperVelocityEL70x1Device<EL7041_0052Port> for EL7041_0052 {
                     torque_reduced: stm_status.torque_reduced,
                 })
             }
-            _ => {
-                return Err(anyhow!(
-                    "Port {:?} is not supported for stepper velocity",
-                    port
-                ));
-            }
+            _ => Err(anyhow!(
+                "Port {:?} is not supported for stepper velocity",
+                port
+            )),
         }
     }
 
@@ -229,12 +225,10 @@ impl StepperVelocityEL70x1Device<EL7041_0052Port> for EL7041_0052 {
                     set_counter: self.counter_wrapper.get_override(),
                 })
             }
-            _ => {
-                return Err(anyhow!(
-                    "Port {:?} is not supported for stepper velocity",
-                    port
-                ));
-            }
+            _ => Err(anyhow!(
+                "Port {:?} is not supported for stepper velocity",
+                port
+            )),
         }
     }
 

--- a/ethercat-hal/src/devices/el7041_0052/pdo.rs
+++ b/ethercat-hal/src/devices/el7041_0052/pdo.rs
@@ -68,8 +68,9 @@ pub struct EL7041_0052RxPdo {
     pub pos_control_2: Option<PosControl2>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EL7041_0052PredefinedPdoAssignment {
+    #[default]
     VelocityControlCompact,
     VelocityControlCompactWithInfoData,
     VelocityControl,
@@ -86,7 +87,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
 {
     fn txpdo_assignment(&self) -> EL7041_0052TxPdo {
         match self {
-            EL7041_0052PredefinedPdoAssignment::VelocityControlCompact => EL7041_0052TxPdo {
+            Self::VelocityControlCompact => EL7041_0052TxPdo {
                 enc_status_compact: Some(EncStatusCompact::default()),
                 enc_status: None,
                 enc_timestamp_compact: None,
@@ -98,21 +99,19 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 stm_external_position: None,
                 pos_actual_position_lag: None,
             },
-            EL7041_0052PredefinedPdoAssignment::VelocityControlCompactWithInfoData => {
-                EL7041_0052TxPdo {
-                    enc_status_compact: Some(EncStatusCompact::default()),
-                    enc_status: None,
-                    enc_timestamp_compact: None,
-                    stm_status: Some(StmStatus::default()),
-                    stm_synchron_info_data: Some(StmSynchronInfoData::default()),
-                    pos_status_compact: None,
-                    pos_status: None,
-                    stm_internal_position: None,
-                    stm_external_position: None,
-                    pos_actual_position_lag: None,
-                }
-            }
-            EL7041_0052PredefinedPdoAssignment::VelocityControl => EL7041_0052TxPdo {
+            Self::VelocityControlCompactWithInfoData => EL7041_0052TxPdo {
+                enc_status_compact: Some(EncStatusCompact::default()),
+                enc_status: None,
+                enc_timestamp_compact: None,
+                stm_status: Some(StmStatus::default()),
+                stm_synchron_info_data: Some(StmSynchronInfoData::default()),
+                pos_status_compact: None,
+                pos_status: None,
+                stm_internal_position: None,
+                stm_external_position: None,
+                pos_actual_position_lag: None,
+            },
+            Self::VelocityControl => EL7041_0052TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -124,7 +123,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 stm_external_position: None,
                 pos_actual_position_lag: None,
             },
-            EL7041_0052PredefinedPdoAssignment::PositionControl => EL7041_0052TxPdo {
+            Self::PositionControl => EL7041_0052TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -136,7 +135,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 stm_external_position: None,
                 pos_actual_position_lag: None,
             },
-            EL7041_0052PredefinedPdoAssignment::PositionInterfaceCompact => EL7041_0052TxPdo {
+            Self::PositionInterfaceCompact => EL7041_0052TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -148,7 +147,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 stm_external_position: None,
                 pos_actual_position_lag: None,
             },
-            EL7041_0052PredefinedPdoAssignment::PositionInterface => EL7041_0052TxPdo {
+            Self::PositionInterface => EL7041_0052TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -160,7 +159,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 stm_external_position: None,
                 pos_actual_position_lag: None,
             },
-            EL7041_0052PredefinedPdoAssignment::PositionInterfaceWithInfoData => EL7041_0052TxPdo {
+            Self::PositionInterfaceWithInfoData => EL7041_0052TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -172,7 +171,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 stm_external_position: None,
                 pos_actual_position_lag: None,
             },
-            EL7041_0052PredefinedPdoAssignment::PositionInterfaceAutoStart => EL7041_0052TxPdo {
+            Self::PositionInterfaceAutoStart => EL7041_0052TxPdo {
                 enc_status_compact: None,
                 enc_status: Some(EncStatus::default()),
                 enc_timestamp_compact: None,
@@ -184,27 +183,24 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 stm_external_position: None,
                 pos_actual_position_lag: None,
             },
-            EL7041_0052PredefinedPdoAssignment::PositionInterfaceAutoStartWithInfoData => {
-                EL7041_0052TxPdo {
-                    enc_status_compact: None,
-                    enc_status: Some(EncStatus::default()),
-                    enc_timestamp_compact: None,
-                    stm_status: Some(StmStatus::default()),
-                    stm_synchron_info_data: Some(StmSynchronInfoData::default()),
-                    pos_status_compact: None,
-                    pos_status: Some(PosStatus::default()),
-                    stm_internal_position: None,
-                    stm_external_position: None,
-                    pos_actual_position_lag: None,
-                }
-            }
+            Self::PositionInterfaceAutoStartWithInfoData => EL7041_0052TxPdo {
+                enc_status_compact: None,
+                enc_status: Some(EncStatus::default()),
+                enc_timestamp_compact: None,
+                stm_status: Some(StmStatus::default()),
+                stm_synchron_info_data: Some(StmSynchronInfoData::default()),
+                pos_status_compact: None,
+                pos_status: Some(PosStatus::default()),
+                stm_internal_position: None,
+                stm_external_position: None,
+                pos_actual_position_lag: None,
+            },
         }
     }
 
     fn rxpdo_assignment(&self) -> EL7041_0052RxPdo {
         match self {
-            EL7041_0052PredefinedPdoAssignment::VelocityControlCompact
-            | EL7041_0052PredefinedPdoAssignment::VelocityControlCompactWithInfoData => {
+            Self::VelocityControlCompact | Self::VelocityControlCompactWithInfoData => {
                 EL7041_0052RxPdo {
                     enc_control_compact: Some(EncControlCompact::default()),
                     enc_control: None,
@@ -216,7 +212,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                     pos_control_2: None,
                 }
             }
-            EL7041_0052PredefinedPdoAssignment::VelocityControl => EL7041_0052RxPdo {
+            Self::VelocityControl => EL7041_0052RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -226,7 +222,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 pos_control: None,
                 pos_control_2: Some(PosControl2::default()),
             },
-            EL7041_0052PredefinedPdoAssignment::PositionControl => EL7041_0052RxPdo {
+            Self::PositionControl => EL7041_0052RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -236,7 +232,7 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 pos_control: None,
                 pos_control_2: Some(PosControl2::default()),
             },
-            EL7041_0052PredefinedPdoAssignment::PositionInterfaceCompact => EL7041_0052RxPdo {
+            Self::PositionInterfaceCompact => EL7041_0052RxPdo {
                 enc_control_compact: None,
                 enc_control: Some(EncControl::default()),
                 stm_control: Some(StmControl::default()),
@@ -246,21 +242,17 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 pos_control: None,
                 pos_control_2: Some(PosControl2::default()),
             },
-            EL7041_0052PredefinedPdoAssignment::PositionInterface
-            | EL7041_0052PredefinedPdoAssignment::PositionInterfaceWithInfoData => {
-                EL7041_0052RxPdo {
-                    enc_control_compact: None,
-                    enc_control: Some(EncControl::default()),
-                    stm_control: Some(StmControl::default()),
-                    stm_position: None,
-                    stm_velocity: None,
-                    pos_control_compact: None,
-                    pos_control: Some(PosControl::default()),
-                    pos_control_2: None,
-                }
-            }
-            EL7041_0052PredefinedPdoAssignment::PositionInterfaceAutoStart
-            | EL7041_0052PredefinedPdoAssignment::PositionInterfaceAutoStartWithInfoData => {
+            Self::PositionInterface | Self::PositionInterfaceWithInfoData => EL7041_0052RxPdo {
+                enc_control_compact: None,
+                enc_control: Some(EncControl::default()),
+                stm_control: Some(StmControl::default()),
+                stm_position: None,
+                stm_velocity: None,
+                pos_control_compact: None,
+                pos_control: Some(PosControl::default()),
+                pos_control_2: None,
+            },
+            Self::PositionInterfaceAutoStart | Self::PositionInterfaceAutoStartWithInfoData => {
                 EL7041_0052RxPdo {
                     enc_control_compact: None,
                     enc_control: Some(EncControl::default()),
@@ -273,11 +265,5 @@ impl PredefinedPdoAssignment<EL7041_0052TxPdo, EL7041_0052RxPdo>
                 }
             }
         }
-    }
-}
-
-impl Default for EL7041_0052PredefinedPdoAssignment {
-    fn default() -> Self {
-        EL7041_0052PredefinedPdoAssignment::VelocityControlCompact
     }
 }

--- a/ethercat-hal/src/devices/mod.rs
+++ b/ethercat-hal/src/devices/mod.rs
@@ -262,6 +262,6 @@ pub async fn specific_device_from_devices<DEVICE: EthercatDevice>(
 
 pub type SubDeviceIdentityTuple = (u32, u32, u32);
 /// function that converts SubDeviceIdentity to tuple
-pub fn subdevice_identity_to_tuple(identity: &SubDeviceIdentity) -> SubDeviceIdentityTuple {
+pub const fn subdevice_identity_to_tuple(identity: &SubDeviceIdentity) -> SubDeviceIdentityTuple {
     (identity.vendor_id, identity.product_id, identity.revision)
 }

--- a/ethercat-hal/src/helpers/counter_wrapper_u16_i128.rs
+++ b/ethercat-hal/src/helpers/counter_wrapper_u16_i128.rs
@@ -14,8 +14,14 @@ pub struct CounterWrapperU16U128 {
     set_counter: Option<i128>,
 }
 
+impl Default for CounterWrapperU16U128 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CounterWrapperU16U128 {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             counter: 0,
             last_counter: 0,
@@ -25,7 +31,7 @@ impl CounterWrapperU16U128 {
         }
     }
 
-    pub fn update(&mut self, counter: u16, counter_underflow: bool, counter_overflow: bool) {
+    pub const fn update(&mut self, counter: u16, counter_underflow: bool, counter_overflow: bool) {
         // Only process rising edges of the underflow and overflow flags
         let counter_underflow_rising = counter_underflow && !self.last_counter_underflow;
         let counter_overflow_rising = counter_overflow && !self.last_counter_overflow;
@@ -42,19 +48,19 @@ impl CounterWrapperU16U128 {
         self.last_counter_overflow = counter_overflow;
     }
 
-    pub fn current(&self) -> i128 {
+    pub const fn current(&self) -> i128 {
         self.counter
     }
 
     /// Schedules a counter override
     ///
     /// The value is only set when `pop_set` is called.
-    pub fn push_override(&mut self, new_counter: i128) {
+    pub const fn push_override(&mut self, new_counter: i128) {
         self.set_counter = Some(new_counter);
     }
 
     /// Return the override value as an u16 and overrides the current counter.
-    pub fn pop_override(&mut self) -> Option<u16> {
+    pub const fn pop_override(&mut self) -> Option<u16> {
         match self.set_counter {
             Some(counter) => {
                 // set our coutner to the new value
@@ -73,12 +79,12 @@ impl CounterWrapperU16U128 {
     }
 
     /// Returns the override value as an i128
-    pub fn get_override(&self) -> Option<i128> {
+    pub const fn get_override(&self) -> Option<i128> {
         self.set_counter
     }
 }
 
-fn counter_change(
+const fn counter_change(
     last_counter: u16,
     counter: u16,
     counter_underflow: bool,
@@ -109,15 +115,15 @@ fn counter_change(
     }
 }
 
-fn set_counter_u16_to_i128(new_counter: i128) -> u16 {
+const fn set_counter_u16_to_i128(new_counter: i128) -> u16 {
     // Use modulo arithmetic to handle both positive and negative values
     let modulo = (new_counter % (U16_MAX + 1)) as i32;
 
     if modulo < 0 {
         // If negative, wrap around from the end
-        return (modulo + (U16_MAX + 1) as i32) as u16;
+        (modulo + (U16_MAX + 1) as i32) as u16
     } else {
-        return modulo as u16;
+        modulo as u16
     }
 }
 

--- a/ethercat-hal/src/helpers/el70xx_velocity_converter.rs
+++ b/ethercat-hal/src/helpers/el70xx_velocity_converter.rs
@@ -6,7 +6,7 @@ pub struct EL70x1VelocityConverter {
 }
 
 impl EL70x1VelocityConverter {
-    pub fn new(speed_range: &EL70x1SpeedRange) -> Self {
+    pub const fn new(speed_range: &EL70x1SpeedRange) -> Self {
         let speed_range_value = match speed_range {
             EL70x1SpeedRange::Steps1000 => 1000,
             EL70x1SpeedRange::Steps2000 => 2000,

--- a/ethercat-hal/src/helpers/signing_converter_u16.rs
+++ b/ethercat-hal/src/helpers/signing_converter_u16.rs
@@ -17,19 +17,19 @@ impl U16SigningConverter {
     /// assert_eq!(value.into_unsigned(), 42);
     /// ```
     #[inline]
-    pub fn load_raw(value: u16) -> Self {
+    pub const fn load_raw(value: u16) -> Self {
         Self { raw: value }
     }
 
     /// Converts the value to an unsigned 16-bit integer.
     #[inline]
-    pub fn as_unsigned(self) -> u16 {
+    pub const fn as_unsigned(self) -> u16 {
         self.raw
     }
 
     /// Converts the value to a signed 16-bit integer using two's complement.
     #[inline]
-    pub fn as_signed(self) -> i16 {
+    pub const fn as_signed(self) -> i16 {
         self.raw as i16
     }
 
@@ -38,7 +38,7 @@ impl U16SigningConverter {
     /// In sign-magnitude representation, the most significant bit represents the sign
     /// (0 for positive, 1 for negative) and the remaining bits represent the magnitude.
     #[inline]
-    pub fn as_signed_magnitude(self) -> i16 {
+    pub const fn as_signed_magnitude(self) -> i16 {
         if self.raw & 0x8000 != 0 {
             -((self.raw & 0x7FFF) as i16)
         } else {
@@ -47,7 +47,7 @@ impl U16SigningConverter {
     }
 
     #[inline]
-    pub fn as_absolute(self) -> i16 {
+    pub const fn as_absolute(self) -> i16 {
         self.as_signed().abs()
     }
 }

--- a/ethercat-hal/src/io/analog_input/mod.rs
+++ b/ethercat-hal/src/io/analog_input/mod.rs
@@ -25,7 +25,7 @@ impl fmt::Debug for AnalogInput {
 
 /// Implement on device that have analog inputs
 impl AnalogInput {
-    pub fn new<PORT>(device: Arc<RwLock<dyn AnalogInputDevice<PORT>>>, port: PORT) -> AnalogInput
+    pub fn new<PORT>(device: Arc<RwLock<dyn AnalogInputDevice<PORT>>>, port: PORT) -> Self
     where
         PORT: Clone + Send + Sync + 'static,
     {
@@ -46,7 +46,7 @@ impl AnalogInput {
             })
         });
 
-        AnalogInput { get_input, range }
+        Self { get_input, range }
     }
 
     /// Value from -1.0 to 1.0

--- a/ethercat-hal/src/io/analog_input/physical.rs
+++ b/ethercat-hal/src/io/analog_input/physical.rs
@@ -23,34 +23,34 @@ pub enum AnalogInputRange {
 }
 
 impl AnalogInputRange {
-    pub fn get_min_raw(&self) -> i16 {
-        return match self {
-            AnalogInputRange::Potential { min_raw, .. } => *min_raw,
-            AnalogInputRange::Current { min_raw, .. } => *min_raw,
-        };
+    pub const fn get_min_raw(&self) -> i16 {
+        match self {
+            Self::Potential { min_raw, .. } => *min_raw,
+            Self::Current { min_raw, .. } => *min_raw,
+        }
     }
 
-    pub fn get_max_raw(&self) -> i16 {
-        return match self {
-            AnalogInputRange::Potential { max_raw, .. } => *max_raw,
-            AnalogInputRange::Current { max_raw, .. } => *max_raw,
-        };
+    pub const fn get_max_raw(&self) -> i16 {
+        match self {
+            Self::Potential { max_raw, .. } => *max_raw,
+            Self::Current { max_raw, .. } => *max_raw,
+        }
     }
 
     pub fn raw_to_normalized(&self, raw_value: i16) -> f64 {
         let range = (self.get_max_raw() as i32 - self.get_min_raw() as i32) as f64;
-        return (raw_value as i32 - self.get_min_raw() as i32) as f64 / range;
+        (raw_value as i32 - self.get_min_raw() as i32) as f64 / range
     }
 
     pub fn raw_to_physical(&self, raw_value: i16) -> AnalogInputValue {
         let normalized = self.raw_to_normalized(raw_value);
         match self {
-            AnalogInputRange::Potential { min, max, .. } => {
-                let value = *min + (*max - *min).abs() * normalized as f64;
+            Self::Potential { min, max, .. } => {
+                let value = *min + (*max - *min).abs() * normalized;
                 AnalogInputValue::Potential(value)
             }
-            AnalogInputRange::Current { min, max, .. } => {
-                let value = *min + (*max - *min).abs() * normalized as f64;
+            Self::Current { min, max, .. } => {
+                let value = *min + (*max - *min).abs() * normalized;
                 AnalogInputValue::Current(value)
             }
         }
@@ -59,11 +59,11 @@ impl AnalogInputRange {
     /// Convert a normalized value (0 to 1.0) to a physical value
     pub fn normalized_to_physical(&self, normalized: f32) -> AnalogInputValue {
         match self {
-            AnalogInputRange::Potential { min, max, .. } => {
+            Self::Potential { min, max, .. } => {
                 let value = *min + (*max - *min).abs() * normalized as f64;
                 AnalogInputValue::Potential(value)
             }
-            AnalogInputRange::Current { min, max, .. } => {
+            Self::Current { min, max, .. } => {
                 let value = *min + (*max - *min).abs() * normalized as f64;
                 AnalogInputValue::Current(value)
             }

--- a/ethercat-hal/src/io/analog_input_dummy.rs
+++ b/ethercat-hal/src/io/analog_input_dummy.rs
@@ -35,7 +35,7 @@ impl AnalogInputDummy {
 
     pub fn analog_input(&self) -> AnalogInput {
         let device: Arc<RwLock<dyn AnalogInputDevice<AnalogInputDummyPort>>> =
-            Arc::new(RwLock::new(AnalogInputDummy {
+            Arc::new(RwLock::new(Self {
                 state: self.state.clone(),
                 range: self.range.clone(),
             }));

--- a/ethercat-hal/src/io/analog_output.rs
+++ b/ethercat-hal/src/io/analog_output.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// device and its range.
 pub struct AnalogOutput {
     /// Write a value to the analog output
-    pub set_output: Box<dyn Fn(AnalogOutputOutput) -> () + Send + Sync>,
+    pub set_output: Box<dyn Fn(AnalogOutputOutput) + Send + Sync>,
 
     /// Read the state of the analog output
     pub get_output: Box<dyn Fn() -> AnalogOutputOutput + Send + Sync>,
@@ -23,7 +23,7 @@ impl fmt::Debug for AnalogOutput {
 
 /// Implement on device that have analog outputs
 impl AnalogOutput {
-    pub fn new<PORT>(device: Arc<RwLock<dyn AnalogOutputDevice<PORT>>>, port: PORT) -> AnalogOutput
+    pub fn new<PORT>(device: Arc<RwLock<dyn AnalogOutputDevice<PORT>>>, port: PORT) -> Self
     where
         PORT: Clone + Send + Sync + 'static,
     {
@@ -36,14 +36,14 @@ impl AnalogOutput {
         });
 
         // build sync get closure
-        let port2 = port.clone();
+        let port2 = port;
         let device2 = device.clone();
         let get_output = Box::new(move || -> AnalogOutputOutput {
             let device = block_on(device2.read());
             device.get_output(port2.clone())
         });
 
-        AnalogOutput {
+        Self {
             set_output,
             get_output,
         }
@@ -66,7 +66,7 @@ pub struct AnalogOutputOutput(pub f32);
 
 impl From<f32> for AnalogOutputOutput {
     fn from(value: f32) -> Self {
-        AnalogOutputOutput(value)
+        Self(value)
     }
 }
 

--- a/ethercat-hal/src/io/digital_input.rs
+++ b/ethercat-hal/src/io/digital_input.rs
@@ -19,19 +19,19 @@ impl fmt::Debug for DigitalInput {
 
 /// Implement on device that have digital inputs
 impl DigitalInput {
-    pub fn new<PORT>(device: Arc<RwLock<dyn DigitalInputDevice<PORT>>>, port: PORT) -> DigitalInput
+    pub fn new<PORT>(device: Arc<RwLock<dyn DigitalInputDevice<PORT>>>, port: PORT) -> Self
     where
         PORT: Clone + Send + Sync + 'static,
     {
         // build sync get closure
-        let port2 = port.clone();
+        let port2 = port;
         let device2 = device.clone();
         let get_input = Box::new(move || {
             let device = block_on(device2.read());
             device.get_input(port2.clone())
         });
 
-        DigitalInput { get_input }
+        Self { get_input }
     }
 
     /// Get the current value of the digital input

--- a/ethercat-hal/src/io/pulse_train_output.rs
+++ b/ethercat-hal/src/io/pulse_train_output.rs
@@ -8,7 +8,7 @@ use smol::lock::RwLock;
 /// Generates digital puleses with a given frequency (not PWM) and counts them.
 pub struct PulseTrainOutput {
     /// Write to the pulse train output
-    set_output: Box<dyn Fn(PulseTrainOutputOutput) -> () + Send + Sync>,
+    set_output: Box<dyn Fn(PulseTrainOutputOutput) + Send + Sync>,
     /// Read the state of the pulse train output
     get_output: Box<dyn Fn() -> PulseTrainOutputOutput + Send + Sync>,
     get_input: Box<dyn Fn() -> PulseTrainOutputInput + Send + Sync>,
@@ -21,7 +21,7 @@ impl fmt::Debug for PulseTrainOutput {
 }
 
 impl<'device> PulseTrainOutput {
-    pub fn new<PORT, DEVICE>(device: Arc<RwLock<DEVICE>>, port: PORT) -> PulseTrainOutput
+    pub fn new<PORT, DEVICE>(device: Arc<RwLock<DEVICE>>, port: PORT) -> Self
     where
         PORT: Clone + Copy + Send + Sync + 'static,
         DEVICE: PulseTrainOutputDevice<PORT> + Send + Sync + 'static,
@@ -41,13 +41,13 @@ impl<'device> PulseTrainOutput {
         });
 
         // build sync get closure
-        let device2 = device.clone();
+        let device2 = device;
         let get_input = Box::new(move || -> PulseTrainOutputInput {
             let device = block_on(device2.read());
             device.get_input(port)
         });
 
-        PulseTrainOutput {
+        Self {
             set_output,
             get_output,
             get_input,

--- a/ethercat-hal/src/io/stepper_velocity_el70x1.rs
+++ b/ethercat-hal/src/io/stepper_velocity_el70x1.rs
@@ -28,7 +28,7 @@ impl fmt::Debug for StepperVelocityEL70x1 {
 }
 
 impl<'device> StepperVelocityEL70x1 {
-    pub fn new<PORT, DEVICE>(device: Arc<RwLock<DEVICE>>, port: PORT) -> StepperVelocityEL70x1
+    pub fn new<PORT, DEVICE>(device: Arc<RwLock<DEVICE>>, port: PORT) -> Self
     where
         PORT: Clone + Copy + Send + Sync + 'static,
         DEVICE: StepperVelocityEL70x1Device<PORT> + Send + Sync + 'static,
@@ -62,7 +62,7 @@ impl<'device> StepperVelocityEL70x1 {
         });
 
         // build async get speed range closure
-        let device3 = device.clone();
+        let device3 = device;
         let get_speed_range = Box::new(
             move || -> Result<crate::shared_config::el70x1::EL70x1SpeedRange, Error> {
                 block_on(async {
@@ -72,7 +72,7 @@ impl<'device> StepperVelocityEL70x1 {
             },
         );
 
-        StepperVelocityEL70x1 {
+        Self {
             set_output,
             get_input,
             get_output,

--- a/ethercat-hal/src/io/temperature_input.rs
+++ b/ethercat-hal/src/io/temperature_input.rs
@@ -19,15 +19,12 @@ impl fmt::Debug for TemperatureInput {
 }
 
 impl TemperatureInput {
-    pub fn new<PORTS>(
-        device: Arc<RwLock<dyn TemperatureInputDevice<PORTS>>>,
-        port: PORTS,
-    ) -> TemperatureInput
+    pub fn new<PORTS>(device: Arc<RwLock<dyn TemperatureInputDevice<PORTS>>>, port: PORTS) -> Self
     where
         PORTS: Clone + Send + Sync + 'static,
     {
         // build sync get closure
-        let port2 = port.clone();
+        let port2 = port;
         let device2 = device.clone();
         let get_input = Box::new(move || {
             let device2 = device2.clone();
@@ -37,7 +34,7 @@ impl TemperatureInput {
                 device.get_input(port_clone)
             })
         });
-        TemperatureInput { get_input }
+        Self { get_input }
     }
 
     /// Get the current temperature in degrees Celsius

--- a/ethercat-hal/src/pdo/analog_input.rs
+++ b/ethercat-hal/src/pdo/analog_input.rs
@@ -6,7 +6,7 @@ use super::{TxPdoObject, basic::Limit};
 /// PDO Object for EL30xx devices
 ///
 /// The value is accompanied by some metadata.
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct AiStandard {
     /// The signal voltage is over the defined operating range of the device
@@ -54,7 +54,7 @@ impl TxPdoObject for AiStandard {
 /// PDO Object for EL30xx devices
 ///
 /// The value without metadata.
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct AiCompact {
     /// The 16bit analog value is unsigned here but devices could write signed value with different signing strategies.

--- a/ethercat-hal/src/pdo/basic.rs
+++ b/ethercat-hal/src/pdo/basic.rs
@@ -14,7 +14,7 @@ pub struct BoolPdoObject {
 
 impl TxPdoObject for BoolPdoObject {
     fn read(&mut self, buffer: &BitSlice<u8, Lsb0>) {
-        self.value = buffer[0].into();
+        self.value = buffer[0];
     }
 }
 
@@ -50,8 +50,9 @@ impl RxPdoObject for F32PdoObject {
 /// A u8 is used to map represent 4 states of a configured limit.
 /// The type of limit depends on the device.
 /// The threshhold value is configured via CoE and is commonly deactivated in the base configuration.
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Default)]
 pub enum Limit {
+    #[default]
     NotActive,
     Greater,
     Smaller,
@@ -61,18 +62,12 @@ pub enum Limit {
 impl From<u8> for Limit {
     fn from(value: u8) -> Self {
         match value {
-            0b00 => Limit::NotActive,
-            0b01 => Limit::Greater,
-            0b10 => Limit::Smaller,
-            0b11 => Limit::Equal,
+            0b00 => Self::NotActive,
+            0b01 => Self::Greater,
+            0b10 => Self::Smaller,
+            0b11 => Self::Equal,
             _ => unreachable!(),
         }
-    }
-}
-
-impl Default for Limit {
-    fn default() -> Self {
-        Limit::NotActive
     }
 }
 

--- a/ethercat-hal/src/pdo/el252x.rs
+++ b/ethercat-hal/src/pdo/el252x.rs
@@ -5,7 +5,7 @@ use ethercat_hal_derive::PdoObject;
 /// PDO Object for EL252x devices
 ///
 /// "PTO Status" contains status information about the pulse train output.
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct PtoStatus {
     pub select_end_counter: bool,
@@ -48,7 +48,7 @@ impl TxPdoObject for PtoStatus {
 /// PDO Object for EL252x devices
 ///
 /// "Encoder Status" contains the encoder status information.
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 48)]
 pub struct EncStatus {
     /// Acknowedges the set counter command of the last cycle

--- a/ethercat-hal/src/pdo/el40xx.rs
+++ b/ethercat-hal/src/pdo/el40xx.rs
@@ -6,7 +6,7 @@ use super::RxPdoObject;
 /// PDO Object for EL40xx (analog output) devices
 ///
 /// The "Analog Output" holds the output value and status information.
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct AnalogOutput {
     /// Output value (-32768-32767 typically corresponds to -10 -10V or 0mA-20mA (from 4-20mA for EL402x))

--- a/ethercat-hal/src/pdo/el70x1.rs
+++ b/ethercat-hal/src/pdo/el70x1.rs
@@ -4,7 +4,7 @@ use ethercat_hal_derive::PdoObject;
 
 /// # `EncStatusCompact`
 /// 48 bits / 6 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 48)]
 pub struct EncStatusCompact {
     /// # 6000:01
@@ -78,7 +78,7 @@ impl TxPdoObject for EncStatusCompact {
 
 /// # `EncStatus`
 /// 80 bits / 10 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 80)]
 pub struct EncStatus {
     /// # 6000:01
@@ -151,7 +151,7 @@ impl TxPdoObject for EncStatus {
 
 /// # `EncTimestampCompact`
 /// 32 bits / 4 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct EncTimestampCompact {
     /// # 6000:16
@@ -168,7 +168,7 @@ impl TxPdoObject for EncTimestampCompact {
 
 /// # `EncTimestamp`
 /// 16 bits / 2 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct StmStatus {
     /// # 6010:01
@@ -249,7 +249,7 @@ impl TxPdoObject for StmStatus {
 
 /// # `StmSynchronInfoData`
 /// 32 bits / 4 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct StmSynchronInfoData {
     /// # 6010:11
@@ -272,7 +272,7 @@ impl TxPdoObject for StmSynchronInfoData {
 
 /// # `PosStatusCompact`
 /// 16 bits / 2 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct PosStatusCompact {
     /// # 6020:01
@@ -331,7 +331,7 @@ impl TxPdoObject for PosStatusCompact {
 
 /// # `PosStatus`
 /// 96 bits / 12 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 96)]
 pub struct PosStatus {
     /// # 6020:01
@@ -407,7 +407,7 @@ impl TxPdoObject for PosStatus {
 
 /// # `StmInternalPosition`
 /// 32 bits / 4 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct StmInternalPosition {
     /// # 6010:14
@@ -424,7 +424,7 @@ impl TxPdoObject for StmInternalPosition {
 
 /// # `StmExternalPosition`
 /// 32 bits / 4 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct StmExternalPosition {
     /// # 6010:15
@@ -441,7 +441,7 @@ impl TxPdoObject for StmExternalPosition {
 
 /// # `PosActualPositionLag`
 /// 32 bits / 4 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct PosActualPositionLag {
     /// # 6020:23
@@ -458,7 +458,7 @@ impl TxPdoObject for PosActualPositionLag {
 
 /// # `EncControlCompact`
 /// 32 bits / 4 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct EncControlCompact {
     /// # 7000:01
@@ -496,7 +496,7 @@ impl RxPdoObject for EncControlCompact {
 
 /// # `EncControl`
 /// 48 bits / 6 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 48)]
 pub struct EncControl {
     /// # 7000:01
@@ -535,7 +535,7 @@ impl RxPdoObject for EncControl {
 
 /// # `StmControl`
 /// 16 bits / 2 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct StmControl {
     /// # 7010:01
@@ -564,7 +564,7 @@ impl RxPdoObject for StmControl {
 
 /// # `StmPosition`
 /// 32 bits / 4 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
 pub struct StmPosition {
     /// # 7010:11
@@ -581,7 +581,7 @@ impl RxPdoObject for StmPosition {
 
 /// # `StmVelocity`
 /// 16 bits / 2 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 16)]
 pub struct StmVelocity {
     /// # 7010:21
@@ -598,7 +598,7 @@ impl RxPdoObject for StmVelocity {
 
 /// # `PosControlCompact`
 /// 48 bits / 6 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 48)]
 pub struct PosControlCompact {
     /// # 7020:01
@@ -627,7 +627,7 @@ impl RxPdoObject for PosControlCompact {
 
 /// # `PosControl`
 /// 112 bits / 14 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 112)]
 pub struct PosControl {
     /// # 7020:01
@@ -680,7 +680,7 @@ impl RxPdoObject for PosControl {
 
 /// # `PosControl2`
 /// 112 bits / 14 bytes
-#[derive(Debug, Clone, Default, PdoObject, PartialEq)]
+#[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 112)]
 pub struct PosControl2 {
     /// # 7021:01

--- a/ethercat-hal/src/pdo/mod.rs
+++ b/ethercat-hal/src/pdo/mod.rs
@@ -141,7 +141,7 @@ pub trait RxPdo: Configuration {
             0 => 0,
             _ => 8 - used_bits % 8,
         };
-        return used_bits + padding;
+        used_bits + padding
     }
 
     /// Will give the mutable PDU bit array to the PDO objects to encode the data
@@ -215,7 +215,7 @@ pub trait TxPdo: Configuration {
             0 => 0,
             _ => 8 - used_bits % 8,
         };
-        return used_bits + padding;
+        used_bits + padding
     }
 
     /// Will give the PDU bit array to the PDO objects to decode the data

--- a/ethercat-hal/src/shared_config/el70x1.rs
+++ b/ethercat-hal/src/shared_config/el70x1.rs
@@ -563,21 +563,21 @@ impl TryFrom<u16> for StartType {
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(StartType::Idle),
-            1 => Ok(StartType::Absolute),
-            2 => Ok(StartType::Relative),
-            3 => Ok(StartType::EndlessPlus),
-            4 => Ok(StartType::EndlessMinus),
-            6 => Ok(StartType::Additive),
-            1029 => Ok(StartType::ModuloCurrent),
-            773 => Ok(StartType::ModuloMinus),
-            517 => Ok(StartType::ModuloPlus),
-            261 => Ok(StartType::ModuloShort),
-            24832 => Ok(StartType::CalibrationHardwareSync),
-            24576 => Ok(StartType::CalibrationPlcCam),
-            28416 => Ok(StartType::CalibrationClearManual),
-            28160 => Ok(StartType::CalibrationSetManual),
-            28161 => Ok(StartType::CalibrationSetManualAuto),
+            0 => Ok(Self::Idle),
+            1 => Ok(Self::Absolute),
+            2 => Ok(Self::Relative),
+            3 => Ok(Self::EndlessPlus),
+            4 => Ok(Self::EndlessMinus),
+            6 => Ok(Self::Additive),
+            1029 => Ok(Self::ModuloCurrent),
+            773 => Ok(Self::ModuloMinus),
+            517 => Ok(Self::ModuloPlus),
+            261 => Ok(Self::ModuloShort),
+            24832 => Ok(Self::CalibrationHardwareSync),
+            24576 => Ok(Self::CalibrationPlcCam),
+            28416 => Ok(Self::CalibrationClearManual),
+            28160 => Ok(Self::CalibrationSetManual),
+            28161 => Ok(Self::CalibrationSetManualAuto),
             _ => Err(anyhow::anyhow!("Invalid value for StartType: {}", value)),
         }
     }
@@ -585,7 +585,7 @@ impl TryFrom<u16> for StartType {
 
 impl From<StartType> for u16 {
     fn from(start_type: StartType) -> Self {
-        start_type as u16
+        start_type as Self
     }
 }
 
@@ -723,7 +723,7 @@ impl TryFrom<u8> for EL70x1OperationMode {
 
 impl From<EL70x1OperationMode> for u8 {
     fn from(value: EL70x1OperationMode) -> Self {
-        value as u8
+        value as Self
     }
 }
 
@@ -778,7 +778,7 @@ impl TryFrom<u8> for EL70x1SpeedRange {
 
 impl From<EL70x1SpeedRange> for u8 {
     fn from(value: EL70x1SpeedRange) -> Self {
-        value as u8
+        value as Self
     }
 }
 
@@ -869,7 +869,7 @@ impl TryFrom<u8> for EL70x1InfoData {
 
 impl From<EL70x1InfoData> for u8 {
     fn from(value: EL70x1InfoData) -> Self {
-        value as u8
+        value as Self
     }
 }
 
@@ -916,7 +916,7 @@ impl TryFrom<u8> for EL70x1InputFunction {
 
 impl From<EL70x1InputFunction> for u8 {
     fn from(value: EL70x1InputFunction) -> Self {
-        value as u8
+        value as Self
     }
 }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.86"
 
+[lints]
+workspace = true
+
 
 [dependencies]
 ethercrab = "0.6"

--- a/server/src/app_state.rs
+++ b/server/src/app_state.rs
@@ -66,6 +66,12 @@ impl EthercatSetup {
     }
 }
 
+impl Default for AppState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AppState {
     pub fn new() -> Self {
         let (socket_queue_tx, socket_queue_rx) = smol::channel::unbounded();

--- a/server/src/ethercat/init.rs
+++ b/server/src/ethercat/init.rs
@@ -17,8 +17,8 @@ pub fn init_ethercat(
     thread_panic_tx: Sender<PanicDetails>,
     app_state: Arc<AppState>,
 ) -> Result<(), anyhow::Error> {
-    let thread_panic_tx_clone = thread_panic_tx.clone();
-    let app_state_clone = app_state.clone();
+    let thread_panic_tx_clone = thread_panic_tx;
+    let app_state_clone = app_state;
 
     std::thread::Builder::new()
         .name("init_ethercat".to_string())
@@ -27,7 +27,7 @@ pub fn init_ethercat(
 
             // Notify client via socketio
             let app_state_socketio = app_state_clone.clone();
-            let _ = smol::block_on(async move {
+            smol::block_on(async move {
                 let main_namespace = &mut app_state_socketio
                     .socketio_setup
                     .namespaces
@@ -58,7 +58,7 @@ pub fn init_ethercat(
             // Notify client via socketio
             let interface_clone = interface.clone();
             let app_state_socketio = app_state_clone.clone();
-            let _ = smol::block_on(async move {
+            smol::block_on(async move {
                 let main_namespace = &mut app_state_socketio
                     .socketio_setup
                     .namespaces

--- a/server/src/ethercat/setup.rs
+++ b/server/src/ethercat/setup.rs
@@ -98,7 +98,7 @@ pub async fn setup_loop(
         },
     );
 
-    let _ = smol::block_on({
+    smol::block_on({
         let app_state_clone = app_state.clone();
         async move {
             let main_namespace = &mut app_state_clone
@@ -214,7 +214,7 @@ pub async fn setup_loop(
 
     // Notify client via socketio
     let app_state_clone = app_state.clone();
-    let _ = smol::block_on(async move {
+    smol::block_on(async move {
         let main_namespace = &mut app_state_clone
             .socketio_setup
             .namespaces
@@ -250,7 +250,7 @@ pub async fn setup_loop(
 
     // Notify client via socketio
     let app_state_clone = app_state.clone();
-    let _ = smol::block_on(async move {
+    smol::block_on(async move {
         let main_namespace = &mut app_state_clone
             .socketio_setup
             .namespaces

--- a/server/src/machines/buffer1/api.rs
+++ b/server/src/machines/buffer1/api.rs
@@ -50,14 +50,14 @@ pub struct ModeState {
     pub mode: BufferV1Mode,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum Mode {
     Standby,
     FillingBuffer,
     EmptyingBuffer,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ConnectedMachineState {
     /// Connected Machine
     pub machine_identification_unique: Option<MachineIdentificationUnique>,
@@ -98,11 +98,11 @@ impl Buffer1Namespace {
     }
 }
 
-impl CacheableEvents<BufferV1Events> for BufferV1Events {
+impl CacheableEvents<Self> for BufferV1Events {
     fn event_value(&self) -> GenericEvent {
         match self {
-            BufferV1Events::LiveValues(event) => event.into(),
-            BufferV1Events::State(event) => event.into(),
+            Self::LiveValues(event) => event.into(),
+            Self::State(event) => event.into(),
         }
     }
 
@@ -111,8 +111,8 @@ impl CacheableEvents<BufferV1Events> for BufferV1Events {
         let cache_one = cache_one_event();
 
         match self {
-            BufferV1Events::LiveValues(_) => cache_one_hour,
-            BufferV1Events::State(_) => cache_one,
+            Self::LiveValues(_) => cache_one_hour,
+            Self::State(_) => cache_one,
         }
     }
 }

--- a/server/src/machines/buffer1/buffer_tower_controller.rs
+++ b/server/src/machines/buffer1/buffer_tower_controller.rs
@@ -8,7 +8,7 @@ pub struct BufferTowerController {
 }
 
 impl BufferTowerController {
-    pub fn new(driver: StepperVelocityEL70x1) -> Self {
+    pub const fn new(driver: StepperVelocityEL70x1) -> Self {
         Self {
             enabled: false,
             stepper_driver: driver,

--- a/server/src/machines/buffer1/mod.rs
+++ b/server/src/machines/buffer1/mod.rs
@@ -81,9 +81,7 @@ impl BufferV1 {
             connected_machine_state: ConnectedMachineState {
                 machine_identification_unique: self.connected_winder.as_ref().map(
                     |connected_machine| {
-                        ConnectedMachineData::from(connected_machine)
-                            .machine_identification_unique
-                            .clone()
+                        ConnectedMachineData::from(connected_machine).machine_identification_unique
                     },
                 ),
                 is_available: self
@@ -198,7 +196,7 @@ impl BufferV1 {
 
         self.connected_winder = Some(ConnectedMachine {
             machine_identification_unique,
-            machine: machine.clone(),
+            machine,
         });
 
         self.emit_state();
@@ -250,7 +248,7 @@ impl BufferV1 {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub enum BufferV1Mode {
     Standby,
     FillingBuffer,

--- a/server/src/machines/buffer1/new.rs
+++ b/server/src/machines/buffer1/new.rs
@@ -28,11 +28,7 @@ use super::{BufferV1, api::Buffer1Namespace};
 impl MachineNewTrait for BufferV1 {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
 
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_dublicates(&device_identification)?;
@@ -70,7 +66,7 @@ impl MachineNewTrait for BufferV1 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EK1100_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EK1100>(ethercat_device).await?
@@ -113,7 +109,7 @@ impl MachineNewTrait for BufferV1 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL7041_0052_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL7041_0052>(ethercat_device).await?
@@ -137,7 +133,7 @@ impl MachineNewTrait for BufferV1 {
                 device
                     .write()
                     .await
-                    .write_config(&subdevice, &config)
+                    .write_config(subdevice, &config)
                     .await?;
                 {
                     let mut device_guard = device.write().await;
@@ -171,7 +167,7 @@ impl MachineNewTrait for BufferV1 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL7031_0030_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL7031_0030>(ethercat_device).await?
@@ -199,7 +195,7 @@ impl MachineNewTrait for BufferV1 {
                 device
                     .write()
                     .await
-                    .write_config(&subdevice, &config)
+                    .write_config(subdevice, &config)
                     .await?;
                 {
                     let mut device_guard = device.write().await;
@@ -223,7 +219,7 @@ impl MachineNewTrait for BufferV1 {
                 .clone();
 
             // create buffer instance
-            let mut buffer: BufferV1 = Self {
+            let mut buffer: Self = Self {
                 namespace: Buffer1Namespace::new(params.socket_queue_tx.clone()),
                 last_measurement_emit: Instant::now(),
                 mode: BufferV1Mode::Standby,

--- a/server/src/machines/extruder1/api.rs
+++ b/server/src/machines/extruder1/api.rs
@@ -98,17 +98,17 @@ pub struct StateEvent {
     pub pid_settings: PidSettingsStates,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct RotationState {
     pub forward: bool,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ModeState {
     pub mode: ExtruderV2Mode,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct RegulationState {
     pub uses_rpm: bool,
 }
@@ -144,7 +144,7 @@ pub struct ExtruderSettingsState {
     pub pressure_limit_enabled: bool,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct InverterStatusState {
     /// RUN (Inverter running)
     pub running: bool,
@@ -234,11 +234,11 @@ impl ExtruderV2Namespace {
     }
 }
 
-impl CacheableEvents<ExtruderV2Events> for ExtruderV2Events {
+impl CacheableEvents<Self> for ExtruderV2Events {
     fn event_value(&self) -> GenericEvent {
         match self {
-            ExtruderV2Events::LiveValues(event) => event.into(),
-            ExtruderV2Events::State(event) => event.into(),
+            Self::LiveValues(event) => event.into(),
+            Self::State(event) => event.into(),
         }
     }
 
@@ -247,8 +247,8 @@ impl CacheableEvents<ExtruderV2Events> for ExtruderV2Events {
         let cache_first_and_last = cache_first_and_last_event();
 
         match self {
-            ExtruderV2Events::LiveValues(_) => cache_one_hour,
-            ExtruderV2Events::State(_) => cache_first_and_last,
+            Self::LiveValues(_) => cache_one_hour,
+            Self::State(_) => cache_first_and_last,
         }
     }
 }

--- a/server/src/machines/extruder1/mitsubishi_cs80/mod.rs
+++ b/server/src/machines/extruder1/mitsubishi_cs80/mod.rs
@@ -85,7 +85,7 @@ pub enum MitsubishiCS80Requests {
 
 impl From<MitsubishiCS80Requests> for u32 {
     fn from(request: MitsubishiCS80Requests) -> Self {
-        request as u32
+        request as Self
     }
 }
 

--- a/server/src/machines/extruder1/new.rs
+++ b/server/src/machines/extruder1/new.rs
@@ -43,11 +43,7 @@ use uom::si::{
 impl MachineNewTrait for ExtruderV2 {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
 
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_dublicates(&device_identification)?;
@@ -88,7 +84,7 @@ impl MachineNewTrait for ExtruderV2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EK1100_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EK1100>(ethercat_device).await?
@@ -127,7 +123,7 @@ impl MachineNewTrait for ExtruderV2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL1002_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL1002>(ethercat_device).await?
@@ -167,7 +163,7 @@ impl MachineNewTrait for ExtruderV2 {
                     EL6021_IDENTITY_A | EL6021_IDENTITY_B | EL6021_IDENTITY_C
                     | EL6021_IDENTITY_D => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL6021>(ethercat_device).await?
@@ -182,7 +178,7 @@ impl MachineNewTrait for ExtruderV2 {
                 device
                     .write()
                     .await
-                    .write_config(&subdevice, &EL6021Configuration::default())
+                    .write_config(subdevice, &EL6021Configuration::default())
                     .await?;
                 {
                     let mut device_guard = device.write().await;
@@ -211,7 +207,7 @@ impl MachineNewTrait for ExtruderV2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL2004_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL2004>(ethercat_device).await?
@@ -250,7 +246,7 @@ impl MachineNewTrait for ExtruderV2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL3021_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL3021>(ethercat_device).await?
@@ -289,7 +285,7 @@ impl MachineNewTrait for ExtruderV2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL3204_IDENTITY_A | EL3204_IDENTITY_B => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL3204>(ethercat_device).await?
@@ -311,7 +307,7 @@ impl MachineNewTrait for ExtruderV2 {
             let t1 = TemperatureInput::new(el3204.clone(), EL3204Port::T1);
             let t2 = TemperatureInput::new(el3204.clone(), EL3204Port::T2);
             let t3 = TemperatureInput::new(el3204.clone(), EL3204Port::T3);
-            let t4 = TemperatureInput::new(el3204.clone(), EL3204Port::T4);
+            let t4 = TemperatureInput::new(el3204, EL3204Port::T4);
 
             // For the Relais
             let digital_out_1 = DigitalOutput::new(el2004.clone(), EL2004Port::DO1);
@@ -391,15 +387,15 @@ impl MachineNewTrait for ExtruderV2 {
             let screw_speed_controller =
                 ScrewSpeedController::new(inverter, target_pressure, target_rpm, pressure_sensor);
 
-            let mut extruder: ExtruderV2 = Self {
+            let mut extruder: Self = Self {
                 namespace: ExtruderV2Namespace::new(params.socket_queue_tx.clone()),
                 last_measurement_emit: Instant::now(),
                 mode: ExtruderV2Mode::Standby,
-                temperature_controller_front: temperature_controller_front,
-                temperature_controller_middle: temperature_controller_middle,
-                temperature_controller_back: temperature_controller_back,
-                temperature_controller_nozzle: temperature_controller_nozzle,
-                screw_speed_controller: screw_speed_controller,
+                temperature_controller_front,
+                temperature_controller_middle,
+                temperature_controller_back,
+                temperature_controller_nozzle,
+                screw_speed_controller,
                 emitted_default_state: false,
                 last_state_event: None,
             };

--- a/server/src/machines/extruder1/screw_speed_controller.rs
+++ b/server/src/machines/extruder1/screw_speed_controller.rs
@@ -45,7 +45,7 @@ impl ScrewSpeedController {
     ) -> Self {
         let now = Instant::now();
         Self {
-            inverter: inverter,
+            inverter,
             // need to tune
             pid: ClampingTimeagnosticPidController::simple_new(0.01, 0.0, 0.02),
             last_update: now,
@@ -64,8 +64,8 @@ impl ScrewSpeedController {
         }
     }
 
-    pub fn get_motor_enabled(&mut self) -> bool {
-        return self.motor_on;
+    pub const fn get_motor_enabled(&mut self) -> bool {
+        self.motor_on
     }
 
     pub fn set_nozzle_pressure_limit(&mut self, pressure: Pressure) {
@@ -73,14 +73,14 @@ impl ScrewSpeedController {
     }
 
     pub fn get_nozzle_pressure_limit(&mut self) -> Pressure {
-        return self.nozzle_pressure_limit;
+        self.nozzle_pressure_limit
     }
 
-    pub fn get_nozzle_pressure_limit_enabled(&mut self) -> bool {
-        return self.nozzle_pressure_limit_enabled;
+    pub const fn get_nozzle_pressure_limit_enabled(&mut self) -> bool {
+        self.nozzle_pressure_limit_enabled
     }
 
-    pub fn set_nozzle_pressure_limit_is_enabled(&mut self, enabled: bool) {
+    pub const fn set_nozzle_pressure_limit_is_enabled(&mut self, enabled: bool) {
         self.nozzle_pressure_limit_enabled = enabled;
     }
 
@@ -88,7 +88,7 @@ impl ScrewSpeedController {
         self.target_rpm
     }
 
-    pub fn get_rotation_direction(&mut self) -> bool {
+    pub const fn get_rotation_direction(&mut self) -> bool {
         self.forward_rotation
     }
 
@@ -117,11 +117,11 @@ impl ScrewSpeedController {
         self.inverter.set_frequency_target(target_frequency);
     }
 
-    pub fn get_uses_rpm(&mut self) -> bool {
+    pub const fn get_uses_rpm(&mut self) -> bool {
         self.uses_rpm
     }
 
-    pub fn set_uses_rpm(&mut self, uses_rpm: bool) {
+    pub const fn set_uses_rpm(&mut self, uses_rpm: bool) {
         self.uses_rpm = uses_rpm;
     }
 
@@ -143,10 +143,10 @@ impl ScrewSpeedController {
 
         let screw_rpm = self.transmission.calculate_angular_velocity_output(rpm);
 
-        let mut status = self.inverter.motor_status.clone();
+        let mut status = self.inverter.motor_status;
         status.rpm = screw_rpm;
 
-        return status;
+        status
     }
 
     pub fn get_target_pressure(&self) -> Pressure {
@@ -181,7 +181,7 @@ impl ScrewSpeedController {
         }
     }
 
-    pub fn reset_pid(&mut self) {
+    pub const fn reset_pid(&mut self) {
         self.pid.reset()
     }
 
@@ -197,7 +197,7 @@ impl ScrewSpeedController {
         let normalized = normalize(current, 4.0, 20.0);
         // Our pressure sensor has a range of Up to 350 Bar
         let actual_pressure = (normalized) * 350.0;
-        return Pressure::new::<bar>(actual_pressure);
+        Pressure::new::<bar>(actual_pressure)
     }
 
     pub fn update(&mut self, now: Instant, is_extruding: bool) {
@@ -228,11 +228,11 @@ impl ScrewSpeedController {
             return;
         }
 
-        if is_extruding == true && self.motor_on == false {
+        if is_extruding && !self.motor_on {
             self.turn_motor_on();
         }
 
-        if !self.uses_rpm && is_extruding == true {
+        if !self.uses_rpm && is_extruding {
             let error = self.target_pressure - measured_pressure;
             let freq_change = self.pid.update(error.get::<bar>(), now);
 

--- a/server/src/machines/extruder1/temperature_controller.rs
+++ b/server/src/machines/extruder1/temperature_controller.rs
@@ -45,15 +45,15 @@ impl TemperatureController {
             pid: PidController::new(kp, ki, kd),
             target_temp,
             window_start: Instant::now(),
-            temperature_sensor: temperature_sensor,
-            relais: relais,
-            heating: heating,
+            temperature_sensor,
+            relais,
+            heating,
             heating_allowed: false,
             pwm_period: pwm_duration,
-            max_temperature: max_temperature,
+            max_temperature,
             temperature_pid_output: 0.0,
-            heating_element_wattage: heating_element_wattage,
-            max_clamp: max_clamp,
+            heating_element_wattage,
+            max_clamp,
         }
     }
 
@@ -61,19 +61,19 @@ impl TemperatureController {
         self.heating.target_temperature = temp;
     }
 
-    pub fn disallow_heating(&mut self) {
+    pub const fn disallow_heating(&mut self) {
         self.heating_allowed = false;
     }
 
-    pub fn allow_heating(&mut self) {
+    pub const fn allow_heating(&mut self) {
         self.heating_allowed = true;
     }
 
     pub fn get_heating_element_wattage(&mut self) -> f64 {
-        return self.temperature_pid_output * self.heating_element_wattage;
+        self.temperature_pid_output * self.heating_element_wattage
     }
 
-    pub fn update(&mut self, now: Instant) -> () {
+    pub fn update(&mut self, now: Instant) {
         self.temperature_pid_output = 0.0;
 
         let temperature = self.temperature_sensor.get_temperature();

--- a/server/src/machines/laser/api.rs
+++ b/server/src/machines/laser/api.rs
@@ -70,11 +70,11 @@ impl LaserMachineNamespace {
     }
 }
 
-impl CacheableEvents<LaserEvents> for LaserEvents {
+impl CacheableEvents<Self> for LaserEvents {
     fn event_value(&self) -> GenericEvent {
         match self {
-            LaserEvents::LiveValues(event) => event.into(),
-            LaserEvents::State(event) => event.into(),
+            Self::LiveValues(event) => event.into(),
+            Self::State(event) => event.into(),
         }
     }
 
@@ -83,8 +83,8 @@ impl CacheableEvents<LaserEvents> for LaserEvents {
         let cache_first_and_last = cache_first_and_last_event();
 
         match self {
-            LaserEvents::LiveValues(_) => cache_one_hour,
-            LaserEvents::State(_) => cache_first_and_last,
+            Self::LiveValues(_) => cache_one_hour,
+            Self::State(_) => cache_first_and_last,
         }
     }
 }

--- a/server/src/machines/laser/new.rs
+++ b/server/src/machines/laser/new.rs
@@ -8,16 +8,8 @@ use control_core::machines::new::MachineNewTrait;
 use uom::si::{f64::Length, length::millimeter};
 
 impl MachineNewTrait for LaserMachine {
-    fn new<'maindevice, 'subdevices>(
-        params: &control_core::machines::new::MachineNewParams<
-            'maindevice,
-            'subdevices,
-            '_,
-            '_,
-            '_,
-            '_,
-            '_,
-        >,
+    fn new(
+        params: &control_core::machines::new::MachineNewParams<'_, '_, '_, '_, '_, '_, '_>,
     ) -> Result<Self, Error>
     where
         Self: Sized,

--- a/server/src/machines/mock/api.rs
+++ b/server/src/machines/mock/api.rs
@@ -17,7 +17,7 @@ use socketioxide::extract::SocketRef;
 use std::{sync::Arc, time::Duration};
 use tracing::instrument;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum Mode {
     Standby,
     Running,
@@ -48,7 +48,7 @@ pub struct StateEvent {
     pub mode_state: ModeState,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ModeState {
     /// current mode
     pub mode: Mode,
@@ -72,11 +72,11 @@ impl MockMachineNamespace {
     }
 }
 
-impl CacheableEvents<MockEvents> for MockEvents {
+impl CacheableEvents<Self> for MockEvents {
     fn event_value(&self) -> GenericEvent {
         match self {
-            MockEvents::LiveValues(event) => event.into(),
-            MockEvents::State(event) => event.into(),
+            Self::LiveValues(event) => event.into(),
+            Self::State(event) => event.into(),
         }
     }
 
@@ -85,8 +85,8 @@ impl CacheableEvents<MockEvents> for MockEvents {
         let cache_first_and_last = cache_first_and_last_event();
 
         match self {
-            MockEvents::LiveValues(_) => cache_one_hour,
-            MockEvents::State(_) => cache_first_and_last,
+            Self::LiveValues(_) => cache_one_hour,
+            Self::State(_) => cache_first_and_last,
         }
     }
 }

--- a/server/src/machines/mock/mod.rs
+++ b/server/src/machines/mock/mod.rs
@@ -143,7 +143,7 @@ impl MockMachine {
     }
 
     /// Set the mode of the mock machine
-    pub fn set_mode(&mut self, mode: Mode) {
+    pub const fn set_mode(&mut self, mode: Mode) {
         self.mode = mode;
     }
 }

--- a/server/src/machines/mock/new.rs
+++ b/server/src/machines/mock/new.rs
@@ -9,16 +9,8 @@ use control_core::machines::new::{MachineNewHardware, MachineNewTrait};
 use uom::si::{f64::Frequency, frequency::hertz};
 
 impl MachineNewTrait for MockMachine {
-    fn new<'maindevice, 'subdevices>(
-        params: &control_core::machines::new::MachineNewParams<
-            'maindevice,
-            'subdevices,
-            '_,
-            '_,
-            '_,
-            '_,
-            '_,
-        >,
+    fn new(
+        params: &control_core::machines::new::MachineNewParams<'_, '_, '_, '_, '_, '_, '_>,
     ) -> Result<Self, Error>
     where
         Self: Sized,

--- a/server/src/machines/winder2/adaptive_spool_speed_controller.rs
+++ b/server/src/machines/winder2/adaptive_spool_speed_controller.rs
@@ -56,6 +56,12 @@ pub struct AdaptiveSpoolSpeedController {
     deacceleration_urgency_multiplier: f64,
 }
 
+impl Default for AdaptiveSpoolSpeedController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AdaptiveSpoolSpeedController {
     /// Maximum speed limit (in RPM) used to initialize the acceleration controller
     const INITIAL_MAX_SPEED_RPM: f64 = 150.0;
@@ -202,13 +208,12 @@ impl AdaptiveSpoolSpeedController {
         self.update_radius(filament_tension, t);
 
         // Calculate speed based on inverted tension (lower tension = higher speed)
-        let speed = AngularVelocity::new::<radian_per_second>(scale(
+
+        AngularVelocity::new::<radian_per_second>(scale(
             1.0 - filament_tension,
             min_speed.get::<radian_per_second>(),
             max_speed.get::<radian_per_second>(),
-        ));
-
-        speed
+        ))
     }
 
     /// Simplified urgency-weighted acceleration that adapts to current operating conditions.
@@ -361,7 +366,7 @@ impl AdaptiveSpoolSpeedController {
     ///
     /// # Parameters
     /// - `enabled`: True to enable speed control, false to disable
-    pub fn set_enabled(&mut self, enabled: bool) {
+    pub const fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
     }
 
@@ -369,7 +374,7 @@ impl AdaptiveSpoolSpeedController {
     ///
     /// # Returns
     /// True if the controller is enabled, false if disabled
-    pub fn is_enabled(&self) -> bool {
+    pub const fn is_enabled(&self) -> bool {
         self.enabled
     }
 
@@ -379,7 +384,7 @@ impl AdaptiveSpoolSpeedController {
     /// process changes that would invalidate learned parameters.
     pub fn reset(&mut self) {
         self.last_speed = AngularVelocity::ZERO;
-        let _ = self.acceleration_controller.reset(AngularVelocity::ZERO);
+        self.acceleration_controller.reset(AngularVelocity::ZERO);
         self.radius = Length::new::<centimeter>(4.25);
         self.last_max_speed_factor_update = None;
         self.tension_target = Self::TENSION_TARGET;
@@ -406,7 +411,7 @@ impl AdaptiveSpoolSpeedController {
     /// - `speed`: The angular velocity to set as the current speed
     pub fn set_speed(&mut self, speed: AngularVelocity) {
         self.last_speed = speed;
-        let _ = self.acceleration_controller.reset(speed);
+        self.acceleration_controller.reset(speed);
     }
 
     pub fn get_radius(&self) -> Length {
@@ -414,43 +419,43 @@ impl AdaptiveSpoolSpeedController {
     }
 
     // Getters and setters for the new configurable parameters
-    pub fn get_tension_target(&self) -> f64 {
+    pub const fn get_tension_target(&self) -> f64 {
         self.tension_target
     }
 
-    pub fn set_tension_target(&mut self, tension_target: f64) {
+    pub const fn set_tension_target(&mut self, tension_target: f64) {
         self.tension_target = tension_target.clamp(0.0, 1.0);
     }
 
-    pub fn get_radius_learning_rate(&self) -> f64 {
+    pub const fn get_radius_learning_rate(&self) -> f64 {
         self.radius_learning_rate
     }
 
-    pub fn set_radius_learning_rate(&mut self, radius_learning_rate: f64) {
+    pub const fn set_radius_learning_rate(&mut self, radius_learning_rate: f64) {
         self.radius_learning_rate = radius_learning_rate.max(0.0);
     }
 
-    pub fn get_max_speed_multiplier(&self) -> f64 {
+    pub const fn get_max_speed_multiplier(&self) -> f64 {
         self.max_speed_multiplier
     }
 
-    pub fn set_max_speed_multiplier(&mut self, max_speed_multiplier: f64) {
+    pub const fn set_max_speed_multiplier(&mut self, max_speed_multiplier: f64) {
         self.max_speed_multiplier = max_speed_multiplier.max(0.1);
     }
 
-    pub fn get_acceleration_factor(&self) -> f64 {
+    pub const fn get_acceleration_factor(&self) -> f64 {
         self.acceleration_factor
     }
 
-    pub fn set_acceleration_factor(&mut self, acceleration_factor: f64) {
+    pub const fn set_acceleration_factor(&mut self, acceleration_factor: f64) {
         self.acceleration_factor = acceleration_factor.clamp(0.01, 1.0);
     }
 
-    pub fn get_deacceleration_urgency_multiplier(&self) -> f64 {
+    pub const fn get_deacceleration_urgency_multiplier(&self) -> f64 {
         self.deacceleration_urgency_multiplier
     }
 
-    pub fn set_deacceleration_urgency_multiplier(
+    pub const fn set_deacceleration_urgency_multiplier(
         &mut self,
         deacceleration_urgency_multiplier: f64,
     ) {

--- a/server/src/machines/winder2/api.rs
+++ b/server/src/machines/winder2/api.rs
@@ -32,10 +32,10 @@ pub enum Mode {
 impl From<Winder2Mode> for Mode {
     fn from(mode: Winder2Mode) -> Self {
         match mode {
-            Winder2Mode::Standby => Mode::Standby,
-            Winder2Mode::Hold => Mode::Hold,
-            Winder2Mode::Pull => Mode::Pull,
-            Winder2Mode::Wind => Mode::Wind,
+            Winder2Mode::Standby => Self::Standby,
+            Winder2Mode::Hold => Self::Hold,
+            Winder2Mode::Pull => Self::Pull,
+            Winder2Mode::Wind => Self::Wind,
         }
     }
 }
@@ -43,10 +43,10 @@ impl From<Winder2Mode> for Mode {
 impl From<Mode> for Winder2Mode {
     fn from(mode: Mode) -> Self {
         match mode {
-            Mode::Standby => Winder2Mode::Standby,
-            Mode::Hold => Winder2Mode::Hold,
-            Mode::Pull => Winder2Mode::Pull,
-            Mode::Wind => Winder2Mode::Wind,
+            Mode::Standby => Self::Standby,
+            Mode::Hold => Self::Hold,
+            Mode::Pull => Self::Pull,
+            Mode::Wind => Self::Wind,
         }
     }
 }
@@ -273,11 +273,11 @@ impl Winder2Namespace {
     }
 }
 
-impl CacheableEvents<Winder2Events> for Winder2Events {
+impl CacheableEvents<Self> for Winder2Events {
     fn event_value(&self) -> GenericEvent {
         match self {
-            Winder2Events::LiveValues(event) => event.into(),
-            Winder2Events::State(event) => event.into(),
+            Self::LiveValues(event) => event.into(),
+            Self::State(event) => event.into(),
         }
     }
 
@@ -286,8 +286,8 @@ impl CacheableEvents<Winder2Events> for Winder2Events {
         let cache_first_and_last = cache_first_and_last_event();
 
         match self {
-            Winder2Events::LiveValues(_) => cache_one_hour,
-            Winder2Events::State(_) => cache_first_and_last,
+            Self::LiveValues(_) => cache_one_hour,
+            Self::State(_) => cache_first_and_last,
         }
     }
 }

--- a/server/src/machines/winder2/clamp_revolution.rs
+++ b/server/src/machines/winder2/clamp_revolution.rs
@@ -1,6 +1,6 @@
 use uom::si::{angle::revolution, f64::Angle};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Clamping {
     None,
     Min,
@@ -79,9 +79,8 @@ pub fn scale_revolution_to_range(value: f64, min: f64, max: f64) -> f64 {
     let distance = revolution_distance(min, max);
 
     // we scale the value to the distance
-    let normalized = (value - min) / distance;
 
-    return normalized;
+    (value - min) / distance
 }
 
 /// Clamps a revolution value to be within the specified range [min, max].
@@ -144,7 +143,7 @@ pub fn clamp_revolution(value: f64, min: f64, max: f64) -> (f64, Clamping) {
     // at this point our input value should be either retured (cause in spec) or clamped to min or max
     // so this point should never be reached
     // in case it does we just clamp to min
-    return (min, Clamping::Min);
+    (min, Clamping::Min)
 }
 
 /// Calculates the clamping ranges for min and max values in a circular context.
@@ -282,13 +281,13 @@ fn revolution_in_range(value: f64, min: f64, max: f64) -> bool {
         if value >= min || value <= max {
             return true;
         }
-        return false;
+        false
     } else {
         // check if value is in range for non-crossing ranges
         if value >= min && value <= max {
             return true;
         }
-        return false;
+        false
     }
 }
 
@@ -755,27 +754,27 @@ mod tests {
     #[test]
     fn test_revolution_in_range() {
         // in range (corrected from 0.5 to 0.05)
-        assert_eq!(revolution_in_range(0.05, 0.0, 0.1), true);
+        assert!(revolution_in_range(0.05, 0.0, 0.1));
         // over range
-        assert_eq!(revolution_in_range(0.15, 0.0, 0.1), false);
+        assert!(!revolution_in_range(0.15, 0.0, 0.1));
         // under range
-        assert_eq!(revolution_in_range(0.05, 0.1, 0.2), false);
+        assert!(!revolution_in_range(0.05, 0.1, 0.2));
         // cross 0 in range
-        assert_eq!(revolution_in_range(0.0, 0.97, 0.03), true);
+        assert!(revolution_in_range(0.0, 0.97, 0.03));
         // cross 0 over range
-        assert_eq!(revolution_in_range(0.06, 0.97, 0.03), false);
+        assert!(!revolution_in_range(0.06, 0.97, 0.03));
         // cross 0 under range
-        assert_eq!(revolution_in_range(0.94, 0.97, 0.03), false);
+        assert!(!revolution_in_range(0.94, 0.97, 0.03));
 
         // Boundary values
-        assert_eq!(revolution_in_range(0.0, 0.0, 0.1), true); // value equals min
-        assert_eq!(revolution_in_range(0.1, 0.0, 0.1), true); // value equals max
-        assert_eq!(revolution_in_range(0.97, 0.97, 0.03), true); // value equals min in cross-zero
-        assert_eq!(revolution_in_range(0.03, 0.97, 0.03), true); // value equals max in cross-zero
+        assert!(revolution_in_range(0.0, 0.0, 0.1)); // value equals min
+        assert!(revolution_in_range(0.1, 0.0, 0.1)); // value equals max
+        assert!(revolution_in_range(0.97, 0.97, 0.03)); // value equals min in cross-zero
+        assert!(revolution_in_range(0.03, 0.97, 0.03)); // value equals max in cross-zero
 
         // Edge cases
-        assert_eq!(revolution_in_range(0.05, 0.05, 0.05), true); // min equals max equals value
-        assert_eq!(revolution_in_range(0.06, 0.05, 0.05), false); // min equals max but not equal to value
-        assert_eq!(revolution_in_range(0.5, 0.003, 0.997), true); // almost full circle
+        assert!(revolution_in_range(0.05, 0.05, 0.05)); // min equals max equals value
+        assert!(!revolution_in_range(0.06, 0.05, 0.05)); // min equals max but not equal to value
+        assert!(revolution_in_range(0.5, 0.003, 0.997)); // almost full circle
     }
 }

--- a/server/src/machines/winder2/filament_tension.rs
+++ b/server/src/machines/winder2/filament_tension.rs
@@ -11,6 +11,7 @@ use uom::{
 };
 
 /// The "tension" of the filament is not linear regarding the angle of the tension arm since it moves in an angular motion.
+///
 /// With this calculator we can calculate the filament length and tension based on the angle of the tension arm using geometry.
 ///
 /// ⠉⠢⢄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇ 0.0
@@ -81,8 +82,10 @@ impl FilamentTensionCalculator {
 
         // Calculate tension arm tip position (flipped Y-axis: 0° = down, 90° = left)
         let tension_arm_tip = Point2D::<f64, ()>::new(
-            self.tension_arm_origin.x + self.arm_length * tension_arm_angle_rad.sin(),
-            self.tension_arm_origin.y + self.arm_length * tension_arm_angle_rad.cos(),
+            self.arm_length
+                .mul_add(tension_arm_angle_rad.sin(), self.tension_arm_origin.x),
+            self.arm_length
+                .mul_add(tension_arm_angle_rad.cos(), self.tension_arm_origin.y),
         );
 
         // translate the tip 2cm down to account for the wheel diameter

--- a/server/src/machines/winder2/minmax_spool_speed_controller.rs
+++ b/server/src/machines/winder2/minmax_spool_speed_controller.rs
@@ -42,6 +42,12 @@ pub struct MinMaxSpoolSpeedController {
     speed_time_window: MovingTimeWindow<f64>,
 }
 
+impl Default for MinMaxSpoolSpeedController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MinMaxSpoolSpeedController {
     /// Parameters:
     /// - `min_speed`: Minimum speed
@@ -134,14 +140,13 @@ impl MinMaxSpoolSpeedController {
         let filament_tension_exponential = interpolate_exponential(filament_tension_inverted, 2.0);
 
         // interpolate speed linear
-        let speed = AngularVelocity::new::<radian_per_second>(scale(
+
+        // save speed
+        AngularVelocity::new::<radian_per_second>(scale(
             filament_tension_exponential,
             min_speed.get::<radian_per_second>(),
             max_speed.get::<radian_per_second>(),
-        ));
-
-        // save speed
-        return speed;
+        ))
     }
 
     /// Accelerates the speed using the acceleration controller.
@@ -175,7 +180,7 @@ impl MinMaxSpoolSpeedController {
         self.speed_time_window
             .update(new_speed.get::<radian_per_second>(), t);
 
-        return new_speed;
+        new_speed
     }
 
     /// Clamps the speed to the defined minimum and maximum speed.
@@ -190,11 +195,11 @@ impl MinMaxSpoolSpeedController {
         let max_speed = self.max_speed();
 
         if speed < min_speed {
-            return AngularVelocity::ZERO;
+            AngularVelocity::ZERO
         } else if speed > max_speed {
-            return max_speed;
+            max_speed
         } else {
-            return speed;
+            speed
         }
     }
 }
@@ -214,17 +219,17 @@ impl MinMaxSpoolSpeedController {
         self.clamp_speed(speed)
     }
 
-    pub fn set_enabled(&mut self, enabled: bool) {
+    pub const fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
     }
 
-    pub fn is_enabled(&self) -> bool {
+    pub const fn is_enabled(&self) -> bool {
         self.enabled
     }
 
     pub fn reset(&mut self) {
         self.last_speed = AngularVelocity::ZERO;
-        let _ = self.acceleration_controller.reset(AngularVelocity::ZERO);
+        self.acceleration_controller.reset(AngularVelocity::ZERO);
     }
 
     fn update_acceleration(&mut self) -> Result<(), MotionControllerError> {
@@ -276,7 +281,7 @@ impl MinMaxSpoolSpeedController {
     pub fn set_speed(&mut self, speed: AngularVelocity) {
         self.last_speed = speed;
         // Also update the acceleration controller's current speed to ensure smooth transitions
-        let _ = self.acceleration_controller.reset(speed);
+        self.acceleration_controller.reset(speed);
     }
 
     /// derive the radius from the puller speed and the current angular speed

--- a/server/src/machines/winder2/mod.rs
+++ b/server/src/machines/winder2/mod.rs
@@ -319,9 +319,7 @@ impl Winder2 {
             connected_machine_state: ConnectedMachineState {
                 machine_identification_unique: self.connected_buffer.as_ref().map(
                     |connected_machine| {
-                        ConnectedMachineData::from(connected_machine)
-                            .machine_identification_unique
-                            .clone()
+                        ConnectedMachineData::from(connected_machine).machine_identification_unique
                     },
                 ),
                 is_available: self
@@ -346,7 +344,7 @@ impl Winder2 {
             }
         };
 
-        let should_emit = check_hash_different(&new_state, &old_state);
+        let should_emit = check_hash_different(&new_state, old_state);
         if should_emit {
             let event = &new_state.build();
             self.last_state_event = Some(new_state);
@@ -371,7 +369,7 @@ impl Winder2 {
     }
 
     /// Can wind capability check
-    pub fn can_wind(&self) -> bool {
+    pub const fn can_wind(&self) -> bool {
         // Check if tension arm is zeroed and traverse is homed
         self.tension_arm.zeroed
             && self.traverse_controller.is_homed()
@@ -633,12 +631,15 @@ impl Winder2 {
         self.spool_automatic_action.target_length = Length::new::<meter>(meters);
     }
 
-    pub fn set_spool_automatic_mode(&mut self, mode: SpoolAutomaticActionMode) {
+    pub const fn set_spool_automatic_mode(&mut self, mode: SpoolAutomaticActionMode) {
         self.spool_automatic_action.mode = mode;
     }
 
     pub fn stop_or_pull_spool(&mut self, now: Instant) {
-        if let SpoolAutomaticActionMode::NoAction = self.spool_automatic_action.mode {
+        if matches!(
+            self.spool_automatic_action.mode,
+            SpoolAutomaticActionMode::NoAction
+        ) {
             self.calculate_spool_auto_progress_(now);
             return;
         }
@@ -667,7 +668,7 @@ impl Winder2 {
         }
     }
 
-    pub fn stop_or_pull_spool_reset(&mut self, now: Instant) {
+    pub const fn stop_or_pull_spool_reset(&mut self, now: Instant) {
         self.spool_automatic_action.progress = Length::ZERO;
         self.spool_automatic_action.progress_last_check = now;
     }
@@ -704,7 +705,7 @@ impl Winder2 {
         let _ = self.puller.set_speed(steps_per_second);
     }
 
-    pub fn puller_set_regulation(&mut self, puller_regulation_mode: PullerRegulationMode) {
+    pub const fn puller_set_regulation(&mut self, puller_regulation_mode: PullerRegulationMode) {
         self.puller_speed_controller
             .set_regulation_mode(puller_regulation_mode);
     }
@@ -725,7 +726,7 @@ impl Winder2 {
     }
 
     /// Set forward direction
-    pub fn puller_set_forward(&mut self, forward: bool) {
+    pub const fn puller_set_forward(&mut self, forward: bool) {
         self.puller_speed_controller.set_forward(forward);
     }
 
@@ -754,31 +755,31 @@ impl Winder2 {
     }
 
     /// Set tension target for adaptive mode (0.0-1.0)
-    pub fn spool_set_adaptive_tension_target(&mut self, tension_target: f64) {
+    pub const fn spool_set_adaptive_tension_target(&mut self, tension_target: f64) {
         self.spool_speed_controller
             .set_adaptive_tension_target(tension_target);
     }
 
     /// Set radius learning rate for adaptive mode
-    pub fn spool_set_adaptive_radius_learning_rate(&mut self, radius_learning_rate: f64) {
+    pub const fn spool_set_adaptive_radius_learning_rate(&mut self, radius_learning_rate: f64) {
         self.spool_speed_controller
             .set_adaptive_radius_learning_rate(radius_learning_rate);
     }
 
     /// Set max speed multiplier for adaptive mode
-    pub fn spool_set_adaptive_max_speed_multiplier(&mut self, max_speed_multiplier: f64) {
+    pub const fn spool_set_adaptive_max_speed_multiplier(&mut self, max_speed_multiplier: f64) {
         self.spool_speed_controller
             .set_adaptive_max_speed_multiplier(max_speed_multiplier);
     }
 
     /// Set acceleration factor for adaptive mode
-    pub fn spool_set_adaptive_acceleration_factor(&mut self, acceleration_factor: f64) {
+    pub const fn spool_set_adaptive_acceleration_factor(&mut self, acceleration_factor: f64) {
         self.spool_speed_controller
             .set_adaptive_acceleration_factor(acceleration_factor);
     }
 
     /// Set deacceleration urgency multiplier for adaptive mode
-    pub fn spool_set_adaptive_deacceleration_urgency_multiplier(
+    pub const fn spool_set_adaptive_deacceleration_urgency_multiplier(
         &mut self,
         deacceleration_urgency_multiplier: f64,
     ) {
@@ -822,7 +823,7 @@ impl Winder2 {
 
         self.connected_buffer = Some(ConnectedMachine {
             machine_identification_unique,
-            machine: machine.clone(),
+            machine,
         });
 
         self.reverse_connect();
@@ -871,7 +872,7 @@ impl Winder2 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Winder2Mode {
     Standby,
     Hold,
@@ -879,7 +880,7 @@ pub enum Winder2Mode {
     Wind,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SpoolMode {
     Standby,
     Hold,
@@ -889,15 +890,15 @@ pub enum SpoolMode {
 impl From<Winder2Mode> for SpoolMode {
     fn from(mode: Winder2Mode) -> Self {
         match mode {
-            Winder2Mode::Standby => SpoolMode::Standby,
-            Winder2Mode::Hold => SpoolMode::Hold,
-            Winder2Mode::Pull => SpoolMode::Hold,
-            Winder2Mode::Wind => SpoolMode::Wind,
+            Winder2Mode::Standby => Self::Standby,
+            Winder2Mode::Hold => Self::Hold,
+            Winder2Mode::Pull => Self::Hold,
+            Winder2Mode::Wind => Self::Wind,
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TraverseMode {
     Standby,
     Hold,
@@ -907,15 +908,15 @@ pub enum TraverseMode {
 impl From<Winder2Mode> for TraverseMode {
     fn from(mode: Winder2Mode) -> Self {
         match mode {
-            Winder2Mode::Standby => TraverseMode::Standby,
-            Winder2Mode::Hold => TraverseMode::Hold,
-            Winder2Mode::Pull => TraverseMode::Hold,
-            Winder2Mode::Wind => TraverseMode::Traverse,
+            Winder2Mode::Standby => Self::Standby,
+            Winder2Mode::Hold => Self::Hold,
+            Winder2Mode::Pull => Self::Hold,
+            Winder2Mode::Wind => Self::Traverse,
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PullerMode {
     Standby,
     Hold,
@@ -925,10 +926,10 @@ pub enum PullerMode {
 impl From<Winder2Mode> for PullerMode {
     fn from(mode: Winder2Mode) -> Self {
         match mode {
-            Winder2Mode::Standby => PullerMode::Standby,
-            Winder2Mode::Hold => PullerMode::Hold,
-            Winder2Mode::Pull => PullerMode::Pull,
-            Winder2Mode::Wind => PullerMode::Pull,
+            Winder2Mode::Standby => Self::Standby,
+            Winder2Mode::Hold => Self::Hold,
+            Winder2Mode::Pull => Self::Pull,
+            Winder2Mode::Wind => Self::Pull,
         }
     }
 }

--- a/server/src/machines/winder2/new.rs
+++ b/server/src/machines/winder2/new.rs
@@ -46,11 +46,7 @@ use uom::si::length::{centimeter, meter, millimeter};
 impl MachineNewTrait for Winder2 {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
 
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_dublicates(&device_identification)?;
@@ -91,7 +87,7 @@ impl MachineNewTrait for Winder2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EK1100_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EK1100>(ethercat_device).await?
@@ -131,7 +127,7 @@ impl MachineNewTrait for Winder2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL2002_IDENTITY_A | EL2002_IDENTITY_B => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL2002>(ethercat_device).await?
@@ -173,7 +169,7 @@ impl MachineNewTrait for Winder2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL7041_0052_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL7041_0052>(ethercat_device).await?
@@ -197,7 +193,7 @@ impl MachineNewTrait for Winder2 {
                 device
                     .write()
                     .await
-                    .write_config(&subdevice, &config)
+                    .write_config(subdevice, &config)
                     .await?;
                 {
                     let mut device_guard = device.write().await;
@@ -231,7 +227,7 @@ impl MachineNewTrait for Winder2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL7031_IDENTITY_A | EL7031_IDENTITY_B => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL7031>(ethercat_device).await?
@@ -260,7 +256,7 @@ impl MachineNewTrait for Winder2 {
                 device
                     .write()
                     .await
-                    .write_config(&subdevice, &config)
+                    .write_config(subdevice, &config)
                     .await?;
                 {
                     let mut device_guard = device.write().await;
@@ -294,7 +290,7 @@ impl MachineNewTrait for Winder2 {
                 let device = match subdevice_identity_to_tuple(&subdevice_identity) {
                     EL7031_0030_IDENTITY_A => {
                         let ethercat_device = get_ethercat_device_by_index(
-                            &hardware.ethercat_devices,
+                            hardware.ethercat_devices,
                             subdevice_index,
                         )?;
                         downcast_device::<EL7031_0030>(ethercat_device).await?
@@ -322,7 +318,7 @@ impl MachineNewTrait for Winder2 {
                 device
                     .write()
                     .await
-                    .write_config(&subdevice, &config)
+                    .write_config(subdevice, &config)
                     .await?;
                 {
                     let mut device_guard = device.write().await;

--- a/server/src/machines/winder2/puller_speed_controller.rs
+++ b/server/src/machines/winder2/puller_speed_controller.rs
@@ -55,7 +55,7 @@ impl PullerSpeedController {
         }
     }
 
-    pub fn set_enabled(&mut self, enabled: bool) {
+    pub const fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
     }
 
@@ -67,11 +67,11 @@ impl PullerSpeedController {
         self.target_diameter = target;
     }
 
-    pub fn set_regulation_mode(&mut self, regulation: PullerRegulationMode) {
+    pub const fn set_regulation_mode(&mut self, regulation: PullerRegulationMode) {
         self.regulation_mode = regulation;
     }
 
-    pub fn set_forward(&mut self, forward: bool) {
+    pub const fn set_forward(&mut self, forward: bool) {
         self.forward = forward;
     }
 

--- a/server/src/machines/winder2/spool_speed_controller.rs
+++ b/server/src/machines/winder2/spool_speed_controller.rs
@@ -30,6 +30,12 @@ pub struct SpoolSpeedController {
     radius_history: MovingTimeWindow<f64>,
 }
 
+impl Default for SpoolSpeedController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SpoolSpeedController {
     pub fn new() -> Self {
         Self {
@@ -54,12 +60,12 @@ impl SpoolSpeedController {
         }
     }
 
-    pub fn set_enabled(&mut self, enabled: bool) {
+    pub const fn set_enabled(&mut self, enabled: bool) {
         self.adaptive_controller.set_enabled(enabled);
         self.minmax_controller.set_enabled(enabled);
     }
 
-    pub fn is_enabled(&self) -> bool {
+    pub const fn is_enabled(&self) -> bool {
         match self.r#type {
             SpoolSpeedControllerType::Adaptive => self.adaptive_controller.is_enabled(),
             SpoolSpeedControllerType::MinMax => self.minmax_controller.is_enabled(),
@@ -93,7 +99,7 @@ impl SpoolSpeedController {
         self.r#type = r#type;
     }
 
-    pub fn get_type(&self) -> &SpoolSpeedControllerType {
+    pub const fn get_type(&self) -> &SpoolSpeedControllerType {
         &self.r#type
     }
 
@@ -154,47 +160,47 @@ impl SpoolSpeedController {
     }
 
     // Adaptive controller parameter getters and setters
-    pub fn get_adaptive_tension_target(&self) -> f64 {
+    pub const fn get_adaptive_tension_target(&self) -> f64 {
         self.adaptive_controller.get_tension_target()
     }
 
-    pub fn set_adaptive_tension_target(&mut self, tension_target: f64) {
+    pub const fn set_adaptive_tension_target(&mut self, tension_target: f64) {
         self.adaptive_controller.set_tension_target(tension_target);
     }
 
-    pub fn get_adaptive_radius_learning_rate(&self) -> f64 {
+    pub const fn get_adaptive_radius_learning_rate(&self) -> f64 {
         self.adaptive_controller.get_radius_learning_rate()
     }
 
-    pub fn set_adaptive_radius_learning_rate(&mut self, radius_learning_rate: f64) {
+    pub const fn set_adaptive_radius_learning_rate(&mut self, radius_learning_rate: f64) {
         self.adaptive_controller
             .set_radius_learning_rate(radius_learning_rate);
     }
 
-    pub fn get_adaptive_max_speed_multiplier(&self) -> f64 {
+    pub const fn get_adaptive_max_speed_multiplier(&self) -> f64 {
         self.adaptive_controller.get_max_speed_multiplier()
     }
 
-    pub fn set_adaptive_max_speed_multiplier(&mut self, max_speed_multiplier: f64) {
+    pub const fn set_adaptive_max_speed_multiplier(&mut self, max_speed_multiplier: f64) {
         self.adaptive_controller
             .set_max_speed_multiplier(max_speed_multiplier);
     }
 
-    pub fn get_adaptive_acceleration_factor(&self) -> f64 {
+    pub const fn get_adaptive_acceleration_factor(&self) -> f64 {
         self.adaptive_controller.get_acceleration_factor()
     }
 
-    pub fn set_adaptive_acceleration_factor(&mut self, acceleration_factor: f64) {
+    pub const fn set_adaptive_acceleration_factor(&mut self, acceleration_factor: f64) {
         self.adaptive_controller
             .set_acceleration_factor(acceleration_factor);
     }
 
-    pub fn get_adaptive_deacceleration_urgency_multiplier(&self) -> f64 {
+    pub const fn get_adaptive_deacceleration_urgency_multiplier(&self) -> f64 {
         self.adaptive_controller
             .get_deacceleration_urgency_multiplier()
     }
 
-    pub fn set_adaptive_deacceleration_urgency_multiplier(
+    pub const fn set_adaptive_deacceleration_urgency_multiplier(
         &mut self,
         deacceleration_urgency_multiplier: f64,
     ) {

--- a/server/src/machines/winder2/tension_arm.rs
+++ b/server/src/machines/winder2/tension_arm.rs
@@ -28,12 +28,10 @@ impl TensionArm {
         // get the normalized value from the analog input
         let value = self.analog_input.get_physical();
 
-        let volts = match value {
+        match value {
             AnalogInputValue::Potential(v) => v.get::<volt>(),
             _ => panic!("Expected a potential value"),
-        };
-
-        volts
+        }
     }
 
     fn raw_angle(&self) -> Angle {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -65,8 +65,8 @@ fn main() {
     let init_thread = std::thread::Builder::new()
         .name("init".to_string())
         .spawn({
-            let thread_panic_tx = thread_panic_tx.clone();
-            let app_state = app_state.clone();
+            let thread_panic_tx = thread_panic_tx;
+            let app_state = app_state;
             move || {
                 #[cfg(feature = "dhat-heap")]
                 init_dhat_heap_profiling();
@@ -85,7 +85,7 @@ fn main() {
                     .expect("Failed to initialize Serial");
 
                 #[cfg(not(feature = "mock-machine"))]
-                init_ethercat(thread_panic_tx.clone(), app_state.clone())
+                init_ethercat(thread_panic_tx.clone(), app_state)
                     .expect("Failed to initialize EtherCAT");
             }
         })

--- a/server/src/performance_metrics.rs
+++ b/server/src/performance_metrics.rs
@@ -14,6 +14,12 @@ pub struct EthercatPerformanceMetrics {
     last_log_time: Instant,
 }
 
+impl Default for EthercatPerformanceMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EthercatPerformanceMetrics {
     /// Creates a new metrics collector
     pub fn new() -> Self {
@@ -132,7 +138,7 @@ fn calculate_stats(durations: &VecDeque<Duration>) -> MetricsStats {
     let stddev_us = variance.sqrt();
 
     // Calculate 99.99th percentile
-    let mut sorted_values = values_us.clone();
+    let mut sorted_values = values_us;
     sorted_values.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let percentile_index = ((count * 0.9999) as usize).min(sorted_values.len() - 1);
     let percentile_9999_us = sorted_values[percentile_index];

--- a/server/src/rest/handlers/machine_mutation.rs
+++ b/server/src/rest/handlers/machine_mutation.rs
@@ -60,12 +60,12 @@ async fn _post_machine_mutate(
     let mut machine_guard = machine.lock().await;
 
     // write data to machine
-    machine_guard.api_mutate(body.data).or_else(|e| {
-        Err(anyhow::anyhow!(
+    machine_guard.api_mutate(body.data).map_err(|e| {
+        anyhow::anyhow!(
             "[{}::_post_machine_mutate] Machine api_mutate error: {}",
             module_path!(),
             e
-        ))
+        )
     })?;
 
     Ok(())

--- a/server/src/rest/util.rs
+++ b/server/src/rest/util.rs
@@ -30,7 +30,7 @@ impl ResponseUtil {
             Ok(json) => json,
             Err(e) => {
                 tracing::error!("Failed to serialize response data: {}", e);
-                return ResponseUtil::error("Failed to serialize response data");
+                return Self::error("Failed to serialize response data");
             }
         };
 
@@ -46,7 +46,7 @@ impl ResponseUtil {
             Ok(json) => json,
             Err(e) => {
                 tracing::error!("Failed to serialize not found message: {}", e);
-                return ResponseUtil::error("Failed to serialize not found message");
+                return Self::error("Failed to serialize not found message");
             }
         };
         Response::builder()

--- a/server/src/serial/init.rs
+++ b/server/src/serial/init.rs
@@ -10,7 +10,7 @@ pub fn init_serial(
     thread_panic_tx: Sender<PanicDetails>,
     app_state: Arc<AppState>,
 ) -> Result<(), anyhow::Error> {
-    let thread_panic_tx_clone = thread_panic_tx.clone();
+    let thread_panic_tx_clone = thread_panic_tx;
 
     let app_state_clone = app_state.clone();
 
@@ -61,7 +61,7 @@ pub fn init_serial(
 
                             // Notify client via socketio
                             let app_state_event = app_state.clone();
-                            let _ = smol::block_on(async {
+                            smol::block_on(async {
                                 let main_namespace = &mut app_state_event
                                     .socketio_setup
                                     .namespaces

--- a/server/src/socketio/init.rs
+++ b/server/src/socketio/init.rs
@@ -40,7 +40,7 @@ pub async fn init_socketio(app_state: &Arc<AppState>) -> SocketIoLayer {
     let mut socketio_guard = app_state.socketio_setup.socketio.write().await;
     socketio_guard.replace(io);
 
-    return socketio_layer;
+    socketio_layer
 }
 
 fn handle_socket_connection(socket: SocketRef, app_state: Arc<AppState>) {
@@ -101,7 +101,7 @@ fn setup_connection(socket: SocketRef, namespace_id: NamespaceId, app_state: Arc
     // Spawn async task to avoid blocking and potential deadlocks
     let socket_clone = socket.clone();
     let namespace_id_clone = namespace_id.clone();
-    let app_state_clone = app_state.clone();
+    let app_state_clone = app_state;
 
     let span = info_span!(
         "socketio_connection",
@@ -125,7 +125,7 @@ fn setup_connection(socket: SocketRef, namespace_id: NamespaceId, app_state: Arc
                                 namespace_interface.subscribe(socket_clone.clone());
 
                                 // Then re-emit cached events
-                                namespace_interface.reemit(socket_clone.clone());
+                                namespace_interface.reemit(socket_clone);
                             }
                             Err(err) => {
                                 tracing::warn!(

--- a/server/src/socketio/main_namespace/ethercat_devices_event.rs
+++ b/server/src/socketio/main_namespace/ethercat_devices_event.rs
@@ -34,7 +34,7 @@ impl DeviceObj {
         subdevice: &SubDeviceRef<'_, SubDevicePdi<'_, PDI_LEN>>,
         device_identification: DeviceIdentification,
     ) -> Self {
-        DeviceObj {
+        Self {
             name: subdevice.name().to_string(),
             configured_address: subdevice.configured_address(),
             product_id: subdevice.identity().product_id,

--- a/server/src/socketio/main_namespace/mod.rs
+++ b/server/src/socketio/main_namespace/mod.rs
@@ -46,20 +46,20 @@ pub enum MainNamespaceEvents {
     EthercatInterfaceDiscoveryEvent(Event<EthercatInterfaceDiscoveryEvent>),
 }
 
-impl CacheableEvents<MainNamespaceEvents> for MainNamespaceEvents {
+impl CacheableEvents<Self> for MainNamespaceEvents {
     fn event_value(&self) -> GenericEvent {
         match self {
-            MainNamespaceEvents::EthercatDevicesEvent(event) => event.into(),
-            MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(event) => event.into(),
-            MainNamespaceEvents::MachinesEvent(event) => event.into(),
+            Self::EthercatDevicesEvent(event) => event.into(),
+            Self::EthercatInterfaceDiscoveryEvent(event) => event.into(),
+            Self::MachinesEvent(event) => event.into(),
         }
     }
 
     fn event_cache_fn(&self) -> CacheFn {
         match self {
-            MainNamespaceEvents::EthercatDevicesEvent(_) => cache_one_event(),
-            MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(_) => cache_one_event(),
-            MainNamespaceEvents::MachinesEvent(_) => cache_one_event(),
+            Self::EthercatDevicesEvent(_) => cache_one_event(),
+            Self::EthercatInterfaceDiscoveryEvent(_) => cache_one_event(),
+            Self::MachinesEvent(_) => cache_one_event(),
         }
     }
 }


### PR DESCRIPTION
I configured the `/Cargo.toml` to warn about clippy lints.

The package `Cargo.toml`s now reference the lints configured in `/Cargo.tml`

I also ran `cargo clippy --fix` to auto-fix some lints.