### PR TITLE
Update export logs button icon to FileDown

### DIFF
--- a/electron/src/setup/Trobleshoot.tsx
+++ b/electron/src/setup/Trobleshoot.tsx
@@ -96,7 +96,7 @@ export function TroubleshootPage() {
 
         <TouchButton
           variant="outline"
-          icon="lu:Power"
+          icon="lu:FileDown"
           isLoading={isExportLoading}
           onClick={exportLogs}
           className="w-max"


### PR DESCRIPTION
This pull request makes a small change to the `TroubleshootPage` component by updating the icon used for the export logs button to better reflect its purpose.

* Changed the export logs button icon from `"lu:Power"` to `"lu:FileDown"` in `Trobleshoot.tsx`.