### PR TITLE
Read git information during build instead of addign new commit via installInfo.nix

### DIFF
--- a/cargo_run_linux.sh
+++ b/cargo_run_linux.sh
@@ -24,7 +24,7 @@ if [ "$1" != "mock-machine" ]; then
     sudo setcap 'cap_net_raw,cap_sys_nice=eip' ./target/debug/server
 
     echo "Setting permissions for serial ports"
-    sudo chown "root:$USER" /dev/ttyUSB*
+    sudo chown "root:$(groups | cut -f1 -d' ')" /dev/ttyUSB*
 fi
 
 # run

--- a/nixos-install.sh
+++ b/nixos-install.sh
@@ -1,53 +1,39 @@
-# write the installInfo.nix while
-# we capture information about the current git commit
-sudo touch ./nixos/os/installInfo.nix
+#!/bin/sh
+
+set -euo pipefail
 
 # Capture all git information
-GIT_TIMESTAMP=$(git --no-pager show -s --format=%cI HEAD)  # e.g., "2025-06-10T14:30:45+02:00"
-GIT_COMMIT=$(git rev-parse HEAD)                           # e.g., "b2c7f6e0b138174770798f84ada8b0aa65afeb"
-GIT_URL=$(git config --get remote.origin.url)             # e.g., "https://github.com/qitechindustries/control.git"
+export GIT_TIMESTAMP=$(git --no-pager show -s --format=%cI HEAD)  # e.g., "2025-06-10T14:30:45+02:00"
+export GIT_COMMIT=$(git rev-parse HEAD)                           # e.g., "b2c7f6e0b138174770798f84ada8b0aa65afeb"
+export GIT_URL=$(git config --get remote.origin.url)             # e.g., "https://github.com/qitechindustries/control.git"
 
 # Determine the git abbreviation (tag, branch, or commit hash)
-GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+export GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
 if [ -n "$GIT_TAG" ]; then
-  GIT_ABBREVIATION="$GIT_TAG"                              # e.g., "2.0.0" (when on a tag)
+  export GIT_ABBREVIATION="$GIT_TAG"                              # e.g., "2.0.0" (when on a tag)
 else
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
   if [ "$GIT_BRANCH" = "HEAD" ]; then
-    GIT_ABBREVIATION=$(git rev-parse --short HEAD)         # e.g., "b2c7f6e" (when on detached HEAD/commit)
+    export GIT_ABBREVIATION=$(git rev-parse --short HEAD)         # e.g., "b2c7f6e" (when on detached HEAD/commit)
   else
-    GIT_ABBREVIATION="$GIT_BRANCH"                         # e.g., "main", "develop" (when on a branch)
+    export GIT_ABBREVIATION="$GIT_BRANCH"                         # e.g., "main", "develop" (when on a branch)
   fi
 fi
 
 # Create escaped version for system.nixos.label
-GIT_ABBREVIATION_ESCAPED=$(echo "$GIT_ABBREVIATION" | sed -e 's/+/-/g' -e 's/[^a-zA-Z0-9:_\.-]//g')  # e.g., "2-0-0", "main", "b2c7f6e"
+export GIT_ABBREVIATION_ESCAPED=$(echo "$GIT_ABBREVIATION" | sed -e 's/+/-/g' -e 's/[^a-zA-Z0-9:_\.-]//g')  # e.g., "2-0-0", "main", "b2c7f6e"
 
-sudo tee ./nixos/os/installInfo.nix > /dev/null << EOF
-{
-  gitTimestamp = "$GIT_TIMESTAMP";
-  gitCommit = "$GIT_COMMIT";
-  gitAbbreviation = "$GIT_ABBREVIATION";
-  gitUrl = "$GIT_URL";
-  # Like abbreviation but can be used in system.nixos.label
-  gitAbbreviationEscaped = "$GIT_ABBREVIATION_ESCAPED";
-}
-EOF
+sudo \
+    --preserve-env=GIT_TIMESTAMP \
+    --preserve-env=GIT_COMMIT \
+    --preserve-env=GIT_URL \
+    --preserve-env=GIT_ABBREVIATION \
+    --preserve-env=GIT_ABBREVIATION_ESCAPED \
+    nixos-rebuild boot \
+    	--flake .#nixos \
+    	--show-trace \
+    	--impure \
+    	--option sandbox false \
+    	--option eval-cache false
 
-# make sure the installInfo.nix file is tracked by git
-# otherwise it will be ignored by nix
-# configure a git user
-git config --global user.name "nixos-install.sh"
-git config --global user.email "nixos-install.sh@localhost"
-# add the installInfo.nix file to the git index
-git add ./nixos/os/installInfo.nix
-# commit the changes
-git commit -m "Add installInfo.nix file with current commit information"
-# Now we can install the system
-
-# Now we install the new system
-if sudo nixos-rebuild boot --flake .#nixos --show-trace --impure --option sandbox false --option eval-cache false; then
-  reboot
-else
-  exit 1
-fi
+sudo reboot

