### PR TITLE
removed excessive logging, simplified socketio task with actual error…

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -15,9 +15,10 @@ use machines::{
     serial::{devices::laser::Laser, init::SerialDetection},
     winder2::api::GenericEvent,
 };
-use socketio::{main_namespace::{
-    MainNamespaceEvents, ethercat_devices_event::EthercatDevicesEventBuilder,
-}, queue::start_socketio_queue};
+use socketio::{
+    main_namespace::{MainNamespaceEvents, ethercat_devices_event::EthercatDevicesEventBuilder},
+    queue::start_socketio_queue,
+};
 
 #[cfg(feature = "development-build")]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -322,7 +323,6 @@ async fn handle_async_requests(recv: Receiver<AsyncThreadMessage>, shared_state:
 
     tracing::warn!("Async handler task finished");
 }
-
 
 #[cfg(feature = "development-build")]
 fn setup_ctrlc_handler() -> Arc<AtomicBool> {

--- a/server/src/socketio/queue.rs
+++ b/server/src/socketio/queue.rs
@@ -1,5 +1,5 @@
 use crate::app_state::SharedState;
-use std::{sync::Arc};
+use std::sync::Arc;
 use tracing::{error, info, instrument, trace};
 
 /// Send a single event with retry logic
@@ -59,15 +59,15 @@ async fn send_event_with_retry(
 }
 
 pub async fn start_socketio_queue(app_state: Arc<SharedState>) {
-    let app_state = app_state.as_ref();    
+    let app_state = app_state.as_ref();
     loop {
         let res = app_state.socketio_setup.socket_queue_rx.recv().await;
         match res {
-            Ok((socket,event)) => send_event_with_retry(&socket, &event).await,
-            Err(e) => {                
+            Ok((socket, event)) => send_event_with_retry(&socket, &event).await,
+            Err(e) => {
                 error!("SocketIO global queue listener stopped: {:?}", e);
                 break;
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
fix #1105
The issue was due to journald being spammed SO FAST that it was under memory pressure and got killed, since we read from journal in frontend, the frontend suffers too ... 
