### PR TITLE
Fixed fullscreen not working on user machines

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -30,7 +30,7 @@ if (!gotTheLock) {
 }
 
 function createWindow() {
-  const preload = path.join(DIR, "preload.js");
+  const preload = path.resolve(DIR, "preload.js");
   console.log("Setting preload.js to", preload);
 
   const mainWindow = new BrowserWindow({


### PR DESCRIPTION
Preload didn't load correctly due to requiring an absolute path.