### PR TITLE
596 extend total power output tile

### DIFF
--- a/electron/src/control/units.tsx
+++ b/electron/src/control/units.tsx
@@ -31,6 +31,8 @@ export function getUnitIcon(unit: Unit): IconName {
       return "lu:Zap";
     case "A":
       return "lu:Zap";
+    case "kWh":
+      return "lu:BatteryFull";
     default:
       return "lu:ChartNoAxesColumn";
   }
@@ -64,6 +66,8 @@ export function renderUnitSymbol(unit: Unit | undefined): string {
       return "V";
     case "A":
       return "A";
+    case "kWh":
+      return "kWh";
     default:
       return "";
   }
@@ -119,6 +123,8 @@ export function renderUnitSymbolLong(unit: Unit): string {
       return "volts";
     case "A":
       return "amperes";
+    case "kWh":
+      return "kilowatt-hours";
     default:
       return "";
   }
@@ -138,6 +144,7 @@ export const units = [
   "W",
   "V",
   "A",
+  "kWh",
 ] as const;
 
 export type Unit = (typeof units)[number];

--- a/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
@@ -30,6 +30,8 @@ export function Extruder2ControlPage() {
 
     motorScrewRpm,
     motorPower,
+    motorCurrent,
+    totalEnergyKWh,
     combinedPower,
 
     setExtruderMode,
@@ -224,12 +226,30 @@ export function Extruder2ControlPage() {
           />
         </ControlCard>
 
-        <ControlCard className="bg-blue" title="Total Power Consumption">
+        <ControlCard className="bg-blue" title="Power Consumption">
           <TimeSeriesValueNumeric
-            label=""
+            label="Total Power"
             unit="W"
-            renderValue={(value) => roundToDecimals(value, 1)}
+            renderValue={(value) => roundToDecimals(value, 0)}
             timeseries={combinedPower}
+          />
+          <TimeSeriesValueNumeric
+            label="Motor Power"
+            unit="W"
+            renderValue={(value) => roundToDecimals(value, 0)}
+            timeseries={motorPower}
+          />
+          <TimeSeriesValueNumeric
+            label="Motor Current"
+            unit="A"
+            renderValue={(value) => roundToDecimals(value, 1)}
+            timeseries={motorCurrent}
+          />
+          <TimeSeriesValueNumeric
+            label="Total Energy Consumption"
+            unit="kWh"
+            renderValue={(value) => roundToDecimals(value, 3)}
+            timeseries={totalEnergyKWh}
           />
         </ControlCard>
       </ControlGrid>

--- a/electron/src/machines/extruder/extruder2/extruder2Namespace.ts
+++ b/electron/src/machines/extruder/extruder2/extruder2Namespace.ts
@@ -43,6 +43,8 @@ export const liveValuesEventDataSchema = z.object({
   front_power: z.number(),
   back_power: z.number(),
   middle_power: z.number(),
+  combined_power: z.number(),
+  total_energy_kwh: z.number(),
 });
 
 /**
@@ -197,8 +199,9 @@ export type Extruder2NamespaceStore = {
   middlePower: TimeSeries;
   backPower: TimeSeries;
 
-  // Combined power consumption
+  // Combined power consumption and energy
   combinedPower: TimeSeries;
+  totalEnergyKWh: TimeSeries;
 };
 
 // Constants for time durations
@@ -206,13 +209,6 @@ const TWENTY_MILLISECOND = 20;
 const ONE_SECOND = 1000;
 const FIVE_SECOND = 5 * ONE_SECOND;
 const ONE_HOUR = 60 * 60 * ONE_SECOND;
-
-const { initialTimeSeries: screwRpm, insert: addScrewRpm } = createTimeSeries(
-  TWENTY_MILLISECOND,
-  ONE_SECOND,
-  FIVE_SECOND,
-  ONE_HOUR,
-);
 
 const { initialTimeSeries: pressure, insert: addPressure } = createTimeSeries(
   TWENTY_MILLISECOND,
@@ -250,6 +246,9 @@ const { initialTimeSeries: backPower, insert: addBackPower } = createTimeSeries(
 );
 
 const { initialTimeSeries: combinedPower, insert: addCombinedPower } =
+  createTimeSeries(TWENTY_MILLISECOND, ONE_SECOND, FIVE_SECOND, ONE_HOUR);
+
+const { initialTimeSeries: totalEnergyKWh, insert: addTotalEnergyKWh } =
   createTimeSeries(TWENTY_MILLISECOND, ONE_SECOND, FIVE_SECOND, ONE_HOUR);
 
 const { initialTimeSeries: motorCurrent, insert: addMotorCurrent } =
@@ -347,12 +346,11 @@ export function extruder2MessageHandler(
             timestamp,
           }),
           combinedPower: addCombinedPower(state.combinedPower, {
-            value:
-              liveValuesEvent.data.motor_status.power +
-              liveValuesEvent.data.nozzle_power +
-              liveValuesEvent.data.front_power +
-              liveValuesEvent.data.middle_power +
-              liveValuesEvent.data.back_power,
+            value: liveValuesEvent.data.combined_power,
+            timestamp,
+          }),
+          totalEnergyKWh: addTotalEnergyKWh(state.totalEnergyKWh, {
+            value: liveValuesEvent.data.total_energy_kwh,
             timestamp,
           }),
         }));
@@ -388,6 +386,7 @@ export const createExtruder2NamespaceStore =
         backPower,
         middlePower,
         combinedPower,
+        totalEnergyKWh,
       };
     });
 

--- a/electron/src/machines/extruder/extruder2/useExtruder.ts
+++ b/electron/src/machines/extruder/extruder2/useExtruder.ts
@@ -56,6 +56,7 @@ export function useExtruder2() {
     middlePower,
     backPower,
     combinedPower,
+    totalEnergyKWh,
   } = useExtruder2Namespace(machineIdentification);
 
   // Single optimistic state for all state management
@@ -383,6 +384,7 @@ export function useExtruder2() {
     middlePower,
     backPower,
     combinedPower,
+    totalEnergyKWh,
 
     // Loading states
     isLoading: stateOptimistic.isOptimistic,

--- a/server/src/machines/extruder1/api.rs
+++ b/server/src/machines/extruder1/api.rs
@@ -67,6 +67,10 @@ pub struct LiveValuesEvent {
     pub back_power: f64,
     /// middle heating power in watts
     pub middle_power: f64,
+    /// combined power consumption in watts
+    pub combined_power: f64,
+    /// total energy consumption in kWh
+    pub total_energy_kwh: f64,
 }
 
 impl LiveValuesEvent {

--- a/server/src/machines/extruder1/new.rs
+++ b/server/src/machines/extruder1/new.rs
@@ -400,6 +400,8 @@ impl MachineNewTrait for ExtruderV2 {
                 temperature_controller_back: temperature_controller_back,
                 temperature_controller_nozzle: temperature_controller_nozzle,
                 screw_speed_controller: screw_speed_controller,
+                total_energy_kwh: 0.0,
+                last_energy_calculation_time: None,
                 emitted_default_state: false,
             };
             extruder.emit_state();


### PR DESCRIPTION
This pull request adds tracking and display of total energy consumption (in kWh) for the Extruder2 machine, alongside improvements to power consumption calculations and UI enhancements. The changes include backend logic for calculating combined power and total energy, updating the API and schema, and extending the frontend to show these new metrics.

**Backend: Power and Energy Tracking**
* Added fields and logic to track total energy consumption (`total_energy_kwh`) and combined power (`combined_power`) in the Extruder2 backend; this includes calculation methods and state initialization. [[1]](diffhunk://#diff-f1828ea0df8cc344114c60d246119a13290cc473deb83dd5eec7cd76f0171812R75-R78) [[2]](diffhunk://#diff-f1828ea0df8cc344114c60d246119a13290cc473deb83dd5eec7cd76f0171812R103-R143) [[3]](diffhunk://#diff-f1828ea0df8cc344114c60d246119a13290cc473deb83dd5eec7cd76f0171812R179-R180) [[4]](diffhunk://#diff-75a719762cbaa7f758f8b303f526a70f1312e151952e76943f0b9c859110ace1R403-R404)
* Updated the API (`LiveValuesEvent`) to include `combined_power` and `total_energy_kwh` so these metrics are sent to the frontend.

**Frontend: Data Handling and Display**
* Extended the frontend schema and store to support `combinedPower` and `totalEnergyKWh` as time series, and updated the message handler to process these new fields. [[1]](diffhunk://#diff-5a4c2bed1668a4055b322acece48d8c7286781c57b7237b008fa1fbb4bb81a53R46-R47) [[2]](diffhunk://#diff-5a4c2bed1668a4055b322acece48d8c7286781c57b7237b008fa1fbb4bb81a53L200-R204) [[3]](diffhunk://#diff-5a4c2bed1668a4055b322acece48d8c7286781c57b7237b008fa1fbb4bb81a53R251-R253) [[4]](diffhunk://#diff-5a4c2bed1668a4055b322acece48d8c7286781c57b7237b008fa1fbb4bb81a53L350-R353) [[5]](diffhunk://#diff-5a4c2bed1668a4055b322acece48d8c7286781c57b7237b008fa1fbb4bb81a53R389) [[6]](diffhunk://#diff-d9dd35c21e0b6b7e088aaf6cafb49c6e5b9ccee76ca8620b650543a6affffbc9R59) [[7]](diffhunk://#diff-d9dd35c21e0b6b7e088aaf6cafb49c6e5b9ccee76ca8620b650543a6affffbc9R387)
* Improved the control page UI to display total power, motor power, motor current, and total energy consumption (kWh) with appropriate formatting. [[1]](diffhunk://#diff-5cb3092cd5c6eb17f6c648e4114f1808f0869fa13fee5ce698263db147373699R33-R34) [[2]](diffhunk://#diff-5cb3092cd5c6eb17f6c648e4114f1808f0869fa13fee5ce698263db147373699L227-R253)

**Units Support**
* Added support for the `kWh` unit in the units utility functions, including icon, symbol, and long name. [[1]](diffhunk://#diff-4304d30d20c0bca7df7421e86463927fde53794e023dfa9a749da7f2873ae2c2R34-R35) [[2]](diffhunk://#diff-4304d30d20c0bca7df7421e86463927fde53794e023dfa9a749da7f2873ae2c2R69-R70) [[3]](diffhunk://#diff-4304d30d20c0bca7df7421e86463927fde53794e023dfa9a749da7f2873ae2c2R126-R127) [[4]](diffhunk://#diff-4304d30d20c0bca7df7421e86463927fde53794e023dfa9a749da7f2873ae2c2R147)