--- a/nixos/gitInfo.nix
+++ b/nixos/gitInfo.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+
+let
+  # Generate Git info in the store
+  gitInfoDerivation = pkgs.runCommand "git-info" {} ''
+    gitTimestamp="${builtins.getEnv "GIT_TIMESTAMP"}"
+    gitCommit="${builtins.getEnv "GIT_COMMIT"}"
+    gitUrl="${builtins.getEnv "GIT_URL"}"
+    gitAbbreviation="${builtins.getEnv "GIT_ABBREVIATION"}"
+    gitAbbreviationEscaped="${builtins.getEnv "GIT_ABBREVIATION_ESCAPED"}"
+
+    mkdir -p $out
+
+    cat <<EOF > $out/git-info.json
+      {
+        "gitTimestamp": "$gitTimestamp",
+        "gitCommit": "$gitCommit",
+        "gitAbbreviation": "$gitAbbreviation",
+        "gitUrl": "$gitUrl",
+        "gitAbbreviationEscaped": "$gitAbbreviationEscaped"
+      }
+    EOF
+  '';
+in
+  builtins.fromJSON (builtins.readFile "${gitInfoDerivation}/git-info.json")

--- a/nixos/os/configuration.nix
+++ b/nixos/os/configuration.nix
@@ -1,9 +1,8 @@
-# Edit this configuration file to define what should be installed on
-# your system.  Help is available in the configuration.nix(5) man page
-# and in the NixOS manual (accessible by running ‘nixos-help’).
+{ config, pkgs, ... }:
 
-{ config, pkgs, installInfo, ... }:
-
+let
+  gitInfo = import ../gitInfo.nix { inherit pkgs; };
+in
 {
   imports =
     [ # Include the results of the hardware scan.
@@ -20,13 +19,12 @@
   boot.kernelPackages = pkgs.linuxPackages-rt_latest;
   boot.kernelModules = [ "i915" ];
 
-
   boot.kernelParams = [
     # Graphical
     "logo.nologo" # Remove kernel logo during boot
 
-    # Performance 
-    
+    # Performance
+
     # Specific Vulnerabilities Addressed by Mitigations:
     # - Spectre variants (V1, V2, V4, SWAPGS, SpectreRSB, etc.)
     # - Meltdown (Rogue Data Cache Load)
@@ -36,7 +34,7 @@
     # - TSX Asynchronous Abort (TAA)
     # - iTLB Multihit
     # - And others as they're discovered and mitigated
-    # 
+    #
     # With mitigations=off
     # - PROS: Maximum performance, equivalent to pre-2018 behavior
     # - CONS: Vulnerable to Spectre, Meltdown, Foreshadow, ZombieLoad, etc.
@@ -48,7 +46,7 @@
     # Memory Management
     "transparent_hugepage=always" # Use larger memory pages for memory intense applications
     "nmi_watchdog=0"              # Disable NMI watchdog for reduced CPU overhead and realtime execution
-    
+
     # High-throughput ethernet parameters
     "pcie_aspm=off"         # Disable PCIe power management for NICs
     "intel_iommu=off"       # Disable IOMMU (performance gain)
@@ -144,7 +142,7 @@
     autoSuspend = false;
     wayland = true;
   };
-  
+
   services.xserver.desktopManager.gnome.enable = true;
 
   # Disable sleep/suspend
@@ -217,7 +215,7 @@
     enable = true;
     openFirewall = true;
     user = "qitech-service";
-    group = "qitech-service"; 
+    group = "qitech-service";
     package = pkgs.qitechPackages.server;
   };
 
@@ -259,7 +257,7 @@
     pkgs.qitechPackages.electron
     htop
     wireshark
-    pciutils    
+    pciutils
     neofetch
   ];
 
@@ -295,15 +293,15 @@
   # Set system wide env variables
   environment.variables = {
     QITECH_OS = "true";
-    QITECH_OS_GIT_TIMESTAMP = installInfo.gitTimestamp;
-    QITECH_OS_GIT_COMMIT = installInfo.gitCommit;
-    QITECH_OS_GIT_ABBREVIATION = installInfo.gitAbbreviation;
-    QITECH_OS_GIT_URL = installInfo.gitUrl;
+    QITECH_OS_GIT_TIMESTAMP = gitInfo.gitTimestamp;
+    QITECH_OS_GIT_COMMIT = gitInfo.gitCommit;
+    QITECH_OS_GIT_ABBREVIATION = gitInfo.gitAbbreviation;
+    QITECH_OS_GIT_URL = gitInfo.gitUrl;
   };
 
   # Set revision labe;
-  system.nixos.label = "${installInfo.gitAbbreviationEscaped}_${installInfo.gitCommit}";
-  
+  system.nixos.label = "${gitInfo.gitAbbreviationEscaped}_${gitInfo.gitCommit}";
+
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.
   # programs.mtr.enable = true;


### PR DESCRIPTION
Problem is that the new commit corrupts hashes and therefore makes caching impossible. Might also be responsible for the builds taking forever.

~~Currently this is done quite hacky. In fact, it is not possible to get access to the `.git` folder to access this information. Git cannot add its own folder and therefore nixos will never copy these files over during `nix-rebuild`.~~

While we still need the install script, now no new commit needs to be added to the history. Also the no janky copy in this new approach.