### PR TITLE
Fix modbus discovery

### DIFF
--- a/control-core/src/ethernet/modbus_tcp_discovery.rs
+++ b/control-core/src/ethernet/modbus_tcp_discovery.rs
@@ -47,7 +47,7 @@ async fn probe_modbus_tcp_addresses(interface: Interface) -> Vec<ModbusTcpProbe>
             let prefix = min(24, m.count_ones()); // mask → prefix length
             let size = 1u32 << (32 - prefix); // number of addresses
 
-            (200..size).map(move |i| SocketAddr::new(Ipv4Addr::from(network + i).into(), 502))
+            (0..size).map(move |i| SocketAddr::new(Ipv4Addr::from(network + i).into(), 502))
         })
         .map(|addr| smol::spawn(ping_modbus_device(addr)))
         .join_all()

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,8 @@
 
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
+            cargo
+            rustc
             pkg-config
             libudev-zero
             libpcap


### PR DESCRIPTION
Seems like we both (me an @kraemr) missed it: I had it not search all addresses because this was to slow until I fixed the timeout. This change now checks all addresses of each interface - does not skip 200.