### PR TITLE
Use minimal set of units instead of full uom::si module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
  "textplots",
  "tokio",
  "tracing",
- "uom",
+ "units",
 ]
 
 [[package]]
@@ -1020,7 +1020,7 @@ dependencies = [
  "rand",
  "smol",
  "tracing",
- "uom",
+ "units",
 ]
 
 [[package]]
@@ -2698,7 +2698,7 @@ dependencies = [
  "tracing-journald",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "uom",
+ "units",
 ]
 
 [[package]]
@@ -3381,10 +3381,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "units"
+version = "0.1.0"
+dependencies = [
+ "uom",
+]
+
+[[package]]
 name = "uom"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
+checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
 dependencies = [
  "num-traits",
  "typenum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "control-core",
     "ethercat-eeprom-dump",
     "control-core-derive",
+    "units",
 ]
 exclude = []
 resolver = "2"

--- a/control-core/Cargo.toml
+++ b/control-core/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.100"
 axum = "0.8.6"
 
 ethercat_hal = { path = "../ethercat-hal" }
+units = { path = "../units" }
 ethercrab = "0.6"
 interfaces = "0.0.9"
 serde = "1.0.219"
@@ -19,7 +20,6 @@ serde_json = "1.0.143"
 serialport = "4.7.3"
 smol = "2.0.2"
 socketioxide = "0.17.2"
-uom = { version = "0.36.0", default-features = false, features = ["f64"] }
 bitvec = { version = "1.0.1", features = ["alloc"] }
 crc = "3.3.0"
 serial = "0.4.0"

