### PR TITLE
916 when assigning the ethercat terminals no keyboard is showing up

### DIFF
--- a/electron/src/setup/DeviceEepromDialog.tsx
+++ b/electron/src/setup/DeviceEepromDialog.tsx
@@ -46,7 +46,11 @@ import { toast } from "sonner";
 import { Toast } from "@/components/Toast";
 import { EthercatDevicesEventData } from "@/client/mainNamespace";
 import { TouchNumpad } from "@/components/touch/TouchNumpad";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 type Device = NonNullable<EthercatDevicesEventData["Done"]>["devices"][number];
 
@@ -173,7 +177,10 @@ export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
   // Numpad handlers for serial input
   const numpadHandlers = useMemo(() => {
     const ensureFocus = () => {
-      if (serialInputRef.current && document.activeElement !== serialInputRef.current) {
+      if (
+        serialInputRef.current &&
+        document.activeElement !== serialInputRef.current
+      ) {
         serialInputRef.current.focus();
       }
     };
@@ -199,7 +206,8 @@ export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
         const start = input.selectionStart || 0;
         const end = input.selectionEnd || 0;
         const currentValue = getCurrentValue();
-        const newValue = currentValue.slice(0, start) + digit + currentValue.slice(end);
+        const newValue =
+          currentValue.slice(0, start) + digit + currentValue.slice(end);
 
         form.setValue("serial", newValue, { shouldValidate: true });
         updateCursorPosition(start + 1);
@@ -228,7 +236,8 @@ export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
           newPosition = start;
         } else if (start > 0) {
           // Backspace
-          newValue = currentValue.slice(0, start - 1) + currentValue.slice(start);
+          newValue =
+            currentValue.slice(0, start - 1) + currentValue.slice(start);
           newPosition = start - 1;
         } else {
           return;
@@ -248,7 +257,10 @@ export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
         ensureFocus();
         const currentPos = serialInputRef.current.selectionStart || 0;
         if (currentPos > 0) {
-          serialInputRef.current.setSelectionRange(currentPos - 1, currentPos - 1);
+          serialInputRef.current.setSelectionRange(
+            currentPos - 1,
+            currentPos - 1,
+          );
         }
       },
 
@@ -259,7 +271,10 @@ export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
         const currentPos = serialInputRef.current.selectionStart || 0;
         const currentValue = getCurrentValue();
         if (currentPos < currentValue.length) {
-          serialInputRef.current.setSelectionRange(currentPos + 1, currentPos + 1);
+          serialInputRef.current.setSelectionRange(
+            currentPos + 1,
+            currentPos + 1,
+          );
         }
       },
     };

--- a/electron/src/setup/DeviceEepromDialog.tsx
+++ b/electron/src/setup/DeviceEepromDialog.tsx
@@ -64,6 +64,7 @@ type FormSchema = z.infer<typeof formSchema>;
 export function DeviceEepromDialog({ device }: Props) {
   const [open, setOpen] = React.useState(false);
   const key = useMemo(() => Math.random(), [open]);
+  const onClose = () => setOpen(false);
 
   return (
     <Dialog
@@ -78,7 +79,7 @@ export function DeviceEepromDialog({ device }: Props) {
           Assign
         </Button>
       </DialogTrigger>
-      <DeviceEeepromDialogContent device={device} key={key} setOpen={setOpen} />
+      <DeviceEeepromDialogContent device={device} key={key} setOpen={onClose} />
     </Dialog>
   );
 }
@@ -86,7 +87,7 @@ export function DeviceEepromDialog({ device }: Props) {
 // (Empty comment block removed)
 type ContentProps = {
   device: Device;
-  setOpen: (open: boolean) => void;
+  setOpen: () => void;
 };
 
 export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
@@ -139,7 +140,7 @@ export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
               Machine assignment written successfully.
             </Toast>,
           );
-          setOpen(false);
+          setOpen();
         }
       });
   };

--- a/electron/src/setup/DeviceEepromDialog.tsx
+++ b/electron/src/setup/DeviceEepromDialog.tsx
@@ -348,6 +348,7 @@ export function DeviceEeepromDialogContent({ device, setOpen }: ContentProps) {
                           type="button"
                           variant="outline"
                           size="icon"
+                          aria-label="Toggle numpad"
                           onClick={(e) => {
                             e.preventDefault();
                             setNumpadOpen(!numpadOpen);

--- a/electron/src/setup/DeviceEepromDialog.tsx
+++ b/electron/src/setup/DeviceEepromDialog.tsx
@@ -68,13 +68,7 @@ export function DeviceEepromDialog({ device }: Props) {
   return (
     <Dialog
       open={open}
-      onOpenChange={(newOpen) => {
-        setOpen(newOpen);
-        // Close numpad when dialog closes
-        if (!newOpen) {
-          // This will be handled by the key change resetting the component
-        }
-      }}
+      onOpenChange={setOpen}
       // Prevent closing via Escape to keep numpad open while interacting
       modal
     >


### PR DESCRIPTION
## Add Touch Numpad to EtherCAT Device Assignment Dialog

### What Changed

I've added a touch-friendly numpad to the serial number input field in the EtherCAT device assignment dialog. This makes it much easier to enter serial numbers when working with touchscreens or when you prefer using a numpad instead of typing on a keyboard..

### How It Works

- When you click on the serial number input field, a numpad automatically appears in a popover
- You can also manually open/close it using the calculator icon button next to the input
- The numpad supports:
  - Number input (0-9)
  - Delete/backspace
  - Cursor movement (left/right arrows)
- All input is directly synchronized with the form field and validation still works as expected

### Technical Details

- Reuses the existing `TouchNumpad` component that's already used in other parts of the application
- Integrated with react-hook-form to maintain form validation
- Properly handles cursor position and focus management
- The numpad handlers work seamlessly with the form state

### Testing

Tested the numpad functionality in the EtherCAT setup page:
1. Open the device assignment dialog
2. Click on the serial number field - numpad should appear
3. Enter numbers using the numpad
4. Verify form validation still works correctly