--- a/control-core/src/controllers/first_degree_motion/angular_acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/angular_acceleration_speed_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use uom::si::{
+use units::{
     angular_acceleration::radian_per_second_squared,
     angular_velocity::radian_per_second,
     f64::{AngularAcceleration, AngularVelocity},

--- a/control-core/src/controllers/first_degree_motion/linear_acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/linear_acceleration_speed_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use uom::si::{
+use units::{
     acceleration::meter_per_second_squared,
     f64::{Acceleration, Velocity},
     velocity::meter_per_second,

--- a/control-core/src/controllers/second_degree_motion/angular_acceleration_position_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/angular_acceleration_position_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use uom::si::{
+use units::{
     angle::radian,
     angular_acceleration::radian_per_second_squared,
     angular_velocity::radian_per_second,
@@ -199,8 +199,8 @@ impl AngularAccelerationPositionController {
     /// # Example
     /// ```ignore
     /// use control_core::controllers::second_degree_motion::angular_acceleration_position_controller::AngularAccelerationPositionController;
-    /// use uom::si::f64::Angle;
-    /// use uom::si::angle::degree;
+    /// use units::f64::Angle;
+    /// use units::angle::degree;
     ///
     /// let mut controller = AngularAccelerationPositionController::new_simple(
     ///     Some(Angle::new::<degree>(180.0)),

--- a/control-core/src/controllers/second_degree_motion/angular_jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/angular_jerk_speed_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use uom::si::{
+use units::{
     angular_acceleration::radian_per_second_squared,
     angular_jerk::radian_per_second_cubed,
     angular_velocity::radian_per_second,
@@ -23,7 +23,7 @@ use super::jerk_speed_controller::JerkSpeedController;
 ///
 /// # Example
 /// ```ignore
-/// use uom::si::{
+/// use units::{
 ///     angular_velocity::revolution_per_minute,
 ///     angular_acceleration::revolution_per_minute_per_second,
 ///     angular_jerk::revolution_per_minute_per_second_squared,
@@ -65,7 +65,7 @@ impl AngularJerkSpeedController {
     ///
     /// # Example
     /// ```ignore
-    /// use uom::si::{
+    /// use units::{
     ///     angular_velocity::revolution_per_minute,
     ///     angular_acceleration::revolution_per_minute_per_second,
     ///     angular_jerk::revolution_per_minute_per_second_squared,
@@ -127,7 +127,7 @@ impl AngularJerkSpeedController {
     ///
     /// # Example
     /// ```ignore
-    /// use uom::si::{
+    /// use units::{
     ///     angular_velocity::revolution_per_minute,
     ///     angular_acceleration::revolution_per_minute_per_second,
     ///     angular_jerk::revolution_per_minute_per_second_squared,
@@ -185,7 +185,7 @@ impl AngularJerkSpeedController {
     /// # Example
     /// ```ignore
     /// use std::time::Instant;
-    /// use uom::si::{angular_velocity::revolution_per_minute, f64::AngularVelocity};
+    /// use units::{angular_velocity::revolution_per_minute, f64::AngularVelocity};
     ///
     /// let mut controller = AngularJerkSpeedController::new_simple(/* ... */);
     /// let target = AngularVelocity::new::<revolution_per_minute>(1500.0);

--- a/control-core/src/controllers/second_degree_motion/linear_acceleration_position_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/linear_acceleration_position_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use uom::si::{
+use units::{
     acceleration::meter_per_second_squared,
     f64::{Acceleration, Length, Velocity},
     length::meter,
@@ -22,8 +22,8 @@ use super::acceleration_position_controller::{
 ///
 /// # Example
 /// ```ignore
-/// use uom::si::{length::meter, velocity::meter_per_second, acceleration::meter_per_second_squared};
-/// use uom::si::f64::{Length, Velocity, Acceleration};
+/// use units::{length::meter, velocity::meter_per_second, acceleration::meter_per_second_squared};
+/// use units::f64::{Length, Velocity, Acceleration};
 ///
 /// let position_limit = Length::new::<meter>(10.0);
 /// let max_speed = Velocity::new::<meter_per_second>(2.0);
@@ -101,8 +101,8 @@ impl LinearAccelerationPositionController {
     ///
     /// # Example
     /// ```ignore
-    /// use uom::si::{length::meter, velocity::meter_per_second, acceleration::meter_per_second_squared};
-    /// use uom::si::f64::{Length, Velocity, Acceleration};
+    /// use units::{length::meter, velocity::meter_per_second, acceleration::meter_per_second_squared};
+    /// use units::f64::{Length, Velocity, Acceleration};
     ///
     /// let position_limit = Length::new::<meter>(5.0);  // Creates [-5.0, +5.0] meter range
     /// let max_speed = Velocity::new::<meter_per_second>(1.0);  // Creates [-1.0, +1.0] m/s range
@@ -150,7 +150,7 @@ impl LinearAccelerationPositionController {
     /// # Example
     /// ```ignore
     /// use std::time::Instant;
-    /// use uom::si::{length::meter, f64::Length};
+    /// use units::{length::meter, f64::Length};
     ///
     /// let mut controller = LinearAccelerationPositionController::new_simple(
     ///     Some(Length::new::<meter>(10.0)),
@@ -375,7 +375,7 @@ impl LinearAccelerationPositionController {
     ///
     /// # Example
     /// ```ignore
-    /// use uom::si::{length::meter, velocity::meter_per_second, f64::{Length, Velocity}};
+    /// use units::{length::meter, velocity::meter_per_second, f64::{Length, Velocity}};
     ///
     /// let new_position = Length::new::<meter>(0.0);
     ///

--- a/control-core/src/controllers/second_degree_motion/linear_jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/linear_jerk_speed_controller.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use uom::si::{
+use units::{
     acceleration::meter_per_second_squared,
     f64::{Acceleration, Jerk, Velocity},
     jerk::meter_per_second_cubed,
@@ -23,7 +23,7 @@ use super::jerk_speed_controller::JerkSpeedController;
 ///
 /// # Example
 /// ```ignore
-/// use uom::si::{
+/// use units::{
 ///     velocity::meter_per_second,
 ///     acceleration::meter_per_second_squared,
 ///     jerk::meter_per_second_cubed,
@@ -65,7 +65,7 @@ impl LinearJerkSpeedController {
     ///
     /// # Example
     /// ```ignore
-    /// use uom::si::{
+    /// use units::{
     ///     velocity::meter_per_second,
     ///     acceleration::meter_per_second_squared,
     ///     jerk::meter_per_second_cubed,
@@ -127,7 +127,7 @@ impl LinearJerkSpeedController {
     ///
     /// # Example
     /// ```ignore
-    /// use uom::si::{
+    /// use units::{
     ///     velocity::meter_per_second,
     ///     acceleration::meter_per_second_squared,
     ///     jerk::meter_per_second_cubed,

--- a/control-core/src/converters/angle_converter.rs
+++ b/control-core/src/converters/angle_converter.rs
@@ -1,4 +1,4 @@
-use uom::si::{angle::radian, f64::Angle};
+use units::{angle::radian, f64::Angle};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AngleConverter {

--- a/control-core/src/converters/angular_step_converter.rs
+++ b/control-core/src/converters/angular_step_converter.rs
@@ -1,4 +1,4 @@
-use uom::si::{
+use units::{
     angle::revolution,
     angular_acceleration::radian_per_second_squared,
     angular_velocity::revolution_per_second,
@@ -90,7 +90,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use std::f64::EPSILON;
-    use uom::si::{
+    use units::{
         angle::degree, angular_acceleration::degree_per_second_squared,
         angular_velocity::degree_per_second,
     };

--- a/control-core/src/converters/circular_converter.rs
+++ b/control-core/src/converters/circular_converter.rs
@@ -14,14 +14,14 @@
 //!
 //! ```rust
 //! use control_core::converters::circular_converter::CircularConverter;
-//! use uom::si::{f64::{Length, Velocity}, length::meter, velocity::meter_per_second};
+//! use units::{f64::{Length, Velocity}, length::meter, velocity::meter_per_second};
 //!
 //! let converter = CircularConverter::from_radius(Length::new::<meter>(0.1));
 //! let velocity = Velocity::new::<meter_per_second>(1.0);
 //! let angular_velocity = converter.linear_to_angular_velocity(velocity);
 //! ```
 
-use uom::si::{
+use units::{
     acceleration::meter_per_second_squared,
     angle::radian,
     angular_acceleration::radian_per_second_squared,
@@ -199,7 +199,7 @@ impl CircularConverter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use uom::si::length::centimeter;
+    use units::length::centimeter;
 
     #[test]
     fn test_constructors() {

--- a/control-core/src/converters/linear_step_converter.rs
+++ b/control-core/src/converters/linear_step_converter.rs
@@ -1,4 +1,4 @@
-use uom::si::{
+use units::{
     angle::revolution,
     angular_velocity::revolution_per_second,
     f64::{Acceleration, Angle, AngularAcceleration, AngularVelocity, Length, Velocity},
@@ -251,7 +251,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use std::f64::EPSILON;
-    use uom::si::{
+    use units::{
         acceleration::meter_per_second_squared, angular_acceleration::radian_per_second_squared,
         length::meter, velocity::meter_per_second,
     };

--- a/control-core/src/lib.rs
+++ b/control-core/src/lib.rs
@@ -11,10 +11,6 @@ pub mod rest;
 pub mod serial;
 pub mod socketio;
 pub mod transmission;
-pub mod uom_extensions;
 
 #[cfg(feature = "video-streaming")]
 pub mod video_streaming;
-
-#[macro_use]
-extern crate uom;

--- a/control-core/src/transmission/mod.rs
+++ b/control-core/src/transmission/mod.rs
@@ -1,4 +1,4 @@
-use uom::si::{
+use units::{
     angle::radian,
     angular_velocity::radian_per_second,
     f64::{Angle, AngularVelocity, Length, Velocity},

--- a/control-core/src/uom_extensions/acceleration.rs
+++ b/control-core/src/uom_extensions/acceleration.rs
@@ -1,7 +1,0 @@
-unit! {
-    system: uom::si;
-    quantity: uom::si::acceleration;
-
-    @meter_per_minute_per_second: 0.016_666_666_666_666_67; "m/min/s", "meters per minute per second",
-        "meters per minute per second";
-}

--- a/control-core/src/uom_extensions/angular_acceleration.rs
+++ b/control-core/src/uom_extensions/angular_acceleration.rs
@@ -1,7 +1,0 @@
-unit! {
-    system: uom::si;
-    quantity: uom::si::angular_acceleration;
-
-    @revolution_per_minute_per_second: 0.104_719_755_119_659_77; "rev/min/s", "revolutions per minute per second",
-        "revolutions per minute per second";
-}

--- a/control-core/src/uom_extensions/angular_jerk.rs
+++ b/control-core/src/uom_extensions/angular_jerk.rs
@@ -1,7 +1,0 @@
-unit! {
-    system: uom::si;
-    quantity: uom::si::angular_jerk;
-
-    @revolution_per_minute_per_second_squared: 0.104_719_755_119_659_77; "rev/min/s²", "revolution per minute per second squared",
-        "revolution per minute per second squared";
-}

--- a/control-core/src/uom_extensions/jerk.rs
+++ b/control-core/src/uom_extensions/jerk.rs
@@ -1,7 +1,0 @@
-unit! {
-    system: uom::si;
-    quantity: uom::si::jerk;
-
-    @meter_per_minute_per_second_squared: 0.016_666_666_666_666_666_67; "m/min/s²", "meters per minute per second squared",
-        "meters per minute per second squared";
-}

--- a/control-core/src/uom_extensions/mod.rs
+++ b/control-core/src/uom_extensions/mod.rs
@@ -1,5 +1,0 @@
-pub mod acceleration;
-pub mod angular_acceleration;
-pub mod angular_jerk;
-pub mod jerk;
-pub mod velocity;

--- a/control-core/src/uom_extensions/velocity.rs
+++ b/control-core/src/uom_extensions/velocity.rs
@@ -1,7 +1,0 @@
-unit! {
-    system: uom::si;
-    quantity: uom::si::velocity;
-
-    @meter_per_minute: 0.016_666_666_666_666_67; "m/min", "meters per minute",
-        "meters per minute";
-}

--- a/ethercat-hal/Cargo.toml
+++ b/ethercat-hal/Cargo.toml
@@ -10,9 +10,9 @@ workspace = true
 anyhow = "1.0.100"
 ethercrab = "0.6"
 ethercat_hal_derive = { version = "0.1.0", path = "../ethercat-hal-derive" }
+units = { path = "../units" }
 bitvec = { version = "1.0.1", features = ["alloc"] }
 smol = "2.0.2"
-uom = { version = "0.36.0", default-features = false, features = ["f64","si"] }
 rand = "0.9.2"
 futures = "0.3.31"
 tracing = "0.1.41"

--- a/ethercat-hal/src/devices/el3001.rs
+++ b/ethercat-hal/src/devices/el3001.rs
@@ -14,7 +14,7 @@ use crate::{
     io::analog_input::{AnalogInputDevice, AnalogInputInput},
 };
 use ethercat_hal_derive::{EthercatDevice, RxPdo, TxPdo};
-use uom::si::{electric_potential::volt, f64::ElectricPotential};
+use units::{electric_potential::volt, f64::ElectricPotential};
 
 #[derive(EthercatDevice)]
 pub struct EL3001 {

--- a/ethercat-hal/src/devices/el3021.rs
+++ b/ethercat-hal/src/devices/el3021.rs
@@ -17,8 +17,8 @@ use crate::{
     io::analog_input::{AnalogInputDevice, AnalogInputInput},
 };
 use ethercat_hal_derive::{EthercatDevice, RxPdo, TxPdo};
-use uom::si::electric_current::milliampere;
-use uom::si::f64::ElectricCurrent;
+use units::electric_current::milliampere;
+use units::f64::ElectricCurrent;
 
 #[derive(Debug, Clone)]
 pub struct EL3021Configuration {

--- a/ethercat-hal/src/devices/el3024.rs
+++ b/ethercat-hal/src/devices/el3024.rs
@@ -17,8 +17,8 @@ use crate::{
     io::analog_input::{AnalogInputDevice, AnalogInputInput},
 };
 use ethercat_hal_derive::{EthercatDevice, RxPdo, TxPdo};
-use uom::si::electric_current::milliampere;
-use uom::si::f64::ElectricCurrent;
+use units::electric_current::milliampere;
+use units::f64::ElectricCurrent;
 
 #[derive(Debug, Clone)]
 pub struct EL3024Configuration {

--- a/ethercat-hal/src/devices/el3062_0030.rs
+++ b/ethercat-hal/src/devices/el3062_0030.rs
@@ -15,7 +15,7 @@ use crate::{
     io::analog_input::{AnalogInputDevice, AnalogInputInput},
 };
 use ethercat_hal_derive::EthercatDevice;
-use uom::si::{electric_potential::volt, f64::ElectricPotential};
+use units::{electric_potential::volt, f64::ElectricPotential};
 
 #[derive(Debug, Clone)]
 pub struct EL3062_0030Configuration {

--- a/ethercat-hal/src/devices/el7031_0030/mod.rs
+++ b/ethercat-hal/src/devices/el7031_0030/mod.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use coe::EL7031_0030Configuration;
 use ethercat_hal_derive::EthercatDevice;
 use pdo::{EL7031_0030RxPdo, EL7031_0030TxPdo};
-use uom::si::{electric_potential::volt, f64::ElectricPotential};
+use units::{electric_potential::volt, f64::ElectricPotential};
 
 use crate::{
     helpers::{

--- a/ethercat-hal/src/io/analog_input/physical.rs
+++ b/ethercat-hal/src/io/analog_input/physical.rs
@@ -1,4 +1,4 @@
-use uom::si::f64::{ElectricCurrent, ElectricPotential};
+use units::f64::{ElectricCurrent, ElectricPotential};
 
 #[derive(Debug, Clone)]
 pub enum AnalogInputValue {
@@ -77,9 +77,9 @@ mod tests {
 
     use super::*;
     use approx::assert_relative_eq;
-    use uom::si::electric_current::milliampere;
-    use uom::si::electric_potential::volt;
-    use uom::si::f64::{ElectricCurrent, ElectricPotential};
+    use units::electric_current::milliampere;
+    use units::electric_potential::volt;
+    use units::f64::{ElectricCurrent, ElectricPotential};
 
     #[test]
     fn test_analog_input_getter_voltage() {

--- a/ethercat-hal/src/io/analog_input_dummy.rs
+++ b/ethercat-hal/src/io/analog_input_dummy.rs
@@ -57,7 +57,7 @@ impl AnalogInputDummy {
 
 #[cfg(test)]
 mod tests {
-    use uom::si::{electric_potential::volt, f64::ElectricPotential};
+    use units::{electric_potential::volt, f64::ElectricPotential};
 
     use super::*;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,8 +13,8 @@ ethercrab = "0.6"
 ethercat_hal = { path = "../ethercat-hal" }
 control_core = { path = "../control-core" }
 control_core_derive = { path = "../control-core-derive" }
+units = { path = "../units" }
 
-uom = { version = "0.36.0", default-features = false, features = ["f64"] }
 serde = "1.0.217"
 anyhow = "1.0.100"
 

--- a/server/src/machines/aquapath1/controller.rs
+++ b/server/src/machines/aquapath1/controller.rs
@@ -1,4 +1,3 @@
-use crate::machines::aquapath1::VolumeRate;
 use crate::machines::aquapath1::{Flow, Temperature};
 use control_core::controllers::pid::PidController;
 use ethercat_hal::io::encoder_input::EncoderInput;
@@ -7,9 +6,9 @@ use ethercat_hal::io::{
 };
 use std::time::{Duration, Instant};
 
-use uom::si::f64::ThermodynamicTemperature;
-use uom::si::thermodynamic_temperature::degree_celsius;
-use uom::si::volume_rate::liter_per_minute;
+use units::f64::{ThermodynamicTemperature, VolumeRate};
+use units::thermodynamic_temperature::degree_celsius;
+use units::volume_rate::liter_per_minute;
 #[derive(Debug)]
 
 pub struct Controller {

--- a/server/src/machines/aquapath1/mod.rs
+++ b/server/src/machines/aquapath1/mod.rs
@@ -6,11 +6,8 @@ use control_core::{
 use control_core_derive::Machine;
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
-use uom::si::{
-    f64::{ThermodynamicTemperature, VolumeRate},
-    thermodynamic_temperature::degree_celsius,
-    volume_rate::liter_per_minute,
-};
+use units::f64::*;
+use units::{thermodynamic_temperature::degree_celsius, volume_rate::liter_per_minute};
 
 use crate::machines::{
     MACHINE_AQUAPATH_V1, VENDOR_QITECH,

--- a/server/src/machines/aquapath1/new.rs
+++ b/server/src/machines/aquapath1/new.rs
@@ -26,7 +26,7 @@ use ethercat_hal::{
     },
 };
 use std::time::{Duration, Instant};
-use uom::si::{f64::ThermodynamicTemperature, thermodynamic_temperature::degree_celsius};
+use units::thermodynamic_temperature::{ThermodynamicTemperature, degree_celsius};
 
 impl MachineNewTrait for AquaPathV1 {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {

--- a/server/src/machines/extruder1/api.rs
+++ b/server/src/machines/extruder1/api.rs
@@ -22,10 +22,10 @@ use serde_json::Value;
 use smol::lock::Mutex;
 use std::{sync::Arc, time::Duration};
 use tracing::instrument;
-use uom::si::{
-    angular_velocity::revolution_per_minute, electric_current::ampere, electric_potential::volt,
-    frequency::hertz,
-};
+use units::angular_velocity::revolution_per_minute;
+use units::electric_current::ampere;
+use units::electric_potential::volt;
+use units::frequency::hertz;
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct MotorStatusValues {

--- a/server/src/machines/extruder1/emit.rs
+++ b/server/src/machines/extruder1/emit.rs
@@ -15,14 +15,13 @@ use control_core::socketio::event::BuildEvent;
 #[cfg(not(feature = "mock-machine"))]
 use control_core::socketio::namespace::NamespaceCacheingLogic;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::{angular_velocity::revolution_per_minute, thermodynamic_temperature::degree_celsius};
-
+use units::angular_velocity::AngularVelocity;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::angular_velocity::AngularVelocity;
+use units::pressure::{Pressure, bar};
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::pressure::{Pressure, bar};
+use units::thermodynamic_temperature::ThermodynamicTemperature;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::thermodynamic_temperature::ThermodynamicTemperature;
+use units::{angular_velocity::revolution_per_minute, thermodynamic_temperature::degree_celsius};
 
 #[cfg(not(feature = "mock-machine"))]
 impl ExtruderV2 {

--- a/server/src/machines/extruder1/mitsubishi_cs80/mod.rs
+++ b/server/src/machines/extruder1/mitsubishi_cs80/mod.rs
@@ -6,12 +6,10 @@ use control_core::modbus::{
 use ethercat_hal::io::serial_interface::SerialInterface;
 use serde::Serialize;
 use std::time::{Duration, Instant};
-use uom::si::{
-    electric_current::centiampere,
-    electric_potential::centivolt,
-    f64::{AngularVelocity, ElectricCurrent, ElectricPotential, Frequency},
-    frequency::centihertz,
-};
+use units::electric_current::centiampere;
+use units::electric_potential::centivolt;
+use units::f64::*;
+use units::frequency::centihertz;
 
 /// Specifies all System environment Variables
 /// Register addresses are calculated as follows: Register-value 40002 -> address: 40002-40001 -> actual address in request:0x1

--- a/server/src/machines/extruder1/mod.rs
+++ b/server/src/machines/extruder1/mod.rs
@@ -7,10 +7,11 @@ use control_core::machines::identification::{MachineIdentification, MachineIdent
 use control_core_derive::Machine;
 use serde::{Deserialize, Serialize};
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::electric_current::ampere;
+use units::electric_current::ampere;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::electric_potential::volt;
-use uom::si::{f64::ThermodynamicTemperature, thermodynamic_temperature::degree_celsius};
+use units::electric_potential::volt;
+use units::f64::*;
+use units::thermodynamic_temperature::degree_celsius;
 
 #[cfg(not(feature = "mock-machine"))]
 use crate::machines::{

--- a/server/src/machines/extruder1/new.rs
+++ b/server/src/machines/extruder1/new.rs
@@ -29,13 +29,13 @@ use std::time::Duration;
 #[cfg(not(feature = "mock-machine"))]
 use std::time::Instant;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::angular_velocity::AngularVelocity;
+use units::angular_velocity::AngularVelocity;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::angular_velocity::revolution_per_minute;
+use units::angular_velocity::revolution_per_minute;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::pressure::Pressure;
+use units::pressure::Pressure;
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::pressure::bar;
+use units::pressure::bar;
 
 #[cfg(not(feature = "mock-machine"))]
 use ethercat_hal::{
@@ -50,7 +50,7 @@ use ethercat_hal::{
     },
 };
 #[cfg(not(feature = "mock-machine"))]
-use uom::si::thermodynamic_temperature::{ThermodynamicTemperature, degree_celsius};
+use units::thermodynamic_temperature::{ThermodynamicTemperature, degree_celsius};
 
 #[cfg(not(feature = "mock-machine"))]
 use crate::machines::extruder1::temperature_controller::TemperatureController;

--- a/server/src/machines/extruder1/screw_speed_controller.rs
+++ b/server/src/machines/extruder1/screw_speed_controller.rs
@@ -7,13 +7,11 @@ use control_core::{
 };
 use ethercat_hal::io::analog_input::AnalogInput;
 use futures::executor::block_on;
-use uom::si::{
-    angular_velocity::revolution_per_minute,
-    electric_current::milliampere,
-    f64::{AngularVelocity, ElectricCurrent, Frequency, Pressure},
-    frequency::{cycle_per_minute, hertz},
-    pressure::bar,
-};
+use units::angular_velocity::revolution_per_minute;
+use units::electric_current::milliampere;
+use units::f64::*;
+use units::frequency::{cycle_per_minute, hertz};
+use units::pressure::bar;
 
 use crate::machines::extruder1::mitsubishi_cs80::MitsubishiCS80Status;
 

--- a/server/src/machines/extruder1/temperature_controller.rs
+++ b/server/src/machines/extruder1/temperature_controller.rs
@@ -2,7 +2,8 @@ use super::Heating;
 use control_core::controllers::pid::PidController;
 use ethercat_hal::io::{digital_output::DigitalOutput, temperature_input::TemperatureInput};
 use std::time::{Duration, Instant};
-use uom::si::{f64::ThermodynamicTemperature, thermodynamic_temperature::degree_celsius};
+use units::f64::*;
+use units::thermodynamic_temperature::degree_celsius;
 
 #[derive(Debug)]
 

--- a/server/src/machines/laser/mod.rs
+++ b/server/src/machines/laser/mod.rs
@@ -10,7 +10,8 @@ use control_core::{
 use control_core_derive::Machine;
 use smol::lock::RwLock;
 use std::{sync::Arc, time::Instant};
-use uom::si::{f64::Length, length::millimeter};
+use units::f64::*;
+use units::length::millimeter;
 
 pub mod act;
 pub mod api;

--- a/server/src/machines/laser/new.rs
+++ b/server/src/machines/laser/new.rs
@@ -5,8 +5,8 @@ use crate::serial::{devices::laser::Laser, registry::SERIAL_DEVICE_REGISTRY};
 use super::{LaserMachine, LaserTarget, api::LaserMachineNamespace};
 use anyhow::Error;
 use control_core::machines::new::{MachineNewHardware, MachineNewTrait};
-use uom::ConstZero;
-use uom::si::{f64::Length, length::millimeter};
+use units::ConstZero;
+use units::length::{Length, millimeter};
 
 impl MachineNewTrait for LaserMachine {
     fn new(

--- a/server/src/machines/mock/mod.rs
+++ b/server/src/machines/mock/mod.rs
@@ -9,10 +9,8 @@ use control_core_derive::Machine;
 
 use std::time::Instant;
 use tracing::info;
-use uom::si::{
-    f64::Frequency,
-    frequency::{hertz, millihertz},
-};
+use units::f64::*;
+use units::frequency::{hertz, millihertz};
 
 pub mod act;
 pub mod api;

--- a/server/src/machines/mock/new.rs
+++ b/server/src/machines/mock/new.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use anyhow::Error;
 use control_core::machines::new::{MachineNewHardware, MachineNewParams, MachineNewTrait};
-use uom::si::{f64::Frequency, frequency::hertz};
+use units::frequency::{Frequency, hertz};
 
 impl MachineNewTrait for MockMachine {
     fn new<'maindevice, 'subdevices>(

--- a/server/src/machines/winder2/adaptive_spool_speed_controller.rs
+++ b/server/src/machines/winder2/adaptive_spool_speed_controller.rs
@@ -10,17 +10,13 @@ use control_core::{
 };
 use core::f64;
 use std::time::Instant;
-use uom::{
-    ConstZero,
-    si::{
-        angle::degree,
-        angular_acceleration::radian_per_second_squared,
-        angular_velocity::{radian_per_second, revolution_per_minute},
-        f64::{Angle, AngularAcceleration, AngularVelocity, Length},
-        length::{centimeter, meter},
-        velocity::meter_per_second,
-    },
-};
+use units::ConstZero;
+use units::angle::degree;
+use units::angular_acceleration::radian_per_second_squared;
+use units::angular_velocity::{radian_per_second, revolution_per_minute};
+use units::f64::*;
+use units::length::{centimeter, meter};
+use units::velocity::meter_per_second;
 
 /// Adaptive spool speed controller that automatically adjusts to maintain optimal filament tension.
 ///

--- a/server/src/machines/winder2/clamp_revolution.rs
+++ b/server/src/machines/winder2/clamp_revolution.rs
@@ -1,4 +1,5 @@
-use uom::si::{angle::revolution, f64::Angle};
+use units::angle::revolution;
+use units::f64::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Clamping {
@@ -24,7 +25,7 @@ pub enum Clamping {
 /// # Examples
 ///
 /// ```ignore
-/// use uom::si::{angle::revolution, f64::Angle};
+/// units::angle::{revolution, Angle};
 ///
 /// let value = Angle::new::<revolution>(0.15);
 /// let min = Angle::new::<revolution>(0.1);

--- a/server/src/machines/winder2/emit.rs
+++ b/server/src/machines/winder2/emit.rs
@@ -13,14 +13,15 @@ mod winder2_imports {
     pub use control_core::socketio::event::BuildEvent;
     pub use control_core::{
         machines::identification::MachineIdentificationUnique,
-        socketio::namespace::NamespaceCacheingLogic, uom_extensions::velocity::meter_per_minute,
+        socketio::namespace::NamespaceCacheingLogic,
     };
     pub use std::time::Instant;
-    pub use uom::si::{
+    pub use units::{
         angle::degree,
         angular_velocity::revolution_per_minute,
-        f64::{Length, Velocity},
+        f64::*,
         length::{meter, millimeter},
+        velocity::meter_per_minute,
     };
 }
 
@@ -435,7 +436,7 @@ impl Winder2 {
 
     /// Set minimum speed for minmax mode in RPM
     pub fn spool_set_minmax_min_speed(&mut self, min_speed_rpm: f64) {
-        let min_speed = uom::si::f64::AngularVelocity::new::<revolution_per_minute>(min_speed_rpm);
+        let min_speed = AngularVelocity::new::<revolution_per_minute>(min_speed_rpm);
         if let Err(e) = self.spool_speed_controller.set_minmax_min_speed(min_speed) {
             tracing::error!("Failed to set spool min speed: {:?}", e);
         }
@@ -444,7 +445,7 @@ impl Winder2 {
 
     /// Set maximum speed for minmax mode in RPM
     pub fn spool_set_minmax_max_speed(&mut self, max_speed_rpm: f64) {
-        let max_speed = uom::si::f64::AngularVelocity::new::<revolution_per_minute>(max_speed_rpm);
+        let max_speed = AngularVelocity::new::<revolution_per_minute>(max_speed_rpm);
         if let Err(e) = self.spool_speed_controller.set_minmax_max_speed(max_speed) {
             tracing::error!("Failed to set spool max speed: {:?}", e);
         }

--- a/server/src/machines/winder2/filament_tension.rs
+++ b/server/src/machines/winder2/filament_tension.rs
@@ -1,14 +1,10 @@
 use control_core::converters::angle_converter::{AngleConverter, AngleConverterUom};
 use euclid::Point2D;
-use uom::{
-    ConstZero,
-    si::{
-        angle::radian,
-        f64::{Angle, Length},
-        length::centimeter,
-        ratio::ratio,
-    },
-};
+use units::ConstZero;
+use units::angle::radian;
+use units::f64::*;
+use units::length::centimeter;
+use units::ratio::ratio;
 
 /// The "tension" of the filament is not linear regarding the angle of the tension arm since it moves in an angular motion.
 ///
@@ -148,7 +144,8 @@ impl FilamentTensionCalculator {
 #[cfg(test)]
 mod tests {
     use textplots::{Chart, Plot, Shape};
-    use uom::si::angle::degree;
+
+    use units::angle::degree;
 
     use super::*;
 

--- a/server/src/machines/winder2/minmax_spool_speed_controller.rs
+++ b/server/src/machines/winder2/minmax_spool_speed_controller.rs
@@ -13,20 +13,16 @@ use control_core::{
         interpolation::{interpolate_exponential, scale},
         moving_time_window::MovingTimeWindow,
     },
-    uom_extensions::angular_acceleration::revolution_per_minute_per_second,
 };
 use std::time::Instant;
-use uom::{
-    ConstZero,
-    si::{
-        angle::degree,
-        angular_acceleration::radian_per_second_squared,
-        angular_velocity::{radian_per_second, revolution_per_minute, revolution_per_second},
-        f64::{Angle, AngularAcceleration, AngularVelocity, Length, Velocity},
-        length::meter,
-        velocity::meter_per_second,
-    },
-};
+
+use units::ConstZero;
+use units::angle::degree;
+use units::angular_acceleration::{radian_per_second_squared, revolution_per_minute_per_second};
+use units::angular_velocity::{radian_per_second, revolution_per_minute, revolution_per_second};
+use units::f64::*;
+use units::length::meter;
+use units::velocity::meter_per_second;
 
 #[derive(Debug)]
 pub struct MinMaxSpoolSpeedController {

--- a/server/src/machines/winder2/mod.rs
+++ b/server/src/machines/winder2/mod.rs
@@ -18,7 +18,7 @@ pub mod mock;
 mod winder2_imports {
     pub use super::api::SpoolAutomaticActionMode;
     pub use std::time::Instant;
-    pub use uom::si::f64::Length;
+    pub use units::f64::Length;
 }
 
 #[cfg(not(feature = "mock-machine"))]
@@ -44,11 +44,11 @@ mod winder2_imports {
     };
     pub use smol::lock::RwLock;
     pub use std::{fmt::Debug, sync::Weak, time::Instant};
-    pub use uom::si::f64::Length;
+    pub use units::f64::Length;
 
     pub use crate::machines::{MACHINE_WINDER_V1, VENDOR_QITECH, buffer1::BufferV1};
-    pub use uom::ConstZero;
-    pub use uom::si::{length::meter, length::millimeter, velocity::meter_per_second};
+    pub use units::ConstZero;
+    pub use units::{length::meter, length::millimeter, velocity::meter_per_second};
 }
 
 pub use winder2_imports::*;
@@ -64,9 +64,9 @@ pub struct SpoolAutomaticAction {
 impl Default for SpoolAutomaticAction {
     fn default() -> Self {
         SpoolAutomaticAction {
-            progress: Length::new::<uom::si::length::meter>(0.0),
+            progress: Length::new::<meter>(0.0),
             progress_last_check: Instant::now(),
-            target_length: Length::new::<uom::si::length::meter>(0.0),
+            target_length: Length::new::<meter>(0.0),
             mode: SpoolAutomaticActionMode::default(),
         }
     }
@@ -404,7 +404,6 @@ impl std::fmt::Display for Winder2 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use uom::si::{f64::Length, length::millimeter};
 
     #[test]
     fn test_validate_traverse_limits() {

--- a/server/src/machines/winder2/new.rs
+++ b/server/src/machines/winder2/new.rs
@@ -15,7 +15,6 @@ mod winder2_imports {
         validate_same_machine_identification_unique,
     };
 
-    pub use control_core::uom_extensions::velocity::meter_per_minute;
     pub use ethercat_hal::coe::ConfigurableDevice;
     pub use ethercat_hal::devices::ek1100::EK1100;
     pub use ethercat_hal::devices::el2002::{EL2002, EL2002_IDENTITY_B, EL2002Port};
@@ -42,9 +41,10 @@ mod winder2_imports {
     pub use ethercat_hal::shared_config;
     pub use ethercat_hal::shared_config::el70x1::{EL70x1OperationMode, StmMotorConfiguration};
     pub use std::time::Instant;
-    pub use uom::ConstZero;
-    pub use uom::si::f64::{Length, Velocity};
-    pub use uom::si::length::{centimeter, meter, millimeter};
+    pub use units::ConstZero;
+    pub use units::f64::*;
+    pub use units::length::{centimeter, meter, millimeter};
+    pub use units::velocity::meter_per_minute;
 }
 
 #[cfg(not(feature = "mock-machine"))]

--- a/server/src/machines/winder2/puller_speed_controller.rs
+++ b/server/src/machines/winder2/puller_speed_controller.rs
@@ -3,16 +3,13 @@ use std::time::Instant;
 use control_core::{
     controllers::second_degree_motion::linear_jerk_speed_controller::LinearJerkSpeedController,
     converters::linear_step_converter::LinearStepConverter,
-    uom_extensions::{
-        acceleration::meter_per_minute_per_second, jerk::meter_per_minute_per_second_squared,
-        velocity::meter_per_minute,
-    },
 };
 use serde::{Deserialize, Serialize};
-use uom::{
-    ConstZero,
-    si::f64::{Acceleration, AngularVelocity, Jerk, Length, Velocity},
-};
+use units::ConstZero;
+use units::acceleration::meter_per_minute_per_second;
+use units::f64::*;
+use units::jerk::meter_per_minute_per_second_squared;
+use units::velocity::meter_per_minute;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum GearRatio {

--- a/server/src/machines/winder2/spool_speed_controller.rs
+++ b/server/src/machines/winder2/spool_speed_controller.rs
@@ -8,7 +8,7 @@ use control_core::controllers::second_degree_motion::acceleration_position_contr
 use super::tension_arm::TensionArm;
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
-use uom::si::f64::AngularVelocity;
+use units::f64::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub enum SpoolSpeedControllerType {

--- a/server/src/machines/winder2/tension_arm.rs
+++ b/server/src/machines/winder2/tension_arm.rs
@@ -1,5 +1,7 @@
 use ethercat_hal::io::analog_input::{AnalogInput, physical::AnalogInputValue};
-use uom::si::{angle::revolution, electric_potential::volt, f64::Angle};
+use units::angle::revolution;
+use units::electric_potential::volt;
+use units::f64::*;
 
 #[derive(Debug)]
 pub struct TensionArm {
@@ -72,7 +74,6 @@ mod tests {
         analog_input_dummy::AnalogInputDummy,
     };
     use std::i16;
-    use uom::si::f64::ElectricPotential;
 
     #[test]
     fn volts_to_angle() {

--- a/server/src/machines/winder2/traverse_controller.rs
+++ b/server/src/machines/winder2/traverse_controller.rs
@@ -4,15 +4,11 @@ use control_core::converters::linear_step_converter::LinearStepConverter;
 use ethercat_hal::io::{
     digital_input::DigitalInput, stepper_velocity_el70x1::StepperVelocityEL70x1,
 };
-use uom::{
-    ConstZero,
-    si::{
-        angular_velocity::revolution_per_second,
-        f64::{AngularVelocity, Length, Velocity},
-        length::millimeter,
-        velocity::millimeter_per_second,
-    },
-};
+use units::ConstZero;
+use units::angular_velocity::revolution_per_second;
+use units::f64::{AngularVelocity, Length, Velocity};
+use units::length::millimeter;
+use units::velocity::millimeter_per_second;
 
 #[derive(Debug)]
 pub struct TraverseController {

--- a/server/src/serial/devices/laser/mod.rs
+++ b/server/src/serial/devices/laser/mod.rs
@@ -22,7 +22,8 @@ use control_core::{
 use serialport::SerialPort;
 use serialport::{ClearBuffer, DataBits, FlowControl, Parity, StopBits};
 use smol::lock::RwLock;
-use uom::si::f64::Length;
+use units::f64::Length;
+use units::length::millimeter;
 
 /// The struct of Laser Device
 #[derive(Debug)]
@@ -59,15 +60,15 @@ impl TryFrom<ModbusResponse> for LaserDiameterResponse {
             let x = u16::from_be_bytes([value.data[3], value.data[4]]) as f64 / 1000.0;
             let y = u16::from_be_bytes([value.data[5], value.data[6]]) as f64 / 1000.0;
             (
-                Some(Length::new::<uom::si::length::millimeter>(x)),
-                Some(Length::new::<uom::si::length::millimeter>(y)),
+                Some(Length::new::<millimeter>(x)),
+                Some(Length::new::<millimeter>(y)),
             )
         } else {
             (None, None)
         };
 
         Ok(Self {
-            diameter: Length::new::<uom::si::length::millimeter>(diameter),
+            diameter: Length::new::<millimeter>(diameter),
             x_axis,
             y_axis,
         })
@@ -94,7 +95,7 @@ impl SerialDeviceNew for Laser {
         params: &SerialDeviceNewParams,
     ) -> Result<(DeviceIdentification, Arc<RwLock<Self>>), anyhow::Error> {
         let laser_data = Some(LaserData {
-            diameter: Length::new::<uom::si::length::millimeter>(0.0),
+            diameter: Length::new::<millimeter>(0.0),
             x_axis: None,
             y_axis: None,
             last_timestamp: Instant::now(),

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "units"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.86"
+
+[lints]
+workspace = true
+
+[dependencies]
+uom = { version = "0.37.0", default-features = false, features = [ "f64" ] }

--- a/units/src/acceleration.rs
+++ b/units/src/acceleration.rs
@@ -1,0 +1,17 @@
+quantity! {
+    /// Acceleration (base unit meter per second squared, m · s⁻²).
+    quantity: Acceleration; "acceleration";
+    /// Dimension of acceleration, LT⁻² (base unit meter per second squared, m · s⁻²).
+    dimension: ISQ<
+        P1,  // length
+        Z0,  // mass
+        N2,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @meter_per_second_squared: 1.0; "m/s²", "meter per second squared", "meters per second squared";
+        @meter_per_minute_per_second: 0.016_666_666_666_666_67; "m/min/s", "meters per minute per second", "meters per minute per second";
+    }
+}

--- a/units/src/amount_of_substance.rs
+++ b/units/src/amount_of_substance.rs
@@ -1,0 +1,16 @@
+quantity! {
+    /// Amount of substance (base unit mole, mol).
+    quantity: AmountOfSubstance; "amount of substance";
+    /// Dimension of amount of substance, N (base unit mole, mol).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        Z0,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        P1,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @mole: 1.0; "mol", "mole", "moles";
+    }
+}

--- a/units/src/angle.rs
+++ b/units/src/angle.rs
@@ -1,0 +1,21 @@
+use super::AngleKind;
+
+quantity! {
+    /// Angle (dimensionless quantity).
+    quantity: Angle; "angle";
+    /// Dimension of angle, 1 (dimensionless).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        Z0,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    kind: dyn AngleKind;
+    units {
+        @radian: 1.0; "rad", "radian", "radians";
+        @degree: 1.745_329_251_994_329_5e-2; "°", "degree", "degrees";
+        @revolution: 6.283_185_307_179_586; "r", "revolution", "revolutions";
+    }
+}

--- a/units/src/angular_acceleration.rs
+++ b/units/src/angular_acceleration.rs
@@ -1,0 +1,22 @@
+use super::AngleKind;
+
+quantity! {
+    /// Angular acceleration (base unit radian per second squared, s⁻²).
+    quantity: AngularAcceleration; "angular acceleration";
+    /// Dimension of angular acceleration, T⁻² (base unit radian per second squared, s⁻²).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        N2,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    kind: dyn AngleKind;
+    units {
+        /// Derived unit of angular acceleration.
+        @radian_per_second_squared: 1.0; "rad/s²", "radian per second squared", "radians per second squared";
+        @degree_per_second_squared: 1.745_329_251_994_329_5_E-2; "°/s²", "degree per second squared", "degrees per second squared";
+        @revolution_per_minute_per_second: 0.104_719_755_119_659_77; "rev/min/s", "revolutions per minute per second", "revolutions per minute per second";
+    }
+}

--- a/units/src/angular_jerk.rs
+++ b/units/src/angular_jerk.rs
@@ -1,0 +1,21 @@
+use crate::AngleKind;
+
+quantity! {
+    /// Angular jerk (base unit radian per second cubed, s⁻³).
+    quantity: AngularJerk; "angular jerk";
+    /// Dimension of angular jerk, T⁻³ (base unit radian per second cubed, s⁻³).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        N3,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    kind: dyn AngleKind;
+    units {
+        @radian_per_second_cubed: 1.0; "rad/s³", "radian per second cubed", "radians per second cubed";
+        @degree_per_second_cubed: 1.745_329_251_994_329_5e-2; "°/s³", "degree per second cubed", "degrees per second cubed";
+        @revolution_per_minute_per_second_squared: 0.104_719_755_119_659_77; "rev/min/s²", "revolution per minute per second squared", "revolution per minute per second squared";
+    }
+}

--- a/units/src/angular_velocity.rs
+++ b/units/src/angular_velocity.rs
@@ -1,0 +1,22 @@
+use super::AngleKind;
+
+quantity! {
+    /// Angular velocity (base unit radian per second, s⁻¹).
+    quantity: AngularVelocity; "angular velocity";
+    /// Dimension of angular velocity, T⁻¹ (base unit radian per second, s⁻¹).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        N1,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    kind: dyn AngleKind;
+    units {
+        @radian_per_second: 1.0; "rad/s", "radian per second", "radians per second";
+        @degree_per_second: 1.745_329_251_994_329_5_E-2; "°/s", "degree per second", "degrees per second";
+        @revolution_per_second: 6.283_185_307_179_586; "rps", "revolution per second", "revolutions per second";
+        @revolution_per_minute: 1.047_197_551_196_597_7e-1; "rpm", "revolution per minute", "revolutions per minute";
+    }
+}

--- a/units/src/electric_current.rs
+++ b/units/src/electric_current.rs
@@ -1,0 +1,18 @@
+quantity! {
+    /// Electric current (base unit ampere, A).
+    quantity: ElectricCurrent; "electric current";
+    /// Dimension of electric current, I (base unit ampere, A).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        Z0,  // time
+        P1,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @milliampere: 1.0e-3; "mA", "millampere", "millamperes";
+        @centiampere: 1.0e-2; "cA", "centiampere", "centiamperes";
+        @ampere: 1.0; "A", "ampere", "amperes";
+    }
+}

--- a/units/src/electric_potential.rs
+++ b/units/src/electric_potential.rs
@@ -1,0 +1,17 @@
+quantity! {
+    /// Electric potential (base unit volt, m² · kg · s⁻³ · A⁻¹).
+    quantity: ElectricPotential; "electric potential";
+    /// Dimension of electric potential, L²MT⁻³I⁻¹ (base unit volt, m² · kg · s⁻³ · A⁻¹).
+    dimension: ISQ<
+        P2,  // length
+        P1,  // mass
+        N3,  // time
+        N1,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @centivolt: 1.0e-2; "cV", "centivolt", "centivolts";
+        @volt: 1.0; "V", "volt", "volts";
+    }
+}

--- a/units/src/frequency.rs
+++ b/units/src/frequency.rs
@@ -1,0 +1,19 @@
+quantity! {
+    /// Frequency (base unit hertz, s⁻¹).
+    quantity: Frequency; "frequency";
+    /// Dimension of frequency, T⁻¹ (base unit hertz, s⁻¹).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        N1,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @millihertz: 1.0e-3; "mHz", "millihertz", "millihertz";
+        @centihertz: 1.0e-2; "cHz", "centihertz", "centihertz";
+        @hertz: 1.0; "Hz", "hertz", "hertz";
+        @cycle_per_minute: 1.666_666_666_666_666_6e-2; "1/min", "cycle per minute", "cycles per minute";
+    }
+}

--- a/units/src/jerk.rs
+++ b/units/src/jerk.rs
@@ -1,0 +1,17 @@
+quantity! {
+    /// Jerk (base unit meter per second cubed, m · s⁻³).
+    quantity: Jerk; "jerk";
+    /// Dimension of jerk, LT⁻³ (base unit meter per second cubed, m · s⁻³).
+    dimension: ISQ<
+        P1,  // length
+        Z0,  // mass
+        N3,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @meter_per_second_cubed: 1.0; "m/s³", "meter per second cubed", "meters per second cubed";
+        @meter_per_minute_per_second_squared: 0.016_666_666_666_666_666_67; "m/min/s²", "meters per minute per second squared", "meters per minute per second squared";
+    }
+}

--- a/units/src/length.rs
+++ b/units/src/length.rs
@@ -1,0 +1,18 @@
+quantity! {
+    /// Length (base unit meter, m).
+    quantity: Length; "length";
+    /// Length dimension, m.
+    dimension: ISQ<
+        P1,  // length
+        Z0,  // mass
+        Z0,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @millimeter: 1.0e-3; "mm", "millimeter", "millimeters";
+        @centimeter: 1.0e-2; "cm", "centimeter", "centimeters";
+        @meter: 1.0; "m", "meter", "meters";
+    }
+}

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -1,0 +1,65 @@
+use uom::Kind;
+
+#[macro_use]
+extern crate uom;
+
+system! {
+    quantities: ISQ {
+        /// Length, one of the base quantities in the ISQ, denoted by the symbol L. The base unit
+        /// for length is meter in the SI.
+        length: meter, L;
+        /// Mass, one of the base quantities in the ISQ, denoted by the symbol M. The base unit
+        /// for mass is kilogram in the SI.
+        mass: kilogram, M;
+        /// Time, one of the base quantities in the ISQ, denoted by the symbol T. The base unit
+        /// for time is second in the SI.
+        time: second, T;
+        /// Electric current, one of the base quantities in the ISQ, denoted by the symbol I. The
+        /// base unit for electric current is ampere in the SI.
+        electric_current: ampere, I;
+        /// Thermodynamic temperature, one of the base quantities in the ISQ, denoted by the symbol
+        /// Th (Θ). The base unit for thermodynamic temperature is kelvin in the SI.
+        thermodynamic_temperature: kelvin, Th;
+        /// Amount of substance, one of the base quantities in the ISQ, denoted by the symbol N.
+        /// The base unit for amount of substance is mole in the SI.
+        amount_of_substance: mole, N;
+        /// Luminous intensity, one of the base quantities in the ISQ, denoted by the symbol J. The
+        /// base unit for luminous intensity is candela in the SI.
+        luminous_intensity: candela, J;
+    }
+
+    units: U {
+        acceleration::Acceleration,
+        amount_of_substance::AmountOfSubstance,
+        angle::Angle,
+        angular_acceleration::AngularAcceleration,
+        angular_jerk::AngularJerk,
+        angular_velocity::AngularVelocity,
+        electric_current::ElectricCurrent,
+        electric_potential::ElectricPotential,
+        frequency::Frequency,
+        jerk::Jerk,
+        length::Length,
+        luminous_intensity::LuminousIntensity,
+        mass::Mass,
+        pressure::Pressure,
+        ratio::Ratio,
+        thermodynamic_temperature::ThermodynamicTemperature,
+        time::Time,
+        velocity::Velocity,
+        volume_rate::VolumeRate,
+    }
+}
+
+pub trait AngleKind: Kind {}
+
+pub mod f64 {
+    mod mks {
+        pub use super::super::*;
+    }
+
+    ISQ!(self::mks, f64);
+}
+
+pub use f64::*;
+pub use uom::ConstZero;

--- a/units/src/luminous_intensity.rs
+++ b/units/src/luminous_intensity.rs
@@ -1,0 +1,16 @@
+quantity! {
+    /// Luminous intensity (base unit candela, cd).
+    quantity: LuminousIntensity; "luminous intensity";
+    /// Dimension of luminous intensity, J (base unit candela, cd).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        Z0,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        P1>; // luminous intensity
+    units {
+        @candela: 1.0; "cd", "candela", "candelas";
+    }
+}

--- a/units/src/mass.rs
+++ b/units/src/mass.rs
@@ -1,0 +1,16 @@
+quantity! {
+    /// Mass (base unit kilogram, kg).
+    quantity: Mass; "mass";
+    /// Mass dimension, kg.
+    dimension: ISQ<
+        Z0,  // length
+        P1,  // mass
+        Z0,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @kilogram: 1.0; "kg", "kilogram", "kilograms";
+    }
+}

--- a/units/src/pressure.rs
+++ b/units/src/pressure.rs
@@ -1,0 +1,17 @@
+quantity! {
+    /// Pressure (base unit pascal, kg · m⁻¹ · s⁻²).
+    quantity: Pressure; "pressure";
+    /// Dimension of pressure, L⁻¹MT⁻² (base unit pascal, kg · m⁻¹ · s⁻²).
+    dimension: ISQ<
+        N1,  // length
+        P1,  // mass
+        N2,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @pascal: 1.0; "Pa", "pascal", "pascals";
+        @bar: 1.0e5; "bar", "bar", "bar";
+    }
+}

--- a/units/src/ratio.rs
+++ b/units/src/ratio.rs
@@ -1,0 +1,17 @@
+quantity! {
+    /// Ratio (dimensionless quantity).
+    quantity: Ratio; "ratio";
+    /// Dimension of ratio, 1 (dimensionless).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        Z0,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        /// ratio
+        @ratio: 1.0; "", "", "";
+    }
+}

--- a/units/src/thermodynamic_temperature.rs
+++ b/units/src/thermodynamic_temperature.rs
@@ -1,0 +1,17 @@
+quantity! {
+    /// Thermodynamic temperature (base unit kelvin, K).
+    quantity: ThermodynamicTemperature; "thermodynamic temperature";
+    /// Dimension of thermodynamic temperature, Th (base unit kelvin, K).
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        Z0,  // time
+        Z0,  // electric current
+        P1,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @kelvin: 1.0; "K", "kelvin", "kelvins";
+        @degree_celsius: 1.0_E0, 273.15_E0; "°C", "degree Celsius", "degrees Celsius";
+    }
+}

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -1,0 +1,16 @@
+quantity! {
+    /// Time (base unit second, s).
+    quantity: Time; "time";
+    /// Time dimension, s.
+    dimension: ISQ<
+        Z0,  // length
+        Z0,  // mass
+        P1,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @second: 1.0; "s", "second", "seconds";
+    }
+}

--- a/units/src/velocity.rs
+++ b/units/src/velocity.rs
@@ -1,0 +1,18 @@
+quantity! {
+    /// Velocity (base unit meter per second, m · s⁻¹).
+    quantity: Velocity; "velocity";
+    /// Dimension of velocity, LT⁻¹ (base unit meter per second, m · s⁻¹).
+    dimension: ISQ<
+        P1,  // length
+        Z0,  // mass
+        N1,  // time
+        Z0,  // electric current
+        Z0,  // thermodynamic temperature
+        Z0,  // amount of substance
+        Z0>; // luminous intensity
+    units {
+        @millimeter_per_second: 1.0e-3; "mm/s", "millimeter per second", "millimeters per second";
+        @meter_per_second: 1.0; "m/s", "meter per second", "meters per second";
+        @meter_per_minute: 0.016_666_666_666_666_67; "m/min", "meters per minute", "meters per minute";
+    }
+}

--- a/units/src/volume_rate.rs
+++ b/units/src/volume_rate.rs
@@ -1,0 +1,18 @@
+quantity! {
+    /// Volume rate (base unit cubic meter per second, m³ · s⁻¹).
+    quantity: VolumeRate; "volume rate";
+    /// Dimension of volume rate, L³T⁻¹ (base unit cubic meter per second, m³ · s⁻¹).
+    dimension: ISQ<
+        P3,     // length
+        Z0,     // mass
+        N1,     // time
+        Z0,     // electric current
+        Z0,     // thermodynamic temperature
+        Z0,     // amount of substance
+        Z0>;    // luminous intensity
+    units {
+        @cubic_meter_per_second: 1.0; "m³/s", "cubic meter per second", "cubic meters per second";
+        @liter_per_second: 1.0e-3; "L/s", "liter per second", "liters per second";
+        @liter_per_minute: 1.0e-3 / 6.0_E1; "L/min", "liter per minute", "liters per minute";
+    }
+}


### PR DESCRIPTION
Closes #789 

uom now has all its built-in units disabled. Instead, the new `units` subcrate contains a minimal set of units thats now being used by all other subcrates.

The `uom_extensions` have been swallowed by the units crate.