### PR TITLE
861 winder laser connection

### DIFF
--- a/electron/src/assets/markdown/winder/manual.md
+++ b/electron/src/assets/markdown/winder/manual.md
@@ -518,6 +518,59 @@ All settings such as the position of the spool sides, the winding speed or the f
 
 <br><br>
 
+## 2.3.1 Puller Adaptive Mode
+
+The Puller Adaptive Mode automatically adjusts the puller speed based on live diameter measurements from a connected laser measurement device. This keeps the filament diameter close to the target value without manual speed adjustments.
+
+<br>
+
+**Prerequisites**
+
+Before the adaptive mode can work correctly, two things must be set up:
+
+1. **Set the Puller Target Speed manually first.** Adjust the "Puller Target Speed" slider so that the filament diameter is approximately **1.75 mm** (or your desired target diameter). The adaptive algorithm uses this speed as its base and makes small corrections around it. If the base speed is far off, the adaptive mode cannot compensate enough and will not work properly.
+
+2. **Set a Reference Machine.** In the "Config" tab under "Puller → Adaptive Speed → Reference Machine", select the laser measurement machine that provides the diameter readings. Without a reference machine, the adaptive mode has no diameter data to work with and will not make any adjustments.
+
+<br>
+
+**How it works**
+
+Once the reference machine is set and the base speed produces a diameter close to the target, the adaptive algorithm periodically checks the measured diameter:
+
+- If the diameter is **within** the allowed deviation, no adjustment is made.
+- If the diameter is **too large**, the puller speeds up slightly (pulling the filament thinner).
+- If the diameter is **too small**, the puller slows down slightly (allowing the filament to become thicker).
+
+Adjustments happen in small steps after a configurable distance of filament has been pulled, and the total speed change is limited to prevent overcorrection.
+
+<br>
+
+**Settings**
+
+The following settings can be found under "Config → Puller → Adaptive Speed":
+
+| Setting                        | Description                                                                                                                                                                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Allowed Diameter Deviation** | The acceptable deviation from the target diameter in mm. As long as the measured diameter is within this range, the algorithm considers it "good enough" and does not adjust the speed. A typical value is around 0.02 mm.    |
+| **Max Speed Deviation**        | The maximum percentage the puller speed can deviate from the base speed. This acts as a safety limit — e.g. 25% means the speed will never be adjusted more than 25% above or below the base speed.                          |
+| **Distance Between Steps**     | The minimum distance of filament (in meters) that must be pulled between consecutive speed adjustments. This prevents the algorithm from reacting too quickly and oscillating. A typical starting value is 0.5 m.             |
+| **Change Per Step**            | The size of each speed adjustment as a percentage of the base speed. Smaller values lead to finer, more gradual corrections. A typical starting value is 5%.                                                                 |
+| **Reference Machine**          | The laser measurement machine whose diameter readings are used as input. This must be set for the adaptive mode to function.                                                                                                  |
+
+<br>
+
+**Step-by-step setup**
+
+1. Navigate to "Config" in the function bar
+2. Under "Puller → Adaptive Speed → Reference Machine", select the laser measurement machine
+3. Go to "Control" and set the "Puller Target Speed" so the filament diameter is approximately 1.75 mm
+4. Adjust the adaptive parameters (Allowed Diameter Deviation, Max Speed Deviation, Distance Between Steps, Change Per Step) to your needs, or keep the defaults
+5. Switch the puller regulation mode to "Diameter" to activate the adaptive mode
+6. Start pulling — the speed will now be adjusted automatically based on the laser measurements
+
+<br>
+
 ## 2.4 Maintenance, inspection, Testing
 
 Maintenance and servicing work on the machine may only be carried out by reliable, trained personnel. The minimum age required by law in the country of use must be observed!

--- a/electron/src/assets/markdown/winder/manual.md
+++ b/electron/src/assets/markdown/winder/manual.md
@@ -518,9 +518,24 @@ All settings such as the position of the spool sides, the winding speed or the f
 
 <br><br>
 
-## 2.3.1 Puller Adaptive Mode
+## 2.3.1 Puller Adaptive Mode (Experimental)
+
+> **⚠ Experimental Feature**
+> The Puller Adaptive Mode is an experimental feature that is still in development. It may cause unexpected behavior and will be improved in future updates. You must explicitly enable it in the settings before it becomes available.
 
 The Puller Adaptive Mode automatically adjusts the puller speed based on live diameter measurements from a connected laser measurement device. This keeps the filament diameter close to the target value without manual speed adjustments.
+
+<br>
+
+**Enabling the feature**
+
+The adaptive puller speed mode is disabled by default. To enable it:
+
+1. Navigate to "Config" in the function bar
+2. Under "Puller", find the **"Adaptive Speed (Experimental)"** toggle
+3. Switch it to **"Enabled"**
+
+Once enabled, the adaptive speed settings and the "Adaptive" regulation mode option on the Control page become available. When disabled, the "Adaptive" option is hidden and only the "Fixed" speed regulation mode can be used.
 
 <br>
 
@@ -528,9 +543,9 @@ The Puller Adaptive Mode automatically adjusts the puller speed based on live di
 
 Before the adaptive mode can work correctly, two things must be set up:
 
-1. **Set the Puller Target Speed manually first.** Adjust the "Puller Target Speed" slider so that the filament diameter is approximately **1.75 mm** (or your desired target diameter). The adaptive algorithm uses this speed as its base and makes small corrections around it. If the base speed is far off, the adaptive mode cannot compensate enough and will not work properly.
+1. **Set the Puller Target Speed manually first.** While in "Fixed" regulation mode, adjust the "Puller Target Speed" slider so that the filament diameter is approximately **1.75 mm** (or your desired target diameter). When you switch to "Adaptive" mode, the current fixed target speed is automatically used as the base speed. The adaptive algorithm makes small corrections around this base speed. If the base speed is far off, the adaptive mode cannot compensate enough and will not work properly. **The base speed can only be changed by switching back to "Fixed" mode, setting a new target speed, and then switching to "Adaptive" mode again.**
 
-2. **Set a Reference Machine.** In the "Config" tab under "Puller → Adaptive Speed → Reference Machine", select the laser measurement machine that provides the diameter readings. Without a reference machine, the adaptive mode has no diameter data to work with and will not make any adjustments.
+2. **Set a Reference Machine.** In the "Config" tab under "Puller → Adaptive Speed → Reference Machine", select the laser measurement machine that provides the diameter readings. Without a reference machine, the adaptive mode has no diameter data to work with and the "Adaptive" option on the Control page will be disabled.
 
 <br>
 
@@ -548,26 +563,30 @@ Adjustments happen in small steps after a configurable distance of filament has 
 
 **Settings**
 
-The following settings can be found under "Config → Puller → Adaptive Speed":
+The following settings can be found under "Config → Puller → Adaptive Speed" (only visible when the experimental feature is enabled):
 
-| Setting                        | Description                                                                                                                                                                                                                   |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Allowed Diameter Deviation** | The acceptable deviation from the target diameter in mm. As long as the measured diameter is within this range, the algorithm considers it "good enough" and does not adjust the speed. A typical value is around 0.02 mm.    |
-| **Max Speed Deviation**        | The maximum percentage the puller speed can deviate from the base speed. This acts as a safety limit — e.g. 25% means the speed will never be adjusted more than 25% above or below the base speed.                          |
-| **Distance Between Steps**     | The minimum distance of filament (in meters) that must be pulled between consecutive speed adjustments. This prevents the algorithm from reacting too quickly and oscillating. A typical starting value is 0.5 m.             |
-| **Change Per Step**            | The size of each speed adjustment as a percentage of the base speed. Smaller values lead to finer, more gradual corrections. A typical starting value is 5%.                                                                 |
-| **Reference Machine**          | The laser measurement machine whose diameter readings are used as input. This must be set for the adaptive mode to function.                                                                                                  |
+| Setting                        | Description                                                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Allowed Diameter Deviation** | The acceptable deviation from the target diameter in mm. As long as the measured diameter is within this range, the algorithm considers it "good enough" and does not adjust the speed. A typical value is around 0.02 mm.                                                                                                                                                            |
+| **Max Speed Deviation**        | The maximum percentage the puller speed can deviate from the base speed. This acts as a safety limit — e.g. 25% means the speed will never be adjusted more than 25% above or below the base speed. **This setting can only be changed while in "Fixed" speed regulation mode.** When in "Adaptive" mode, the value is locked to prevent unintended changes during active regulation. |
+| **Distance Between Steps**     | The minimum distance of filament (in meters) that must be pulled between consecutive speed adjustments. This prevents the algorithm from reacting too quickly and oscillating. A typical starting value is about the distance between the extruder and the laser sensor.                                                                                                              |
+| **Change Per Step**            | The size of each speed adjustment as a percentage of the base speed. Smaller values lead to finer, more gradual corrections. A typical starting value is 3.5%.                                                                                                                                                                                                                        |
+| **Reference Machine**          | The laser measurement machine whose diameter readings are used as input. This must be set for the adaptive mode to function.                                                                                                                                                                                                                                                          |
 
 <br>
 
 **Step-by-step setup**
 
 1. Navigate to "Config" in the function bar
-2. Under "Puller → Adaptive Speed → Reference Machine", select the laser measurement machine
-3. Go to "Control" and set the "Puller Target Speed" so the filament diameter is approximately 1.75 mm
-4. Adjust the adaptive parameters (Allowed Diameter Deviation, Max Speed Deviation, Distance Between Steps, Change Per Step) to your needs, or keep the defaults
-5. Switch the puller regulation mode to "Diameter" to activate the adaptive mode
-6. Start pulling — the speed will now be adjusted automatically based on the laser measurements
+2. Under "Puller", enable the **"Adaptive Speed (Experimental)"** toggle
+3. Under "Puller → Adaptive Speed → Reference Machine", select the laser measurement machine
+4. Go to "Control" and ensure the regulation mode is set to "Fixed"
+5. Set the "Puller Target Speed" so the filament diameter is approximately 1.75 mm — this will become the base speed for the adaptive algorithm
+6. Optionally adjust the adaptive parameters (Allowed Diameter Deviation, Max Speed Deviation, Distance Between Steps, Change Per Step) to your needs, or keep the defaults. Note that **Max Speed Deviation must be configured while still in "Fixed" mode**
+7. Switch the puller regulation mode to "Adaptive" to activate the adaptive mode
+8. Start pulling — the speed will now be adjusted automatically based on the laser measurements
+
+> **Tip:** If the adaptive mode is not producing the desired results, switch back to "Fixed" mode, adjust the target speed to get closer to the desired diameter, then switch back to "Adaptive" mode. The new target speed will be used as the updated base speed.
 
 <br>
 

--- a/electron/src/control/EditValue.tsx
+++ b/electron/src/control/EditValue.tsx
@@ -38,6 +38,7 @@ type Props = {
   step?: number;
   inverted?: boolean;
   confirmation?: string;
+  disabled?: boolean;
   renderValue: (value: number) => string;
   onChange?: (value: number) => void;
 };
@@ -96,6 +97,7 @@ export function EditValue({
   minSlider,
   maxSlider,
   confirmation,
+  disabled,
   onChange,
 }: Props) {
   const defaultOrZero = defaultValue ?? 0;
@@ -475,7 +477,7 @@ export function EditValue({
         <TouchButton
           className={buttonStyle({ open, class: "py-4" })}
           variant="outline"
-          disabled={!valueIsDefined}
+          disabled={!valueIsDefined || disabled}
         >
           <div className="flex flex-row items-center gap-2">
             <span className="font-mono text-4xl font-bold">

--- a/electron/src/machines/winder/MachineSelector.tsx
+++ b/electron/src/machines/winder/MachineSelector.tsx
@@ -48,61 +48,60 @@ export const MachineSelector: React.FC<MachineSelectorProps> = ({
 }) => {
   return (
     <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-            <button className="flex items-center gap-2 rounded border px-4 py-2 text-left">
-              <Icon name="lu:Settings" className="text-xl" />
+      <DropdownMenuTrigger asChild>
+        <button className="flex items-center gap-2 rounded border px-4 py-2 text-left">
+          <Icon name="lu:Settings" className="text-xl" />
+          <span>
+            {selectedMachine?.name ?? "Select a Machine"}{" "}
+            {selectedMachine?.machine_identification_unique.serial ?? ""}
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>Available Machines</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {machines.map((machine) => {
+          const isSelected =
+            connectedMachineState?.machine_identification.machine ===
+            machine.machine_identification_unique.machine_identification
+              .machine;
+
+          return (
+            <DropdownMenuItem
+              key={machine.machine_identification_unique.serial}
+              onClick={() =>
+                setConnectedMachine(machine.machine_identification_unique)
+              }
+              className={`flex min-h-[48px] cursor-pointer items-center gap-2 py-2${
+                isSelected ? "bg-blue-50" : ""
+              }`}
+            >
+              {connectedMachineState != null ? (
+                <Icon name="lu:Power" className="text-lg text-green-600" />
+              ) : (
+                <Icon name="lu:Power" className="text-lg text-gray-400" />
+              )}
               <span>
-                  {selectedMachine?.name ?? "Select a Machine"}{" "}
-                  {selectedMachine?.machine_identification_unique.serial ?? ""}
+                {machine.name} – Serial:{" "}
+                {machine.machine_identification_unique.serial}
               </span>
-            </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-            <DropdownMenuLabel>Available Machines</DropdownMenuLabel>
+            </DropdownMenuItem>
+          );
+        })}
+
+        {clearConnectedMachine && (
+          <>
             <DropdownMenuSeparator />
-            {machines.map((machine) => {
-            const isSelected =
-                connectedMachineState
-                ?.machine_identification.machine ===
-                machine.machine_identification_unique.machine_identification
-                .machine;
-
-            return (
-                <DropdownMenuItem
-                key={machine.machine_identification_unique.serial}
-                onClick={() =>
-                    setConnectedMachine(machine.machine_identification_unique)
-                }
-                className={`flex min-h-[48px] cursor-pointer items-center gap-2 py-2${
-                    isSelected ? "bg-blue-50" : ""
-                }`}
-                >
-                {connectedMachineState != null ? (
-                    <Icon name="lu:Power" className="text-lg text-green-600" />
-                ) : (
-                    <Icon name="lu:Power" className="text-lg text-gray-400" />
-                )}
-                <span>
-                    {machine.name} – Serial:{" "}
-                    {machine.machine_identification_unique.serial}
-                </span>
-                </DropdownMenuItem>
-            );
-            })}
-
-            {clearConnectedMachine && (
-            <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                onClick={clearConnectedMachine}
-                className="flex cursor-pointer items-center gap-2 text-red-600 hover:text-red-600"
-                >
-                <Icon name="lu:Settings" className="text-lg" />
-                <span>Clear Selection</span>
-                </DropdownMenuItem>
-            </>
-            )}
-        </DropdownMenuContent>
+            <DropdownMenuItem
+              onClick={clearConnectedMachine}
+              className="flex cursor-pointer items-center gap-2 text-red-600 hover:text-red-600"
+            >
+              <Icon name="lu:Settings" className="text-lg" />
+              <span>Clear Selection</span>
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
     </DropdownMenu>
   );
 };

--- a/electron/src/machines/winder/MachineSelector.tsx
+++ b/electron/src/machines/winder/MachineSelector.tsx
@@ -1,0 +1,108 @@
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+import React from "react";
+
+import { Icon } from "@/components/Icon";
+
+interface MachineIdentificationUnique {
+  machine_identification: {
+    vendor: number;
+    machine: number;
+  };
+  serial: number;
+}
+
+interface Machine {
+  name: string;
+  machine_identification_unique: MachineIdentificationUnique;
+}
+
+interface MachineSelectorProps {
+  machines: Machine[];
+  selectedMachine?: Machine | null;
+  connectedMachineState?: {
+    machine_identification: {
+      vendor: number;
+      machine: number;
+    };
+    serial: number;
+  } | null;
+  setConnectedMachine: (machine: MachineIdentificationUnique) => void;
+  clearConnectedMachine?: () => void;
+  title?: string;
+}
+
+export const MachineSelector: React.FC<MachineSelectorProps> = ({
+  machines,
+  selectedMachine,
+  connectedMachineState,
+  setConnectedMachine,
+  clearConnectedMachine,
+}) => {
+  return (
+    <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+            <button className="flex items-center gap-2 rounded border px-4 py-2 text-left">
+              <Icon name="lu:Settings" className="text-xl" />
+              <span>
+                  {selectedMachine?.name ?? "Select a Machine"}{" "}
+                  {selectedMachine?.machine_identification_unique.serial ?? ""}
+              </span>
+            </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+            <DropdownMenuLabel>Available Machines</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {machines.map((machine) => {
+            const isSelected =
+                connectedMachineState
+                ?.machine_identification.machine ===
+                machine.machine_identification_unique.machine_identification
+                .machine;
+
+            return (
+                <DropdownMenuItem
+                key={machine.machine_identification_unique.serial}
+                onClick={() =>
+                    setConnectedMachine(machine.machine_identification_unique)
+                }
+                className={`flex min-h-[48px] cursor-pointer items-center gap-2 py-2${
+                    isSelected ? "bg-blue-50" : ""
+                }`}
+                >
+                {connectedMachineState != null ? (
+                    <Icon name="lu:Power" className="text-lg text-green-600" />
+                ) : (
+                    <Icon name="lu:Power" className="text-lg text-gray-400" />
+                )}
+                <span>
+                    {machine.name} – Serial:{" "}
+                    {machine.machine_identification_unique.serial}
+                </span>
+                </DropdownMenuItem>
+            );
+            })}
+
+            {clearConnectedMachine && (
+            <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                onClick={clearConnectedMachine}
+                className="flex cursor-pointer items-center gap-2 text-red-600 hover:text-red-600"
+                >
+                <Icon name="lu:Settings" className="text-lg" />
+                <span>Clear Selection</span>
+                </DropdownMenuItem>
+            </>
+            )}
+        </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -325,17 +325,17 @@ export function Winder2ControlPage() {
 
           {state?.puller_state?.regulation === "Diameter" && (
             <Label label="Base Speed">
-              <EditValue
-                value={state?.puller_state?.adaptive_speed_base}
-                title={"Base Speed"}
-                unit="m/min"
-                step={0.1}
-                min={0}
-                max={maxTargetSpeed}
-                defaultValue={defaultState?.puller_state?.adaptive_speed_base}
-                renderValue={(value) => roundToDecimals(value, 1)}
-                onChange={(value) => setPullerAdaptiveBaseSpeed(value)}
-              />
+              <div className="flex flex-row items-center gap-2 py-4">
+                <span className="font-mono text-4xl font-bold">
+                  {state?.puller_state?.adaptive_speed_base != null
+                    ? roundToDecimals(
+                        state.puller_state.adaptive_speed_base,
+                        1,
+                      )
+                    : "–"}
+                </span>
+                <span>m/min</span>
+              </div>
             </Label>
           )}
         </ControlCard>

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -280,7 +280,7 @@ export function Winder2ControlPage() {
                         children: "Adaptive",
                         icon: "lu:Brain",
                         disabled:
-                          state?.puller_state?.adaptive_reference_machine,
+                          !state?.puller_state?.adaptive_reference_machine,
                       },
                     }
                   : {}),

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -29,7 +29,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { getWinder2TraverseMax } from "./winder2Config";
-import { MachineSelector } from "../MachineSelector";
 
 export function Winder2ControlPage() {
   const [showResetConfirmDialog, setShowResetConfirmDialog] = useState(false);
@@ -59,13 +58,9 @@ export function Winder2ControlPage() {
     setSpoolAutomaticAction,
     isLoading,
     isDisabled,
-    filteredMachines,
-    selectedMachine,
 
     // new stuff
     setPullerAdaptiveBaseSpeed,
-    setPullerAdaptiveDeviationLimit,
-    setPullerAdaptiveReferenceMachine,
   } = useWinder2();
 
   // Calculate max speed based on gear ratio
@@ -284,7 +279,18 @@ export function Winder2ControlPage() {
                   icon: "lu:Brain",
                 },
               }}
-              onChange={(value) => setPullerRegulationMode(value)}
+              onChange={(value) => {
+                // When switching to adaptive mode, seed the base speed from the
+                // current fixed target speed so there is no jump.
+                if (
+                  value === "Diameter" &&
+                  state?.puller_state?.regulation !== "Diameter"
+                ) {
+                  const currentTarget = state?.puller_state?.target_speed ?? 0;
+                  setPullerAdaptiveBaseSpeed(currentTarget);
+                }
+                setPullerRegulationMode(value);
+              }}
             />
           </Label>
 
@@ -307,99 +313,19 @@ export function Winder2ControlPage() {
           )}
 
           {state?.puller_state?.regulation === "Diameter" && (
-            <>
-              <Label label="Base Speed">
-                <EditValue
-                  value={state?.puller_state?.adaptive_speed_base}
-                  title={"Base Speed"}
-                  unit="m/min"
-                  step={0.1}
-                  min={0}
-                  max={maxTargetSpeed}
-                  defaultValue={defaultState?.puller_state?.adaptive_speed_base}
-                  renderValue={(value) => roundToDecimals(value, 1)}
-                  onChange={(value) => setPullerAdaptiveBaseSpeed(value)}
-                />
-              </Label>
-
-              <div className="flex flex-row flex-wrap gap-4">
-                <Label label="Deviation Limit (fixed)">
-                  <EditValue
-                    value={state?.puller_state?.adaptive_deviation_limit}
-                    title={"Deviation Limit (fixed)"}
-                    unit="m/min"
-                    step={0.1}
-                    min={0.0}
-                    max={(() => {
-                      const base = state.puller_state?.adaptive_speed_base;
-                      const max = maxTargetSpeed;
-
-                      // limit is towards upper bound
-                      if (base > max / 2) {
-                        return max - base;
-                      }
-
-                      // limit is towards lower bound
-                      return base;
-                    })()}
-                    defaultValue={0.0}
-                    renderValue={(value) => roundToDecimals(value, 1)}
-                    onChange={(value) => setPullerAdaptiveDeviationLimit(value)}
-                  />
-                </Label>
-                <Label label="Deviation Limit (relative)">
-                  <EditValue
-                    value={(() => {
-                      const base = state?.puller_state?.adaptive_speed_base;
-                      const deviation =
-                        state?.puller_state?.adaptive_deviation_limit;
-                      if (base <= 0) return 0;
-                      return (deviation / base) * 100;
-                    })()}
-                    title={"Deviation Limit (relative)"}
-                    unit="%"
-                    step={0.5}
-                    min={0.0}
-                    max={(() => {
-                      const base = state?.puller_state?.adaptive_speed_base;
-                      const max = maxTargetSpeed;
-                      const mid = max / 2;
-
-                      // limit is towards lower bound
-                      if (base < mid) {
-                        return 100.0;
-                      }
-
-                      // limit is towards upper bound
-                      return ((max - base) / base) * 100.0;
-                    })()}
-                    defaultValue={0.0}
-                    renderValue={(value) => roundToDecimals(value, 1)}
-                    onChange={(value) => {
-                      const base = state?.puller_state?.adaptive_speed_base;
-                      const velocity = base * (value / 100);
-                      setPullerAdaptiveDeviationLimit(velocity);
-                    }}
-                  />
-                </Label>
-              </div>
-              <Label label="Reference Machine">
-                <MachineSelector
-                  machines={filteredMachines}
-                  selectedMachine={selectedMachine}
-                  connectedMachineState={
-                    state?.puller_state.adaptive_reference_machine
-                  }
-                  setConnectedMachine={(machine) => {
-                    setPullerAdaptiveReferenceMachine(machine);
-                  }}
-                  clearConnectedMachine={() => {
-                    if (!selectedMachine) return;
-                    setPullerAdaptiveReferenceMachine(null);
-                  }}
-                />
-              </Label>
-            </>
+            <Label label="Base Speed">
+              <EditValue
+                value={state?.puller_state?.adaptive_speed_base}
+                title={"Base Speed"}
+                unit="m/min"
+                step={0.1}
+                min={0}
+                max={maxTargetSpeed}
+                defaultValue={defaultState?.puller_state?.adaptive_speed_base}
+                renderValue={(value) => roundToDecimals(value, 1)}
+                onChange={(value) => setPullerAdaptiveBaseSpeed(value)}
+              />
+            </Label>
           )}
         </ControlCard>
 

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -284,14 +284,11 @@ export function Winder2ControlPage() {
                   icon: "lu:Brain",
                 },
               }}
-              onChange={(value) =>
-                setPullerRegulationMode(value)
-              }
+              onChange={(value) => setPullerRegulationMode(value)}
             />
           </Label>
 
-          {state?.puller_state?.regulation ===
-            "Speed" && (
+          {state?.puller_state?.regulation === "Speed" && (
             <>
               <Label label="Target Speed">
                 <EditValue
@@ -301,9 +298,7 @@ export function Winder2ControlPage() {
                   step={0.1}
                   min={0}
                   max={maxTargetSpeed}
-                  defaultValue={
-                    defaultState?.puller_state?.target_speed
-                  }
+                  defaultValue={defaultState?.puller_state?.target_speed}
                   renderValue={(value) => roundToDecimals(value, 1)}
                   onChange={(value) => setPullerTargetSpeed(value)}
                 />
@@ -311,8 +306,7 @@ export function Winder2ControlPage() {
             </>
           )}
 
-          {state?.puller_state?.regulation ===
-            "Diameter" && (
+          {state?.puller_state?.regulation === "Diameter" && (
             <>
               <Label label="Base Speed">
                 <EditValue
@@ -322,9 +316,7 @@ export function Winder2ControlPage() {
                   step={0.1}
                   min={0}
                   max={maxTargetSpeed}
-                  defaultValue={
-                    defaultState?.puller_state?.adaptive_speed_base
-                  }
+                  defaultValue={defaultState?.puller_state?.adaptive_speed_base}
                   renderValue={(value) => roundToDecimals(value, 1)}
                   onChange={(value) => setPullerAdaptiveBaseSpeed(value)}
                 />
@@ -338,18 +330,18 @@ export function Winder2ControlPage() {
                     unit="m/min"
                     step={0.1}
                     min={0.0}
-                    max={                    
-                      (() => {
-                        const base = state.puller_state?.adaptive_speed_base;
-                        const max  = maxTargetSpeed;
+                    max={(() => {
+                      const base = state.puller_state?.adaptive_speed_base;
+                      const max = maxTargetSpeed;
 
-                        // limit is towards upper bound
-                        if (base > max / 2) { return max - base; }
+                      // limit is towards upper bound
+                      if (base > max / 2) {
+                        return max - base;
+                      }
 
-                        // limit is towards lower bound
-                        return base;
-                      })()
-                    }
+                      // limit is towards lower bound
+                      return base;
+                    })()}
                     defaultValue={0.0}
                     renderValue={(value) => roundToDecimals(value, 1)}
                     onChange={(value) => setPullerAdaptiveDeviationLimit(value)}
@@ -359,7 +351,8 @@ export function Winder2ControlPage() {
                   <EditValue
                     value={(() => {
                       const base = state?.puller_state?.adaptive_speed_base;
-                      const deviation = state?.puller_state?.adaptive_deviation_limit;
+                      const deviation =
+                        state?.puller_state?.adaptive_deviation_limit;
                       if (base <= 0) return 0;
                       return (deviation / base) * 100;
                     })()}
@@ -367,25 +360,25 @@ export function Winder2ControlPage() {
                     unit="%"
                     step={0.5}
                     min={0.0}
-                    max={                    
-                      (() => {
-                        const base = state?.puller_state?.adaptive_speed_base;
-                        const max  = maxTargetSpeed;
-                        const mid  = max / 2;
+                    max={(() => {
+                      const base = state?.puller_state?.adaptive_speed_base;
+                      const max = maxTargetSpeed;
+                      const mid = max / 2;
 
-                        // limit is towards lower bound
-                        if (base < mid) { return 100.0; }
+                      // limit is towards lower bound
+                      if (base < mid) {
+                        return 100.0;
+                      }
 
-                        // limit is towards upper bound
-                        return (max - base) / base * 100.0;
-                      })()
-                    }
+                      // limit is towards upper bound
+                      return ((max - base) / base) * 100.0;
+                    })()}
                     defaultValue={0.0}
                     renderValue={(value) => roundToDecimals(value, 1)}
                     onChange={(value) => {
                       const base = state?.puller_state?.adaptive_speed_base;
                       const velocity = base * (value / 100);
-                      setPullerAdaptiveDeviationLimit(velocity)
+                      setPullerAdaptiveDeviationLimit(velocity);
                     }}
                   />
                 </Label>
@@ -394,12 +387,13 @@ export function Winder2ControlPage() {
                 <MachineSelector
                   machines={filteredMachines}
                   selectedMachine={selectedMachine}
-                  connectedMachineState={state?.puller_state.adaptive_reference_machine}
+                  connectedMachineState={
+                    state?.puller_state.adaptive_reference_machine
+                  }
                   setConnectedMachine={(machine) => {
                     setPullerAdaptiveReferenceMachine(machine);
                   }}
-                  clearConnectedMachine={() => 
-                  {
+                  clearConnectedMachine={() => {
                     if (!selectedMachine) return;
                     setPullerAdaptiveReferenceMachine(null);
                   }}

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -29,6 +29,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { getWinder2TraverseMax } from "./winder2Config";
+import { MachineSelector } from "../MachineSelector";
 
 export function Winder2ControlPage() {
   const [showResetConfirmDialog, setShowResetConfirmDialog] = useState(false);
@@ -58,13 +59,20 @@ export function Winder2ControlPage() {
     setSpoolAutomaticAction,
     isLoading,
     isDisabled,
+    filteredMachines,
+    selectedMachine,
+
+    // new stuff
+    setPullerAdaptiveBaseSpeed,
+    setPullerAdaptiveDeviationLimit,
+    setPullerAdaptiveReferenceMachine,
   } = useWinder2();
 
   // Calculate max speed based on gear ratio
   const gearRatioMultiplier = getGearRatioMultiplier(
     state?.puller_state?.gear_ratio,
   );
-  const maxMotorSpeed = 75; // Maximum motor speed in m/min
+  const maxMotorSpeed = 50; // Maximum motor speed in m/min
   const maxTargetSpeed = maxMotorSpeed / gearRatioMultiplier;
 
   const handleResetProgress = () => {
@@ -261,38 +269,144 @@ export function Winder2ControlPage() {
             timeseries={pullerSpeed}
             renderValue={(value) => roundToDecimals(value, 1)}
           />
-          <Label label="Regulation">
+          <Label label="Speed Regulation">
             <SelectionGroup
               value={state?.puller_state?.regulation}
-              options={{
-                Speed: {
-                  children: "Speed",
-                  icon: "lu:Gauge",
-                },
-                Diameter: {
-                  children: "Diameter",
-                  icon: "lu:Sun",
-                  disabled: true,
-                },
-              }}
-              onChange={setPullerRegulationMode}
               disabled={isDisabled}
               loading={isLoading}
+              options={{
+                Speed: {
+                  children: "Fixed",
+                  icon: "lu:Crosshair",
+                },
+                Diameter: {
+                  children: "Adaptive",
+                  icon: "lu:Brain",
+                },
+              }}
+              onChange={(value) =>
+                setPullerRegulationMode(value)
+              }
             />
           </Label>
-          <Label label="Target Speed">
-            <EditValue
-              value={state?.puller_state?.target_speed}
-              unit="m/min"
-              title="Target Speed"
-              defaultValue={defaultState?.puller_state?.target_speed}
-              min={0}
-              max={maxTargetSpeed}
-              step={0.1}
-              renderValue={(value) => roundToDecimals(value, 1)}
-              onChange={setPullerTargetSpeed}
-            />
-          </Label>
+
+          {state?.puller_state?.regulation ===
+            "Speed" && (
+            <>
+              <Label label="Target Speed">
+                <EditValue
+                  value={state?.puller_state?.target_speed}
+                  title={"Target Speed"}
+                  unit="m/min"
+                  step={0.1}
+                  min={0}
+                  max={maxTargetSpeed}
+                  defaultValue={
+                    defaultState?.puller_state?.target_speed
+                  }
+                  renderValue={(value) => roundToDecimals(value, 1)}
+                  onChange={(value) => setPullerTargetSpeed(value)}
+                />
+              </Label>
+            </>
+          )}
+
+          {state?.puller_state?.regulation ===
+            "Diameter" && (
+            <>
+              <Label label="Base Speed">
+                <EditValue
+                  value={state?.puller_state?.adaptive_speed_base}
+                  title={"Base Speed"}
+                  unit="m/min"
+                  step={0.1}
+                  min={0}
+                  max={maxTargetSpeed}
+                  defaultValue={
+                    defaultState?.puller_state?.adaptive_speed_base
+                  }
+                  renderValue={(value) => roundToDecimals(value, 1)}
+                  onChange={(value) => setPullerAdaptiveBaseSpeed(value)}
+                />
+              </Label>
+
+              <div className="flex flex-row flex-wrap gap-4">
+                <Label label="Deviation Limit (fixed)">
+                  <EditValue
+                    value={state?.puller_state?.adaptive_deviation_limit}
+                    title={"Deviation Limit (fixed)"}
+                    unit="m/min"
+                    step={0.1}
+                    min={0.0}
+                    max={                    
+                      (() => {
+                        const base = state.puller_state?.adaptive_speed_base;
+                        const max  = maxTargetSpeed;
+
+                        // limit is towards upper bound
+                        if (base > max / 2) { return max - base; }
+
+                        // limit is towards lower bound
+                        return base;
+                      })()
+                    }
+                    defaultValue={0.0}
+                    renderValue={(value) => roundToDecimals(value, 1)}
+                    onChange={(value) => setPullerAdaptiveDeviationLimit(value)}
+                  />
+                </Label>
+                <Label label="Deviation Limit (relative)">
+                  <EditValue
+                    value={(() => {
+                      const base = state?.puller_state?.adaptive_speed_base;
+                      const deviation = state?.puller_state?.adaptive_deviation_limit;
+                      if (base <= 0) return 0;
+                      return (deviation / base) * 100;
+                    })()}
+                    title={"Deviation Limit (relative)"}
+                    unit="%"
+                    step={0.5}
+                    min={0.0}
+                    max={                    
+                      (() => {
+                        const base = state?.puller_state?.adaptive_speed_base;
+                        const max  = maxTargetSpeed;
+                        const mid  = max / 2;
+
+                        // limit is towards lower bound
+                        if (base < mid) { return 100.0; }
+
+                        // limit is towards upper bound
+                        return (max - base) / base * 100.0;
+                      })()
+                    }
+                    defaultValue={0.0}
+                    renderValue={(value) => roundToDecimals(value, 1)}
+                    onChange={(value) => {
+                      const base = state?.puller_state?.adaptive_speed_base;
+                      const velocity = base * (value / 100);
+                      setPullerAdaptiveDeviationLimit(velocity)
+                    }}
+                  />
+                </Label>
+              </div>
+              <Label label="Reference Machine">
+                <MachineSelector
+                  machines={filteredMachines}
+                  selectedMachine={selectedMachine}
+                  connectedMachineState={state?.puller_state.adaptive_reference_machine}
+                  setConnectedMachine={(machine) => {
+                    setPullerAdaptiveReferenceMachine(machine);
+                  }}
+                  clearConnectedMachine={() => 
+                  {
+                    if (!selectedMachine) return;
+                    setPullerAdaptiveReferenceMachine(null);
+                  }}
+                />
+              </Label>
+            </>
+          )}
         </ControlCard>
 
         <ControlCard className="bg-red" title="Spool Autostop">

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -61,9 +61,6 @@ export function Winder2ControlPage() {
     setSpoolAutomaticAction,
     isLoading,
     isDisabled,
-
-    // new stuff
-    setPullerAdaptiveBaseSpeed,
   } = useWinder2();
 
   // Calculate max speed based on gear ratio
@@ -283,21 +280,12 @@ export function Winder2ControlPage() {
                         children: "Adaptive",
                         icon: "lu:Brain",
                         disabled:
-                          !state?.puller_state?.adaptive_reference_machine,
+                          state?.puller_state?.adaptive_reference_machine,
                       },
                     }
                   : {}),
               }}
               onChange={(value) => {
-                // When switching to adaptive mode, seed the base speed from the
-                // current fixed target speed so there is no jump.
-                if (
-                  value === "Diameter" &&
-                  state?.puller_state?.regulation !== "Diameter"
-                ) {
-                  const currentTarget = state?.puller_state?.target_speed ?? 0;
-                  setPullerAdaptiveBaseSpeed(currentTarget);
-                }
                 // When switching back to fixed mode, seed the target speed from
                 // the current puller speed so there is no jump.
                 if (
@@ -334,8 +322,8 @@ export function Winder2ControlPage() {
             <Label label="Base Speed">
               <div className="flex flex-row items-center gap-2 py-4">
                 <span className="font-mono text-4xl font-bold">
-                  {state?.puller_state?.adaptive_speed_base != null
-                    ? roundToDecimals(state.puller_state.adaptive_speed_base, 1)
+                  {state?.puller_state?.target_speed != null
+                    ? roundToDecimals(state.puller_state.target_speed, 1)
                     : "–"}
                 </span>
                 <span>m/min</span>

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -277,6 +277,8 @@ export function Winder2ControlPage() {
                 Diameter: {
                   children: "Adaptive",
                   icon: "lu:Brain",
+                  disabled:
+                    !state?.puller_state?.adaptive_reference_machine,
                 },
               }}
               onChange={(value) => {
@@ -288,6 +290,15 @@ export function Winder2ControlPage() {
                 ) {
                   const currentTarget = state?.puller_state?.target_speed ?? 0;
                   setPullerAdaptiveBaseSpeed(currentTarget);
+                }
+                // When switching back to fixed mode, seed the target speed from
+                // the current puller speed so there is no jump.
+                if (
+                  value === "Speed" &&
+                  state?.puller_state?.regulation !== "Speed"
+                ) {
+                  const currentSpeed = pullerSpeed.current?.value ?? 0;
+                  setPullerTargetSpeed(currentSpeed);
                 }
                 setPullerRegulationMode(value);
               }}

--- a/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2ControlPage.tsx
@@ -15,6 +15,7 @@ import { StatusBadge } from "@/control/StatusBadge";
 import { useWinder2 } from "./useWinder";
 import {
   Mode,
+  PullerRegulation,
   SpoolAutomaticActionMode,
   getGearRatioMultiplier,
 } from "./winder2Namespace";
@@ -29,10 +30,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { getWinder2TraverseMax } from "./winder2Config";
+import { getWinder2AdaptivePullerSpeed } from "./winder2Config";
 
 export function Winder2ControlPage() {
   const [showResetConfirmDialog, setShowResetConfirmDialog] = useState(false);
   const traverseMax = getWinder2TraverseMax();
+  const adaptivePullerEnabled = getWinder2AdaptivePullerSpeed();
 
   // use optimistic state
   const {
@@ -265,7 +268,7 @@ export function Winder2ControlPage() {
             renderValue={(value) => roundToDecimals(value, 1)}
           />
           <Label label="Speed Regulation">
-            <SelectionGroup
+            <SelectionGroup<string>
               value={state?.puller_state?.regulation}
               disabled={isDisabled}
               loading={isLoading}
@@ -274,12 +277,16 @@ export function Winder2ControlPage() {
                   children: "Fixed",
                   icon: "lu:Crosshair",
                 },
-                Diameter: {
-                  children: "Adaptive",
-                  icon: "lu:Brain",
-                  disabled:
-                    !state?.puller_state?.adaptive_reference_machine,
-                },
+                ...(adaptivePullerEnabled
+                  ? {
+                      Diameter: {
+                        children: "Adaptive",
+                        icon: "lu:Brain",
+                        disabled:
+                          !state?.puller_state?.adaptive_reference_machine,
+                      },
+                    }
+                  : {}),
               }}
               onChange={(value) => {
                 // When switching to adaptive mode, seed the base speed from the
@@ -300,7 +307,7 @@ export function Winder2ControlPage() {
                   const currentSpeed = pullerSpeed.current?.value ?? 0;
                   setPullerTargetSpeed(currentSpeed);
                 }
-                setPullerRegulationMode(value);
+                setPullerRegulationMode(value as PullerRegulation);
               }}
             />
           </Label>
@@ -328,10 +335,7 @@ export function Winder2ControlPage() {
               <div className="flex flex-row items-center gap-2 py-4">
                 <span className="font-mono text-4xl font-bold">
                   {state?.puller_state?.adaptive_speed_base != null
-                    ? roundToDecimals(
-                        state.puller_state.adaptive_speed_base,
-                        1,
-                      )
+                    ? roundToDecimals(state.puller_state.adaptive_speed_base, 1)
                     : "–"}
                 </span>
                 <span>m/min</span>

--- a/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
@@ -85,12 +85,6 @@ const previewEntries: PresetPreviewEntries<Winder2> = [
     renderValue: (data: Winder2) => data.puller_state?.target_speed?.toFixed(2),
   },
   {
-    name: "Puller Adaptive Algorithm Base Speed",
-    unit: "m/min",
-    renderValue: (data: Winder2) =>
-      data.puller_state?.adaptive_speed_base?.toFixed(1),
-  },
-  {
     name: "Puller Adaptive Max Speed Change",
     unit: "%",
     renderValue: (data: Winder2) =>

--- a/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
@@ -93,19 +93,19 @@ const previewEntries: PresetPreviewEntries<Winder2> = [
     name: "Puller Adaptive Max Speed Change",
     unit: "%",
     renderValue: (data: Winder2) =>
-      data.puller_state?.adaptive_max_speed_change_percent?.toFixed(1),
+      data.puller_state?.adaptive_speed_delta_max?.toFixed(1),
   },
   {
     name: "Puller Adaptive Adjustment Interval",
     unit: "m",
     renderValue: (data: Winder2) =>
-      data.puller_state?.adaptive_adjustment_interval_meters?.toFixed(1),
+      data.puller_state?.adaptive_adjustment_distance?.toFixed(1),
   },
   {
     name: "Puller Adaptive Step Size",
     unit: "%",
     renderValue: (data: Winder2) =>
-      data.puller_state?.adaptive_step_percent?.toFixed(1),
+      data.puller_state?.adaptive_increase_per_step?.toFixed(1),
   },
   previewSeparator,
   {

--- a/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
@@ -105,7 +105,7 @@ const previewEntries: PresetPreviewEntries<Winder2> = [
     name: "Puller Adaptive Step Size",
     unit: "%",
     renderValue: (data: Winder2) =>
-      data.puller_state?.adaptive_increase_per_step?.toFixed(1),
+      data.puller_state?.adaptive_change_per_step?.toFixed(1),
   },
   previewSeparator,
   {

--- a/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useWinder2 } from "./useWinder";
 import { winder2 } from "@/machines/properties";
+import { getWinder2AdaptivePullerSpeed } from "./winder2Config";
 
 import { PresetsPage } from "@/components/preset/PresetsPage";
 import { Preset } from "@/lib/preset/preset";
@@ -202,7 +203,13 @@ export function Winder2PresetsPage() {
     setTraverseStepSize(preset.data?.traverse_state?.step_size ?? 1.75);
     setTraversePadding(preset.data?.traverse_state?.padding ?? 0.88);
 
-    setPullerRegulationMode(preset.data?.puller_state?.regulation ?? "Speed");
+    const presetRegulation = preset.data?.puller_state?.regulation ?? "Speed";
+    const adaptivePullerEnabled = getWinder2AdaptivePullerSpeed();
+    setPullerRegulationMode(
+      presetRegulation === "Diameter" && !adaptivePullerEnabled
+        ? "Speed"
+        : presetRegulation,
+    );
     setPullerForward(preset.data?.puller_state?.forward ?? true);
     setPullerTargetSpeed(preset.data?.puller_state?.target_speed ?? 1.0);
     setPullerGearRatio(preset.data?.puller_state?.gear_ratio ?? "OneToOne");

--- a/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
@@ -85,15 +85,27 @@ const previewEntries: PresetPreviewEntries<Winder2> = [
   },
   {
     name: "Puller Adaptive Algorithm Base Speed",
-    unit: "mm",
+    unit: "m/min",
     renderValue: (data: Winder2) =>
       data.puller_state?.adaptive_speed_base?.toFixed(1),
   },
   {
-    name: "Puller Adaptive Algorithm Deviation Limit",
-    unit: "mm",
+    name: "Puller Adaptive Max Speed Change",
+    unit: "%",
     renderValue: (data: Winder2) =>
-      data.puller_state?.adaptive_deviation_limit?.toFixed(1),
+      data.puller_state?.adaptive_max_speed_change_percent?.toFixed(1),
+  },
+  {
+    name: "Puller Adaptive Adjustment Interval",
+    unit: "m",
+    renderValue: (data: Winder2) =>
+      data.puller_state?.adaptive_adjustment_interval_meters?.toFixed(1),
+  },
+  {
+    name: "Puller Adaptive Step Size",
+    unit: "%",
+    renderValue: (data: Winder2) =>
+      data.puller_state?.adaptive_step_percent?.toFixed(1),
   },
   previewSeparator,
   {

--- a/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
+++ b/electron/src/machines/winder/winder2/Winder2PresetsPage.tsx
@@ -79,21 +79,21 @@ const previewEntries: PresetPreviewEntries<Winder2> = [
     },
   },
   {
-    name: "Puller Target Speed",
+    name: "Puller Fixed Algorithm Base Speed",
     unit: "m/min",
     renderValue: (data: Winder2) => data.puller_state?.target_speed?.toFixed(2),
   },
   {
-    name: "Puller Target Diameter",
+    name: "Puller Adaptive Algorithm Base Speed",
     unit: "mm",
     renderValue: (data: Winder2) =>
-      data.puller_state?.target_diameter?.toFixed(1),
+      data.puller_state?.adaptive_speed_base?.toFixed(1),
   },
   {
-    name: "Puller Target Diameter",
+    name: "Puller Adaptive Algorithm Deviation Limit",
     unit: "mm",
     renderValue: (data: Winder2) =>
-      data.puller_state?.target_diameter?.toFixed(1),
+      data.puller_state?.adaptive_deviation_limit?.toFixed(1),
   },
   previewSeparator,
   {
@@ -165,7 +165,6 @@ export function Winder2PresetsPage() {
     setTraverseLimitOuter,
 
     setPullerRegulationMode,
-    setPullerTargetDiameter,
     setPullerForward,
     setPullerTargetSpeed,
     setPullerGearRatio,

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -16,6 +16,10 @@ import {
   WINDER2_TRAVERSE_MAX_XL,
 } from "./winder2Config";
 
+function fractionToPercent(value: number | null | undefined) {
+  return value == null ? undefined : value * 100;
+}
+
 export function Winder2SettingPage() {
   const [xlMode, setXlMode] = useState(getWinder2XLMode());
 
@@ -358,10 +362,10 @@ export function Winder2SettingPage() {
           </Label>
 
           <ControlCard title="Adaptive Speed">
-            <Label label="Diameter Tolerance">
+            <Label label="Allowed Diameter Deviation">
               <EditValue
                 value={state?.puller_state?.adaptive_tolerance_limit}
-                title={"Diameter Tolerance"}
+                title={"Allowed Diameter Deviation"}
                 unit="mm"
                 step={0.01}
                 min={0}
@@ -375,14 +379,18 @@ export function Winder2SettingPage() {
             </Label>
             <Label label="Max Speed Deviation">
               <EditValue
-                value={state?.puller_state?.adaptive_speed_delta_max}
+                value={fractionToPercent(
+                  state?.puller_state?.adaptive_speed_delta_max,
+                )}
                 title={"Max Speed Deviation"}
                 unit="%"
                 step={0.5}
                 min={0}
                 max={50}
                 defaultValue={
-                  defaultState?.puller_state?.adaptive_speed_delta_max
+                  fractionToPercent(
+                    defaultState?.puller_state?.adaptive_speed_delta_max,
+                  )
                 }
                 renderValue={(value) => roundToDecimals(value, 1)}
                 onChange={(value) =>
@@ -409,14 +417,18 @@ export function Winder2SettingPage() {
             </Label>
             <Label label="Increase Per Step">
               <EditValue
-                value={state?.puller_state?.adaptive_increase_per_step}
+                value={fractionToPercent(
+                  state?.puller_state?.adaptive_increase_per_step,
+                )}
                 title={"Increase Per Step"}
                 unit="%"
                 step={0.1}
                 min={0.1}
                 max={10}
                 defaultValue={
-                  defaultState?.puller_state?.adaptive_increase_per_step
+                  fractionToPercent(
+                    defaultState?.puller_state?.adaptive_increase_per_step,
+                  )
                 }
                 renderValue={(value) => roundToDecimals(value, 1)}
                 onChange={(value) => setPullerAdaptiveStepPercent(value / 100)}

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -40,10 +40,6 @@ export function Winder2SettingPage() {
     setSpoolAdaptiveDeaccelerationUrgencyMultiplier,
     isLoading,
     isDisabled,
-    selectedMachine,
-    filteredMachines,
-    setConnectedMachine,
-    disconnectMachine,
   } = useWinder2();
 
   const handleXlModeChange = (enabled: boolean) => {
@@ -354,20 +350,6 @@ export function Winder2SettingPage() {
             />
           </Label>
         </ControlCard>
-        <MachineSelector
-          machines={filteredMachines}
-          selectedMachine={selectedMachine}
-          connectedMachineState={state?.connected_machine_state}
-          setConnectedMachine={setConnectedMachine}
-          clearConnectedMachine={() => {
-            if (!selectedMachine) return;
-            setConnectedMachine({
-              machine_identification: { vendor: 0, machine: 0 },
-              serial: 0,
-            });
-            disconnectMachine(selectedMachine.machine_identification_unique);
-          }}
-        />
       </ControlGrid>
     </Page>
   );

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -375,6 +375,9 @@ export function Winder2SettingPage() {
               optionFalse={{
                 children: "Disabled",
                 icon: "lu:X",
+                disabled:
+                  adaptivePullerSpeed &&
+                  state?.puller_state?.regulation === "Diameter",
               }}
               optionTrue={{
                 children: "Enabled",

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -364,14 +364,14 @@ export function Winder2SettingPage() {
           <ControlCard title="Adaptive Speed">
             <Label label="Allowed Diameter Deviation">
               <EditValue
-                value={state?.puller_state?.adaptive_tolerance_limit}
+                value={state?.puller_state?.allowed_diameter_deviation}
                 title={"Allowed Diameter Deviation"}
                 unit="mm"
                 step={0.01}
                 min={0}
                 max={5}
                 defaultValue={
-                  defaultState?.puller_state?.adaptive_tolerance_limit
+                  defaultState?.puller_state?.allowed_diameter_deviation
                 }
                 renderValue={(value) => roundToDecimals(value, 2)}
                 onChange={(value) => setPullerAdaptiveAcceptedDifference(value)}
@@ -415,10 +415,10 @@ export function Winder2SettingPage() {
                 }
               />
             </Label>
-            <Label label="Increase Per Step">
+            <Label label="Change Per Step">
               <EditValue
                 value={fractionToPercent(
-                  state?.puller_state?.adaptive_increase_per_step,
+                  state?.puller_state?.adaptive_change_per_step,
                 )}
                 title={"Increase Per Step"}
                 unit="%"
@@ -427,7 +427,7 @@ export function Winder2SettingPage() {
                 max={10}
                 defaultValue={
                   fractionToPercent(
-                    defaultState?.puller_state?.adaptive_increase_per_step,
+                    defaultState?.puller_state?.adaptive_change_per_step,
                   )
                 }
                 renderValue={(value) => roundToDecimals(value, 1)}

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -14,7 +14,10 @@ import {
   setWinder2XLMode,
   WINDER2_TRAVERSE_MAX_STANDARD,
   WINDER2_TRAVERSE_MAX_XL,
+  getWinder2AdaptivePullerSpeed,
+  setWinder2AdaptivePullerSpeed,
 } from "./winder2Config";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 function fractionToPercent(value: number | null | undefined) {
   return value == null ? undefined : value * 100;
@@ -22,6 +25,9 @@ function fractionToPercent(value: number | null | undefined) {
 
 export function Winder2SettingPage() {
   const [xlMode, setXlMode] = useState(getWinder2XLMode());
+  const [adaptivePullerSpeed, setAdaptivePullerSpeedState] = useState(
+    getWinder2AdaptivePullerSpeed(),
+  );
 
   const {
     state,
@@ -361,102 +367,137 @@ export function Winder2SettingPage() {
             />
           </Label>
 
-          <ControlCard title="Adaptive Speed">
-            <Label label="Allowed Diameter Deviation">
-              <EditValue
-                value={state?.puller_state?.allowed_diameter_deviation}
-                title={"Allowed Diameter Deviation"}
-                unit="mm"
-                step={0.01}
-                min={0}
-                max={5}
-                defaultValue={
-                  defaultState?.puller_state?.allowed_diameter_deviation
-                }
-                renderValue={(value) => roundToDecimals(value, 2)}
-                onChange={(value) => setPullerAdaptiveAcceptedDifference(value)}
-              />
-            </Label>
-            <Label label="Max Speed Deviation">
-              {state?.puller_state?.regulation === "Diameter" && (
-                <span className="text-sm text-muted-foreground">
-                  Only changeable in fixed mode
-                </span>
-              )}
-              <EditValue
-                value={fractionToPercent(
-                  state?.puller_state?.adaptive_speed_delta_max,
+          <Label label="Adaptive Speed (Experimental)">
+            <SelectionGroupBoolean
+              value={adaptivePullerSpeed}
+              disabled={isDisabled}
+              loading={isLoading}
+              optionFalse={{
+                children: "Disabled",
+                icon: "lu:X",
+              }}
+              optionTrue={{
+                children: "Enabled",
+                icon: "lu:FlaskConical",
+              }}
+              onChange={(value) => {
+                setWinder2AdaptivePullerSpeed(value);
+                setAdaptivePullerSpeedState(value);
+              }}
+            />
+            {adaptivePullerSpeed && (
+              <Alert className="mt-2 border-yellow-500/50 bg-yellow-500/10">
+                <AlertTitle className="text-yellow-600">
+                  Experimental Feature
+                </AlertTitle>
+                <AlertDescription>
+                  This feature is still in development and may cause unexpected
+                  behavior. It will be improved in future updates. Please read
+                  section 2.3.1 in the manual on how to use this feature and
+                  provide feedback to help us improve it.
+                </AlertDescription>
+              </Alert>
+            )}
+          </Label>
+
+          {adaptivePullerSpeed && (
+            <ControlCard title="Adaptive Speed">
+              <Label label="Allowed Diameter Deviation">
+                <EditValue
+                  value={state?.puller_state?.allowed_diameter_deviation}
+                  title={"Allowed Diameter Deviation"}
+                  unit="mm"
+                  step={0.01}
+                  min={0}
+                  max={5}
+                  defaultValue={
+                    defaultState?.puller_state?.allowed_diameter_deviation
+                  }
+                  renderValue={(value) => roundToDecimals(value, 2)}
+                  onChange={(value) =>
+                    setPullerAdaptiveAcceptedDifference(value)
+                  }
+                />
+              </Label>
+              <Label label="Max Speed Deviation">
+                {state?.puller_state?.regulation === "Diameter" && (
+                  <span className="text-muted-foreground text-sm">
+                    Only changeable in fixed mode
+                  </span>
                 )}
-                title={"Max Speed Deviation"}
-                unit="%"
-                step={0.5}
-                min={0}
-                max={50}
-                defaultValue={
-                  fractionToPercent(
+                <EditValue
+                  value={fractionToPercent(
+                    state?.puller_state?.adaptive_speed_delta_max,
+                  )}
+                  title={"Max Speed Deviation"}
+                  unit="%"
+                  step={0.5}
+                  min={0}
+                  max={50}
+                  defaultValue={fractionToPercent(
                     defaultState?.puller_state?.adaptive_speed_delta_max,
-                  )
-                }
-                renderValue={(value) => roundToDecimals(value, 1)}
-                onChange={(value) =>
-                  setPullerAdaptiveMaxSpeedChangePercent(value / 100)
-                }
-                disabled={state?.puller_state?.regulation === "Diameter"}
-              />
-            </Label>
-            <Label label="Distance Between Steps">
-              <EditValue
-                value={state?.puller_state?.adaptive_adjustment_distance}
-                title={"Distance Between Steps"}
-                unit="m"
-                step={0.1}
-                min={0}
-                max={200}
-                defaultValue={
-                  defaultState?.puller_state?.adaptive_adjustment_distance
-                }
-                renderValue={(value) => roundToDecimals(value, 1)}
-                onChange={(value) =>
-                  setPullerAdaptiveAdjustmentIntervalMeters(value)
-                }
-              />
-            </Label>
-            <Label label="Change Per Step">
-              <EditValue
-                value={fractionToPercent(
-                  state?.puller_state?.adaptive_change_per_step,
-                )}
-                title={"Increase Per Step"}
-                unit="%"
-                step={0.1}
-                min={0.1}
-                max={10}
-                defaultValue={
-                  fractionToPercent(
+                  )}
+                  renderValue={(value) => roundToDecimals(value, 1)}
+                  onChange={(value) =>
+                    setPullerAdaptiveMaxSpeedChangePercent(value / 100)
+                  }
+                  disabled={state?.puller_state?.regulation === "Diameter"}
+                />
+              </Label>
+              <Label label="Distance Between Steps">
+                <EditValue
+                  value={state?.puller_state?.adaptive_adjustment_distance}
+                  title={"Distance Between Steps"}
+                  unit="m"
+                  step={0.1}
+                  min={0}
+                  max={200}
+                  defaultValue={
+                    defaultState?.puller_state?.adaptive_adjustment_distance
+                  }
+                  renderValue={(value) => roundToDecimals(value, 1)}
+                  onChange={(value) =>
+                    setPullerAdaptiveAdjustmentIntervalMeters(value)
+                  }
+                />
+              </Label>
+              <Label label="Change Per Step">
+                <EditValue
+                  value={fractionToPercent(
+                    state?.puller_state?.adaptive_change_per_step,
+                  )}
+                  title={"Increase Per Step"}
+                  unit="%"
+                  step={0.1}
+                  min={0.1}
+                  max={10}
+                  defaultValue={fractionToPercent(
                     defaultState?.puller_state?.adaptive_change_per_step,
-                  )
-                }
-                renderValue={(value) => roundToDecimals(value, 1)}
-                onChange={(value) => setPullerAdaptiveStepPercent(value / 100)}
-              />
-            </Label>
-            <Label label="Reference Machine">
-              <MachineSelector
-                machines={filteredMachines}
-                selectedMachine={selectedMachine}
-                connectedMachineState={
-                  state?.puller_state.adaptive_reference_machine
-                }
-                setConnectedMachine={(machine) => {
-                  setPullerAdaptiveReferenceMachine(machine);
-                }}
-                clearConnectedMachine={() => {
-                  if (!selectedMachine) return;
-                  setPullerAdaptiveReferenceMachine(null);
-                }}
-              />
-            </Label>
-          </ControlCard>
+                  )}
+                  renderValue={(value) => roundToDecimals(value, 1)}
+                  onChange={(value) =>
+                    setPullerAdaptiveStepPercent(value / 100)
+                  }
+                />
+              </Label>
+              <Label label="Reference Machine">
+                <MachineSelector
+                  machines={filteredMachines}
+                  selectedMachine={selectedMachine}
+                  connectedMachineState={
+                    state?.puller_state.adaptive_reference_machine
+                  }
+                  setConnectedMachine={(machine) => {
+                    setPullerAdaptiveReferenceMachine(machine);
+                  }}
+                  clearConnectedMachine={() => {
+                    if (!selectedMachine) return;
+                    setPullerAdaptiveReferenceMachine(null);
+                  }}
+                />
+              </Label>
+            </ControlCard>
+          )}
         </ControlCard>
       </ControlGrid>
     </Page>

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -415,7 +415,9 @@ export function Winder2SettingPage() {
                 step={0.1}
                 min={0.1}
                 max={10}
-                defaultValue={defaultState?.puller_state?.adaptive_increase_per_step}
+                defaultValue={
+                  defaultState?.puller_state?.adaptive_increase_per_step
+                }
                 renderValue={(value) => roundToDecimals(value, 1)}
                 onChange={(value) => setPullerAdaptiveStepPercent(value / 100)}
               />

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -8,7 +8,7 @@ import { roundToDecimals } from "@/lib/decimal";
 import { Label } from "@/control/Label";
 import { SelectionGroupBoolean } from "@/control/SelectionGroup";
 import { SelectionGroup } from "@/control/SelectionGroup";
-import { MachineSelector } from "@/components/MachineConnectionDropdown";
+import { MachineSelector } from "../MachineSelector";
 import {
   getWinder2XLMode,
   setWinder2XLMode,
@@ -38,6 +38,13 @@ export function Winder2SettingPage() {
     setSpoolAdaptiveMaxSpeedMultiplier,
     setSpoolAdaptiveAccelerationFactor,
     setSpoolAdaptiveDeaccelerationUrgencyMultiplier,
+    setPullerAdaptiveMaxSpeedChangePercent,
+    setPullerAdaptiveAdjustmentIntervalMeters,
+    setPullerAdaptiveStepPercent,
+    setPullerAdaptiveAcceptedDifference,
+    setPullerAdaptiveReferenceMachine,
+    filteredMachines,
+    selectedMachine,
     isLoading,
     isDisabled,
   } = useWinder2();
@@ -347,6 +354,85 @@ export function Winder2SettingPage() {
                   value as "OneToOne" | "OneToFive" | "OneToTen",
                 )
               }
+            />
+          </Label>
+
+          <Label label="Adaptive: Accepted Difference">
+            <EditValue
+              value={state?.puller_state?.adaptive_accepted_difference}
+              title={"Adaptive: Accepted Difference"}
+              unit="mm"
+              step={0.01}
+              min={0}
+              max={5}
+              defaultValue={
+                defaultState?.puller_state?.adaptive_accepted_difference
+              }
+              renderValue={(value) => roundToDecimals(value, 2)}
+              onChange={(value) => setPullerAdaptiveAcceptedDifference(value)}
+            />
+          </Label>
+          <Label label="Adaptive: Max Speed Change">
+            <EditValue
+              value={state?.puller_state?.adaptive_max_speed_change_percent}
+              title={"Adaptive: Max Speed Change"}
+              unit="%"
+              step={0.5}
+              min={0}
+              max={50}
+              defaultValue={
+                defaultState?.puller_state?.adaptive_max_speed_change_percent
+              }
+              renderValue={(value) => roundToDecimals(value, 1)}
+              onChange={(value) =>
+                setPullerAdaptiveMaxSpeedChangePercent(value)
+              }
+            />
+          </Label>
+          <Label label="Adaptive: Adjustment Interval">
+            <EditValue
+              value={state?.puller_state?.adaptive_adjustment_interval_meters}
+              title={"Adaptive: Adjustment Interval"}
+              unit="m"
+              step={0.5}
+              min={0}
+              max={100}
+              defaultValue={
+                defaultState?.puller_state?.adaptive_adjustment_interval_meters
+              }
+              renderValue={(value) => roundToDecimals(value, 1)}
+              onChange={(value) =>
+                setPullerAdaptiveAdjustmentIntervalMeters(value)
+              }
+            />
+          </Label>
+          <Label label="Adaptive: Step Size">
+            <EditValue
+              value={state?.puller_state?.adaptive_step_percent}
+              title={"Adaptive: Step Size"}
+              unit="%"
+              step={0.1}
+              min={0.1}
+              max={10}
+              defaultValue={defaultState?.puller_state?.adaptive_step_percent}
+              renderValue={(value) => roundToDecimals(value, 1)}
+              onChange={(value) => setPullerAdaptiveStepPercent(value)}
+            />
+          </Label>
+          <Label label="Adaptive: Reference Machine">
+            <MachineSelector
+              machines={filteredMachines}
+              selectedMachine={selectedMachine}
+              connectedMachineState={
+                state?.puller_state.adaptive_reference_machine
+              }
+              setConnectedMachine={(machine) => {
+                setPullerAdaptiveReferenceMachine(machine);
+              }}
+              clearConnectedMachine={() => {
+                if (!selectedMachine) return;
+                setPullerAdaptiveReferenceMachine(null);
+              }}
             />
           </Label>
         </ControlCard>

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -378,6 +378,11 @@ export function Winder2SettingPage() {
               />
             </Label>
             <Label label="Max Speed Deviation">
+              {state?.puller_state?.regulation === "Diameter" && (
+                <span className="text-sm text-muted-foreground">
+                  Only changeable in fixed mode
+                </span>
+              )}
               <EditValue
                 value={fractionToPercent(
                   state?.puller_state?.adaptive_speed_delta_max,
@@ -396,6 +401,7 @@ export function Winder2SettingPage() {
                 onChange={(value) =>
                   setPullerAdaptiveMaxSpeedChangePercent(value / 100)
                 }
+                disabled={state?.puller_state?.regulation === "Diameter"}
               />
             </Label>
             <Label label="Distance Between Steps">

--- a/electron/src/machines/winder/winder2/Winder2Settings.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Settings.tsx
@@ -357,84 +357,86 @@ export function Winder2SettingPage() {
             />
           </Label>
 
-          <Label label="Adaptive: Accepted Difference">
-            <EditValue
-              value={state?.puller_state?.adaptive_accepted_difference}
-              title={"Adaptive: Accepted Difference"}
-              unit="mm"
-              step={0.01}
-              min={0}
-              max={5}
-              defaultValue={
-                defaultState?.puller_state?.adaptive_accepted_difference
-              }
-              renderValue={(value) => roundToDecimals(value, 2)}
-              onChange={(value) => setPullerAdaptiveAcceptedDifference(value)}
-            />
-          </Label>
-          <Label label="Adaptive: Max Speed Change">
-            <EditValue
-              value={state?.puller_state?.adaptive_max_speed_change_percent}
-              title={"Adaptive: Max Speed Change"}
-              unit="%"
-              step={0.5}
-              min={0}
-              max={50}
-              defaultValue={
-                defaultState?.puller_state?.adaptive_max_speed_change_percent
-              }
-              renderValue={(value) => roundToDecimals(value, 1)}
-              onChange={(value) =>
-                setPullerAdaptiveMaxSpeedChangePercent(value)
-              }
-            />
-          </Label>
-          <Label label="Adaptive: Adjustment Interval">
-            <EditValue
-              value={state?.puller_state?.adaptive_adjustment_interval_meters}
-              title={"Adaptive: Adjustment Interval"}
-              unit="m"
-              step={0.5}
-              min={0}
-              max={100}
-              defaultValue={
-                defaultState?.puller_state?.adaptive_adjustment_interval_meters
-              }
-              renderValue={(value) => roundToDecimals(value, 1)}
-              onChange={(value) =>
-                setPullerAdaptiveAdjustmentIntervalMeters(value)
-              }
-            />
-          </Label>
-          <Label label="Adaptive: Step Size">
-            <EditValue
-              value={state?.puller_state?.adaptive_step_percent}
-              title={"Adaptive: Step Size"}
-              unit="%"
-              step={0.1}
-              min={0.1}
-              max={10}
-              defaultValue={defaultState?.puller_state?.adaptive_step_percent}
-              renderValue={(value) => roundToDecimals(value, 1)}
-              onChange={(value) => setPullerAdaptiveStepPercent(value)}
-            />
-          </Label>
-          <Label label="Adaptive: Reference Machine">
-            <MachineSelector
-              machines={filteredMachines}
-              selectedMachine={selectedMachine}
-              connectedMachineState={
-                state?.puller_state.adaptive_reference_machine
-              }
-              setConnectedMachine={(machine) => {
-                setPullerAdaptiveReferenceMachine(machine);
-              }}
-              clearConnectedMachine={() => {
-                if (!selectedMachine) return;
-                setPullerAdaptiveReferenceMachine(null);
-              }}
-            />
-          </Label>
+          <ControlCard title="Adaptive Speed">
+            <Label label="Diameter Tolerance">
+              <EditValue
+                value={state?.puller_state?.adaptive_tolerance_limit}
+                title={"Diameter Tolerance"}
+                unit="mm"
+                step={0.01}
+                min={0}
+                max={5}
+                defaultValue={
+                  defaultState?.puller_state?.adaptive_tolerance_limit
+                }
+                renderValue={(value) => roundToDecimals(value, 2)}
+                onChange={(value) => setPullerAdaptiveAcceptedDifference(value)}
+              />
+            </Label>
+            <Label label="Max Speed Deviation">
+              <EditValue
+                value={state?.puller_state?.adaptive_speed_delta_max}
+                title={"Max Speed Deviation"}
+                unit="%"
+                step={0.5}
+                min={0}
+                max={50}
+                defaultValue={
+                  defaultState?.puller_state?.adaptive_speed_delta_max
+                }
+                renderValue={(value) => roundToDecimals(value, 1)}
+                onChange={(value) =>
+                  setPullerAdaptiveMaxSpeedChangePercent(value / 100)
+                }
+              />
+            </Label>
+            <Label label="Distance Between Steps">
+              <EditValue
+                value={state?.puller_state?.adaptive_adjustment_distance}
+                title={"Distance Between Steps"}
+                unit="m"
+                step={0.1}
+                min={0}
+                max={200}
+                defaultValue={
+                  defaultState?.puller_state?.adaptive_adjustment_distance
+                }
+                renderValue={(value) => roundToDecimals(value, 1)}
+                onChange={(value) =>
+                  setPullerAdaptiveAdjustmentIntervalMeters(value)
+                }
+              />
+            </Label>
+            <Label label="Increase Per Step">
+              <EditValue
+                value={state?.puller_state?.adaptive_increase_per_step}
+                title={"Increase Per Step"}
+                unit="%"
+                step={0.1}
+                min={0.1}
+                max={10}
+                defaultValue={defaultState?.puller_state?.adaptive_increase_per_step}
+                renderValue={(value) => roundToDecimals(value, 1)}
+                onChange={(value) => setPullerAdaptiveStepPercent(value / 100)}
+              />
+            </Label>
+            <Label label="Reference Machine">
+              <MachineSelector
+                machines={filteredMachines}
+                selectedMachine={selectedMachine}
+                connectedMachineState={
+                  state?.puller_state.adaptive_reference_machine
+                }
+                setConnectedMachine={(machine) => {
+                  setPullerAdaptiveReferenceMachine(machine);
+                }}
+                clearConnectedMachine={() => {
+                  if (!selectedMachine) return;
+                  setPullerAdaptiveReferenceMachine(null);
+                }}
+              />
+            </Label>
+          </ControlCard>
         </ControlCard>
       </ControlGrid>
     </Page>

--- a/electron/src/machines/winder/winder2/useWinder.ts
+++ b/electron/src/machines/winder/winder2/useWinder.ts
@@ -527,9 +527,9 @@ export function useWinder2() {
   };
 
   // more requests for puller
-  const { request: requestPullerSetAdaptiveBaseSpeed } = useMachineMutation(
+  const { request: requestPullerSetAdaptiveSpeedBase } = useMachineMutation(
     z.object({
-      SetPullerAdaptiveBaseSpeed: z.number(),
+      SetPullerAdaptiveSpeedBase: z.number(),
     }),
   );
   const { request: requestPullerSetAdaptiveDeviationLimit } = useMachineMutation(
@@ -550,9 +550,9 @@ export function useWinder2() {
         current.data.puller_state.adaptive_speed_base = speed;
       },
       () =>
-        requestPullerSetAdaptiveBaseSpeed({
+        requestPullerSetAdaptiveSpeedBase({
           machine_identification_unique: machineIdentification,
-          data: { SetPullerAdaptiveBaseSpeed: speed },
+          data: { SetPullerAdaptiveSpeedBase: speed },
         }),
     );
   };
@@ -607,7 +607,7 @@ export function useWinder2() {
           m.machine_identification_unique.machine_identification.vendor ===
             VENDOR_QITECH &&
           m.machine_identification_unique.machine_identification.machine ===
-            0x0008,
+            0x0006,
       ),
     [machines, machineIdentification],
   );

--- a/electron/src/machines/winder/winder2/useWinder.ts
+++ b/electron/src/machines/winder/winder2/useWinder.ts
@@ -112,9 +112,6 @@ export function useWinder2() {
   const { request: requestPullerSetTargetSpeed } = useMachineMutation(
     z.object({ SetPullerTargetSpeed: z.number() }),
   );
-  const { request: requestPullerSetTargetDiameter } = useMachineMutation(
-    z.object({ SetPullerTargetDiameter: z.number() }),
-  );
   const { request: requestPullerSetRegulationMode } = useMachineMutation(
     z.object({
       SetPullerRegulationMode: pullerRegulationSchema,
@@ -166,18 +163,6 @@ export function useWinder2() {
 
   const { request: requestSpoolAutomaticAction } = useMachineMutation(
     z.object({ SetSpoolAutomaticAction: spoolAutomaticActionModeSchema }),
-  );
-
-  const { request: requestConnectedMachine } = useMachineMutation(
-    z.object({
-      SetConnectedMachine: machineIdentificationUnique,
-    }),
-  );
-
-  const { request: requestDisconnectedMachine } = useMachineMutation(
-    z.object({
-      DisconnectMachine: machineIdentificationUnique,
-    }),
   );
 
   // Helper function for optimistic updates using produce
@@ -332,19 +317,6 @@ export function useWinder2() {
         requestPullerSetTargetSpeed({
           machine_identification_unique: machineIdentification,
           data: { SetPullerTargetSpeed: targetSpeed },
-        }),
-    );
-  };
-
-  const setPullerTargetDiameter = (targetDiameter: number) => {
-    updateStateOptimistically(
-      (current) => {
-        current.data.puller_state.target_diameter = targetDiameter;
-      },
-      () =>
-        requestPullerSetTargetDiameter({
-          machine_identification_unique: machineIdentification,
-          data: { SetPullerTargetDiameter: targetDiameter },
         }),
     );
   };
@@ -554,45 +526,72 @@ export function useWinder2() {
     );
   };
 
-  const setConnectedMachine = (machineIdentificationUnique: {
-    machine_identification: {
-      vendor: number;
-      machine: number;
-    };
-    serial: number;
-  }) => {
+  // more requests for puller
+  const { request: requestPullerSetAdaptiveBaseSpeed } = useMachineMutation(
+    z.object({
+      SetPullerAdaptiveBaseSpeed: z.number(),
+    }),
+  );
+  const { request: requestPullerSetAdaptiveDeviationLimit } = useMachineMutation(
+    z.object({
+      SetPullerAdaptiveDeviationLimit: z.number(),
+    }),
+  );
+  const { request: requestPullerSetAdaptiveReferenceMachine } = useMachineMutation(
+    z.object({
+      SetPullerAdaptiveReferenceMachine: machineIdentificationUnique.nullable(),
+    }),
+  );
+
+  // more boilerplate junk setters from requests
+  const setPullerAdaptiveBaseSpeed = (speed: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.connected_machine_state.machine_identification_unique =
-          machineIdentificationUnique;
+        current.data.puller_state.adaptive_speed_base = speed;
       },
       () =>
-        requestConnectedMachine({
-          machine_identification_unique,
-          data: { SetConnectedMachine: machineIdentificationUnique },
+        requestPullerSetAdaptiveBaseSpeed({
+          machine_identification_unique: machineIdentification,
+          data: { SetPullerAdaptiveBaseSpeed: speed },
         }),
     );
   };
 
-  const disconnectMachine = (machineIdentificationUnique: {
+  const setPullerAdaptiveDeviationLimit = (speed: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.puller_state.adaptive_deviation_limit = speed;
+      },
+      () =>
+        requestPullerSetAdaptiveDeviationLimit({
+          machine_identification_unique: machineIdentification,
+          data: { SetPullerAdaptiveDeviationLimit: speed },
+        }),
+    );
+  };
+
+  const setPullerAdaptiveReferenceMachine = (machineUid: {
     machine_identification: {
       vendor: number;
       machine: number;
     };
     serial: number;
-  }) => {
+  } | null) => {
     updateStateOptimistically(
       (current) => {
-        current.data.connected_machine_state.machine_identification_unique =
-          null;
+        current.data.puller_state
+          .adaptive_reference_machine
+            = machineUid;
       },
       () =>
-        requestDisconnectedMachine({
-          machine_identification_unique,
-          data: { DisconnectMachine: machineIdentificationUnique },
+        requestPullerSetAdaptiveReferenceMachine({
+          machine_identification_unique: machineIdentification,
+          data: { SetPullerAdaptiveReferenceMachine: machineUid },
         }),
     );
   };
+
+
 
   // Calculate loading states
   const isLoading = stateOptimistic.isOptimistic;
@@ -616,8 +615,7 @@ export function useWinder2() {
   // Get selected machine by serial
   const selectedMachine = useMemo(() => {
     const serial =
-      state?.data.connected_machine_state?.machine_identification_unique
-        ?.serial;
+      state?.data.puller_state.adaptive_reference_machine?.serial;
 
     return (
       filteredMachines.find(
@@ -661,7 +659,6 @@ export function useWinder2() {
     setTraverseStepSize,
     setTraversePadding,
     setPullerTargetSpeed,
-    setPullerTargetDiameter,
     setPullerRegulationMode,
     setPullerForward,
     setPullerGearRatio,
@@ -676,7 +673,10 @@ export function useWinder2() {
     setSpoolAdaptiveMaxSpeedMultiplier,
     setSpoolAdaptiveAccelerationFactor,
     setSpoolAdaptiveDeaccelerationUrgencyMultiplier,
-    setConnectedMachine,
-    disconnectMachine,
+
+    // new stuff
+    setPullerAdaptiveBaseSpeed,
+    setPullerAdaptiveDeviationLimit,
+    setPullerAdaptiveReferenceMachine
   };
 }

--- a/electron/src/machines/winder/winder2/useWinder.ts
+++ b/electron/src/machines/winder/winder2/useWinder.ts
@@ -580,7 +580,7 @@ export function useWinder2() {
   const setPullerAdaptiveMaxSpeedChangePercent = (percent: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state.adaptive_max_speed_change_percent = percent;
+        current.data.puller_state.adaptive_speed_delta_max = percent;
       },
       () =>
         requestPullerSetAdaptiveMaxSpeedChangePercent({
@@ -593,7 +593,7 @@ export function useWinder2() {
   const setPullerAdaptiveAdjustmentIntervalMeters = (meters: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state.adaptive_adjustment_interval_meters = meters;
+        current.data.puller_state.adaptive_adjustment_distance = meters;
       },
       () =>
         requestPullerSetAdaptiveAdjustmentIntervalMeters({
@@ -606,7 +606,7 @@ export function useWinder2() {
   const setPullerAdaptiveStepPercent = (percent: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state.adaptive_step_percent = percent;
+        current.data.puller_state.adaptive_increase_per_step = percent;
       },
       () =>
         requestPullerSetAdaptiveStepPercent({
@@ -619,7 +619,7 @@ export function useWinder2() {
   const setPullerAdaptiveAcceptedDifference = (mm: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state.adaptive_accepted_difference = mm;
+        current.data.puller_state.adaptive_tolerance_limit = mm;
       },
       () =>
         requestPullerSetAdaptiveAcceptedDifference({

--- a/electron/src/machines/winder/winder2/useWinder.ts
+++ b/electron/src/machines/winder/winder2/useWinder.ts
@@ -532,16 +532,19 @@ export function useWinder2() {
       SetPullerAdaptiveSpeedBase: z.number(),
     }),
   );
-  const { request: requestPullerSetAdaptiveDeviationLimit } = useMachineMutation(
-    z.object({
-      SetPullerAdaptiveDeviationLimit: z.number(),
-    }),
-  );
-  const { request: requestPullerSetAdaptiveReferenceMachine } = useMachineMutation(
-    z.object({
-      SetPullerAdaptiveReferenceMachine: machineIdentificationUnique.nullable(),
-    }),
-  );
+  const { request: requestPullerSetAdaptiveDeviationLimit } =
+    useMachineMutation(
+      z.object({
+        SetPullerAdaptiveDeviationLimit: z.number(),
+      }),
+    );
+  const { request: requestPullerSetAdaptiveReferenceMachine } =
+    useMachineMutation(
+      z.object({
+        SetPullerAdaptiveReferenceMachine:
+          machineIdentificationUnique.nullable(),
+      }),
+    );
 
   // more boilerplate junk setters from requests
   const setPullerAdaptiveBaseSpeed = (speed: number) => {
@@ -570,18 +573,18 @@ export function useWinder2() {
     );
   };
 
-  const setPullerAdaptiveReferenceMachine = (machineUid: {
-    machine_identification: {
-      vendor: number;
-      machine: number;
-    };
-    serial: number;
-  } | null) => {
+  const setPullerAdaptiveReferenceMachine = (
+    machineUid: {
+      machine_identification: {
+        vendor: number;
+        machine: number;
+      };
+      serial: number;
+    } | null,
+  ) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state
-          .adaptive_reference_machine
-            = machineUid;
+        current.data.puller_state.adaptive_reference_machine = machineUid;
       },
       () =>
         requestPullerSetAdaptiveReferenceMachine({
@@ -590,8 +593,6 @@ export function useWinder2() {
         }),
     );
   };
-
-
 
   // Calculate loading states
   const isLoading = stateOptimistic.isOptimistic;
@@ -614,8 +615,7 @@ export function useWinder2() {
 
   // Get selected machine by serial
   const selectedMachine = useMemo(() => {
-    const serial =
-      state?.data.puller_state.adaptive_reference_machine?.serial;
+    const serial = state?.data.puller_state.adaptive_reference_machine?.serial;
 
     return (
       filteredMachines.find(
@@ -677,6 +677,6 @@ export function useWinder2() {
     // new stuff
     setPullerAdaptiveBaseSpeed,
     setPullerAdaptiveDeviationLimit,
-    setPullerAdaptiveReferenceMachine
+    setPullerAdaptiveReferenceMachine,
   };
 }

--- a/electron/src/machines/winder/winder2/useWinder.ts
+++ b/electron/src/machines/winder/winder2/useWinder.ts
@@ -606,7 +606,7 @@ export function useWinder2() {
   const setPullerAdaptiveStepPercent = (percent: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state.adaptive_increase_per_step = percent;
+        current.data.puller_state.adaptive_change_per_step = percent;
       },
       () =>
         requestPullerSetAdaptiveStepPercent({
@@ -619,7 +619,7 @@ export function useWinder2() {
   const setPullerAdaptiveAcceptedDifference = (mm: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state.adaptive_tolerance_limit = mm;
+        current.data.puller_state.allowed_diameter_deviation = mm;
       },
       () =>
         requestPullerSetAdaptiveAcceptedDifference({

--- a/electron/src/machines/winder/winder2/useWinder.ts
+++ b/electron/src/machines/winder/winder2/useWinder.ts
@@ -527,11 +527,6 @@ export function useWinder2() {
   };
 
   // more requests for puller
-  const { request: requestPullerSetAdaptiveSpeedBase } = useMachineMutation(
-    z.object({
-      SetPullerAdaptiveSpeedBase: z.number(),
-    }),
-  );
   const { request: requestPullerSetAdaptiveMaxSpeedChangePercent } =
     useMachineMutation(
       z.object({
@@ -564,19 +559,6 @@ export function useWinder2() {
     );
 
   // more boilerplate junk setters from requests
-  const setPullerAdaptiveBaseSpeed = (speed: number) => {
-    updateStateOptimistically(
-      (current) => {
-        current.data.puller_state.adaptive_speed_base = speed;
-      },
-      () =>
-        requestPullerSetAdaptiveSpeedBase({
-          machine_identification_unique: machineIdentification,
-          data: { SetPullerAdaptiveSpeedBase: speed },
-        }),
-    );
-  };
-
   const setPullerAdaptiveMaxSpeedChangePercent = (percent: number) => {
     updateStateOptimistically(
       (current) => {
@@ -731,7 +713,6 @@ export function useWinder2() {
     setSpoolAdaptiveDeaccelerationUrgencyMultiplier,
 
     // new stuff
-    setPullerAdaptiveBaseSpeed,
     setPullerAdaptiveMaxSpeedChangePercent,
     setPullerAdaptiveAdjustmentIntervalMeters,
     setPullerAdaptiveStepPercent,

--- a/electron/src/machines/winder/winder2/useWinder.ts
+++ b/electron/src/machines/winder/winder2/useWinder.ts
@@ -532,10 +532,27 @@ export function useWinder2() {
       SetPullerAdaptiveSpeedBase: z.number(),
     }),
   );
-  const { request: requestPullerSetAdaptiveDeviationLimit } =
+  const { request: requestPullerSetAdaptiveMaxSpeedChangePercent } =
     useMachineMutation(
       z.object({
-        SetPullerAdaptiveDeviationLimit: z.number(),
+        SetPullerAdaptiveMaxSpeedChangePercent: z.number(),
+      }),
+    );
+  const { request: requestPullerSetAdaptiveAdjustmentIntervalMeters } =
+    useMachineMutation(
+      z.object({
+        SetPullerAdaptiveAdjustmentIntervalMeters: z.number(),
+      }),
+    );
+  const { request: requestPullerSetAdaptiveStepPercent } = useMachineMutation(
+    z.object({
+      SetPullerAdaptiveStepPercent: z.number(),
+    }),
+  );
+  const { request: requestPullerSetAdaptiveAcceptedDifference } =
+    useMachineMutation(
+      z.object({
+        SetPullerAdaptiveAcceptedDifference: z.number(),
       }),
     );
   const { request: requestPullerSetAdaptiveReferenceMachine } =
@@ -560,15 +577,54 @@ export function useWinder2() {
     );
   };
 
-  const setPullerAdaptiveDeviationLimit = (speed: number) => {
+  const setPullerAdaptiveMaxSpeedChangePercent = (percent: number) => {
     updateStateOptimistically(
       (current) => {
-        current.data.puller_state.adaptive_deviation_limit = speed;
+        current.data.puller_state.adaptive_max_speed_change_percent = percent;
       },
       () =>
-        requestPullerSetAdaptiveDeviationLimit({
+        requestPullerSetAdaptiveMaxSpeedChangePercent({
           machine_identification_unique: machineIdentification,
-          data: { SetPullerAdaptiveDeviationLimit: speed },
+          data: { SetPullerAdaptiveMaxSpeedChangePercent: percent },
+        }),
+    );
+  };
+
+  const setPullerAdaptiveAdjustmentIntervalMeters = (meters: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.puller_state.adaptive_adjustment_interval_meters = meters;
+      },
+      () =>
+        requestPullerSetAdaptiveAdjustmentIntervalMeters({
+          machine_identification_unique: machineIdentification,
+          data: { SetPullerAdaptiveAdjustmentIntervalMeters: meters },
+        }),
+    );
+  };
+
+  const setPullerAdaptiveStepPercent = (percent: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.puller_state.adaptive_step_percent = percent;
+      },
+      () =>
+        requestPullerSetAdaptiveStepPercent({
+          machine_identification_unique: machineIdentification,
+          data: { SetPullerAdaptiveStepPercent: percent },
+        }),
+    );
+  };
+
+  const setPullerAdaptiveAcceptedDifference = (mm: number) => {
+    updateStateOptimistically(
+      (current) => {
+        current.data.puller_state.adaptive_accepted_difference = mm;
+      },
+      () =>
+        requestPullerSetAdaptiveAcceptedDifference({
+          machine_identification_unique: machineIdentification,
+          data: { SetPullerAdaptiveAcceptedDifference: mm },
         }),
     );
   };
@@ -676,7 +732,10 @@ export function useWinder2() {
 
     // new stuff
     setPullerAdaptiveBaseSpeed,
-    setPullerAdaptiveDeviationLimit,
+    setPullerAdaptiveMaxSpeedChangePercent,
+    setPullerAdaptiveAdjustmentIntervalMeters,
+    setPullerAdaptiveStepPercent,
+    setPullerAdaptiveAcceptedDifference,
     setPullerAdaptiveReferenceMachine,
   };
 }

--- a/electron/src/machines/winder/winder2/winder2Config.ts
+++ b/electron/src/machines/winder/winder2/winder2Config.ts
@@ -33,3 +33,15 @@ export function getWinder2TraverseMax(): number {
     ? WINDER2_TRAVERSE_MAX_XL
     : WINDER2_TRAVERSE_MAX_STANDARD;
 }
+
+const WINDER2_ADAPTIVE_PULLER_SPEED_KEY =
+  "winder2_adaptive_puller_speed_enabled";
+
+export function getWinder2AdaptivePullerSpeed(): boolean {
+  const stored = localStorage.getItem(WINDER2_ADAPTIVE_PULLER_SPEED_KEY);
+  return stored === "true";
+}
+
+export function setWinder2AdaptivePullerSpeed(enabled: boolean): void {
+  localStorage.setItem(WINDER2_ADAPTIVE_PULLER_SPEED_KEY, enabled.toString());
+}

--- a/electron/src/machines/winder/winder2/winder2Namespace.ts
+++ b/electron/src/machines/winder/winder2/winder2Namespace.ts
@@ -139,7 +139,6 @@ export const pullerStateSchema = z.object({
   gear_ratio: gearRatioSchema,
 
   // properties of adaptive speed mode
-  adaptive_speed_base: z.number(),
   adaptive_speed_delta_max: z.number(),
   adaptive_adjustment_distance: z.number(),
   adaptive_change_per_step: z.number(),

--- a/electron/src/machines/winder/winder2/winder2Namespace.ts
+++ b/electron/src/machines/winder/winder2/winder2Namespace.ts
@@ -140,7 +140,10 @@ export const pullerStateSchema = z.object({
 
   // properties of adaptive speed mode
   adaptive_speed_base: z.number(),
-  adaptive_deviation_limit: z.number(),
+  adaptive_max_speed_change_percent: z.number(),
+  adaptive_adjustment_interval_meters: z.number(),
+  adaptive_step_percent: z.number(),
+  adaptive_accepted_difference: z.number(),
   adaptive_reference_machine: machineIdentificationUniqueSchema.nullable(),
 });
 

--- a/electron/src/machines/winder/winder2/winder2Namespace.ts
+++ b/electron/src/machines/winder/winder2/winder2Namespace.ts
@@ -96,6 +96,19 @@ export type SpoolAutomaticActionState = z.infer<
 >;
 
 /**
+ *  Connected machine state scheme
+ */
+export const machineIdentificationSchema = z.object({
+  vendor: z.number(),
+  machine: z.number(),
+});
+
+export const machineIdentificationUniqueSchema = z.object({
+  machine_identification: machineIdentificationSchema,
+  serial: z.number(),
+});
+
+/**
  * Traverse state schema
  */
 export const traverseStateSchema = z.object({
@@ -122,9 +135,13 @@ export const traverseStateSchema = z.object({
 export const pullerStateSchema = z.object({
   regulation: pullerRegulationSchema,
   target_speed: z.number(),
-  target_diameter: z.number(),
   forward: z.boolean(),
   gear_ratio: gearRatioSchema,
+
+  // properties of adaptive speed mode
+  adaptive_speed_base: z.number(),
+  adaptive_deviation_limit: z.number(),
+  adaptive_reference_machine: machineIdentificationUniqueSchema.nullable(),
 });
 
 /**
@@ -133,24 +150,6 @@ export const pullerStateSchema = z.object({
 export const modeStateSchema = z.object({
   mode: modeSchema,
   can_wind: z.boolean(),
-});
-
-/**
- *  Connected machine state scheme
- */
-export const machineIdentificationSchema = z.object({
-  vendor: z.number(),
-  machine: z.number(),
-});
-
-export const machineIdentificationUniqueSchema = z.object({
-  machine_identification: machineIdentificationSchema,
-  serial: z.number(),
-});
-
-export const connectedMachineStateSchema = z.object({
-  machine_identification_unique: machineIdentificationUniqueSchema.nullable(),
-  is_available: z.boolean(),
 });
 
 /**
@@ -186,7 +185,6 @@ export const stateEventDataSchema = z.object({
   tension_arm_state: tensionArmStateSchema,
   spool_speed_controller_state: spoolSpeedControllerStateSchema,
   spool_automatic_action_state: spoolAutomaticActionStateSchema,
-  connected_machine_state: connectedMachineStateSchema,
 });
 
 // ========== Event Schemas with Wrappers ==========

--- a/electron/src/machines/winder/winder2/winder2Namespace.ts
+++ b/electron/src/machines/winder/winder2/winder2Namespace.ts
@@ -142,8 +142,8 @@ export const pullerStateSchema = z.object({
   adaptive_speed_base: z.number(),
   adaptive_speed_delta_max: z.number(),
   adaptive_adjustment_distance: z.number(),
-  adaptive_increase_per_step: z.number(),
-  adaptive_tolerance_limit: z.number(),
+  adaptive_change_per_step: z.number(),
+  allowed_diameter_deviation: z.number(),
   adaptive_reference_machine: machineIdentificationUniqueSchema.nullable(),
 });
 

--- a/electron/src/machines/winder/winder2/winder2Namespace.ts
+++ b/electron/src/machines/winder/winder2/winder2Namespace.ts
@@ -140,10 +140,10 @@ export const pullerStateSchema = z.object({
 
   // properties of adaptive speed mode
   adaptive_speed_base: z.number(),
-  adaptive_max_speed_change_percent: z.number(),
-  adaptive_adjustment_interval_meters: z.number(),
-  adaptive_step_percent: z.number(),
-  adaptive_accepted_difference: z.number(),
+  adaptive_speed_delta_max: z.number(),
+  adaptive_adjustment_distance: z.number(),
+  adaptive_increase_per_step: z.number(),
+  adaptive_tolerance_limit: z.number(),
   adaptive_reference_machine: machineIdentificationUniqueSchema.nullable(),
 });
 

--- a/machines/src/aquapath1/act.rs
+++ b/machines/src/aquapath1/act.rs
@@ -44,12 +44,6 @@ impl MachineAct for AquaPathV1 {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/buffer1/act.rs
+++ b/machines/src/buffer1/act.rs
@@ -32,12 +32,6 @@ impl MachineAct for BufferV1 {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/extruder1/act.rs
+++ b/machines/src/extruder1/act.rs
@@ -62,10 +62,6 @@ impl MachineAct for ExtruderV2 {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {}
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/extruder1/mock/act.rs
+++ b/machines/src/extruder1/mock/act.rs
@@ -34,12 +34,6 @@ impl MachineAct for ExtruderV2 {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => (),
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-            /*Doesnt connec to any Machine do nothing*/
-            {
-                ()
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/extruder2/act.rs
+++ b/machines/src/extruder2/act.rs
@@ -65,10 +65,6 @@ impl MachineAct for ExtruderV3 {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {}
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/extruder2/mock/act.rs
+++ b/machines/src/extruder2/mock/act.rs
@@ -33,10 +33,6 @@ impl MachineAct for ExtruderV2 {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {}
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-                /*Doesnt connec to any Machine do nothing*/
-                {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/laser/act.rs
+++ b/machines/src/laser/act.rs
@@ -60,12 +60,6 @@ impl MachineAct for LaserMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-                /*Doesnt connect to any Machine so do nothing*/
-                {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/laser/mod.rs
+++ b/machines/src/laser/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     MACHINE_LASER_V1, VENDOR_QITECH,
     machine_identification::{MachineIdentification, MachineIdentificationUnique},
 };
-use crate::{Machine, MachineMessage, MachineData};
+use crate::{Machine, MachineData, MachineMessage};
 use api::{LaserEvents, LaserMachineNamespace, LaserState, LiveValuesEvent, StateEvent};
 use control_core::socketio::namespace::NamespaceCacheingLogic;
 use smol::{
@@ -67,23 +67,20 @@ impl Machine for LaserMachine {
         self.main_sender.clone()
     }
 
-    fn mutation_counter(&self) -> u64 
-    { 
+    fn mutation_counter(&self) -> u64 {
         self.mutation_counter
     }
 
     fn update_machine_data(
-        &self, 
-        data: &mut MachineData, 
-        refresh_state: bool, 
-        refresh_live_values: bool)
-    {
+        &self,
+        data: &mut MachineData,
+        refresh_state: bool,
+        refresh_live_values: bool,
+    ) {
         use MachineData::*;
 
-        match data 
-        {
-            Laser(state, live_values) => 
-            {
+        match data {
+            Laser(state, live_values) => {
                 if refresh_state {
                     *state = self.build_state_event();
                 }
@@ -91,14 +88,10 @@ impl Machine for LaserMachine {
                 if refresh_live_values {
                     *live_values = self.get_live_values();
                 }
-            },
-            _ => 
-            {
-                *data = MachineData::Laser(
-                    self.build_state_event(), 
-                    self.get_live_values()
-                );
-            },
+            }
+            _ => {
+                *data = MachineData::Laser(self.build_state_event(), self.get_live_values());
+            }
         };
     }
 }

--- a/machines/src/laser/mod.rs
+++ b/machines/src/laser/mod.rs
@@ -71,6 +71,36 @@ impl Machine for LaserMachine {
     { 
         self.mutation_counter
     }
+
+    fn update_machine_data(
+        &self, 
+        data: &mut MachineData, 
+        refresh_state: bool, 
+        refresh_live_values: bool)
+    {
+        use MachineData::*;
+
+        match data 
+        {
+            Laser(state, live_values) => 
+            {
+                if refresh_state {
+                    *state = self.build_state_event();
+                }
+
+                if refresh_live_values {
+                    *live_values = self.get_live_values();
+                }
+            },
+            _ => 
+            {
+                *data = MachineData::Laser(
+                    self.build_state_event(), 
+                    self.get_live_values()
+                );
+            },
+        };
+    }
 }
 
 impl LaserMachineNamespace {

--- a/machines/src/laser/mod.rs
+++ b/machines/src/laser/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     MACHINE_LASER_V1, VENDOR_QITECH,
     machine_identification::{MachineIdentification, MachineIdentificationUnique},
 };
-use crate::{Machine, MachineMessage};
+use crate::{Machine, MachineMessage, MachineData};
 use api::{LaserEvents, LaserMachineNamespace, LaserState, LiveValuesEvent, StateEvent};
 use control_core::socketio::namespace::NamespaceCacheingLogic;
 use smol::{
@@ -27,6 +27,9 @@ pub struct LaserMachine {
     api_sender: Sender<MachineMessage>,
     machine_identification_unique: MachineIdentificationUnique,
     main_sender: Option<Sender<AsyncThreadMessage>>,
+
+    // state
+    mutation_counter: u64,
 
     // drivers
     laser: Arc<RwLock<Laser>>,
@@ -62,6 +65,11 @@ impl Machine for LaserMachine {
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {
         self.main_sender.clone()
+    }
+
+    fn mutation_counter(&self) -> u64 
+    { 
+        self.mutation_counter
     }
 }
 
@@ -153,18 +161,21 @@ impl LaserMachine {
     pub fn set_higher_tolerance(&mut self, higher_tolerance: f64) {
         self.higher_tolerance = Length::new::<millimeter>(higher_tolerance);
         self.laser_target.higher_tolerance = self.higher_tolerance;
+        self.mutation_counter += 1;
         self.emit_state();
     }
 
     pub fn set_lower_tolerance(&mut self, lower_tolerance: f64) {
         self.lower_tolerance = Length::new::<millimeter>(lower_tolerance);
         self.laser_target.lower_tolerance = self.lower_tolerance;
+        self.mutation_counter += 1;
         self.emit_state();
     }
 
     pub fn set_target_diameter(&mut self, target_diameter: f64) {
         self.target_diameter = Length::new::<millimeter>(target_diameter);
         self.laser_target.diameter = Length::new::<millimeter>(target_diameter);
+        self.mutation_counter += 1;
         self.emit_state();
     }
 

--- a/machines/src/laser/new.rs
+++ b/machines/src/laser/new.rs
@@ -39,6 +39,7 @@ impl MachineNewTrait for LaserMachine {
             api_receiver: receiver,
             api_sender: sender,
             machine_identification_unique: params.get_machine_identification_unique(),
+            mutation_counter: 0,
             laser,
             namespace: LaserMachineNamespace {
                 namespace: params.namespace.clone(),

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -32,7 +32,7 @@ pub mod wago_serial_machine;
 pub mod winder2;
 
 mod machine_data;
-pub use machine_data::MachinesData;
+pub use machine_data::MachineData;
 
 pub const VENDOR_QITECH: u16 = 0x0001;
 pub const MACHINE_WINDER_V1: u16 = 0x0002;
@@ -310,11 +310,11 @@ pub trait Machine: MachineAct + MachineApi + Any + Debug + Send + Sync {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique;
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>>;
 
-    fn state_generation(&self) -> u64 { 0 }
+    fn mutation_counter(&self) -> u64 { 0 }
 
     fn refresh_data(
         &self, 
-        data: &mut MachinesData, 
+        data: &mut MachineData, 
         refresh_state: bool, 
         refresh_live_values: bool
     )
@@ -324,7 +324,7 @@ pub trait Machine: MachineAct + MachineApi + Any + Debug + Send + Sync {
         _ = refresh_live_values;
     }
 
-    fn receive_machines_data(&mut self, data: &MachinesData) {
+    fn receive_machines_data(&mut self, data: &MachineData) {
         _ = data;
     }
 

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -60,7 +60,7 @@ use smol::lock::RwLock;
 
 pub struct MachineSubscriptionRequest {
     pub subscriber: MachineIdentificationUnique,
-    pub publisher:  MachineIdentificationUnique,
+    pub publisher: MachineIdentificationUnique,
 }
 
 pub enum AsyncThreadMessage {
@@ -308,15 +308,16 @@ pub trait Machine: MachineAct + MachineApi + Any + Debug + Send + Sync {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique;
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>>;
 
-    fn mutation_counter(&self) -> u64 { 0 }
+    fn mutation_counter(&self) -> u64 {
+        0
+    }
 
     fn update_machine_data(
-        &self, 
-        data: &mut MachineData, 
-        refresh_state: bool, 
-        refresh_live_values: bool
-    )
-    {
+        &self,
+        data: &mut MachineData,
+        refresh_state: bool,
+        refresh_live_values: bool,
+    ) {
         _ = data;
         _ = refresh_state;
         _ = refresh_live_values;

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -295,8 +295,6 @@ pub enum MachineMessage {
     SubscribeNamespace(Namespace),
     UnsubscribeNamespace,
     HttpApiJsonRequest(serde_json::Value),
-    ConnectToMachine(MachineConnection),
-    DisconnectMachine(MachineConnection),
     RequestValues(Sender<MachineValues>),
 }
 
@@ -312,7 +310,7 @@ pub trait Machine: MachineAct + MachineApi + Any + Debug + Send + Sync {
 
     fn mutation_counter(&self) -> u64 { 0 }
 
-    fn refresh_data(
+    fn update_machine_data(
         &self, 
         data: &mut MachineData, 
         refresh_state: bool, 
@@ -551,12 +549,6 @@ where
             }
             MachineMessage::HttpApiJsonRequest(value) => {
                 let _ = self.api_mutate(value);
-            }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                todo!();
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                todo!();
             }
             MachineMessage::RequestValues(sender) => {
                 sender

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -31,6 +31,9 @@ pub mod wago_power;
 pub mod wago_serial_machine;
 pub mod winder2;
 
+mod machine_data;
+pub use machine_data::MachinesData;
+
 pub const VENDOR_QITECH: u16 = 0x0001;
 pub const MACHINE_WINDER_V1: u16 = 0x0002;
 pub const MACHINE_EXTRUDER_V1: u16 = 0x0004;
@@ -55,21 +58,15 @@ pub const WAGO_750_501_TEST_MACHINE: u16 = 0x0042;
 use serde_json::Value;
 use smol::lock::RwLock;
 
-#[derive(Serialize, Debug, Clone)]
-pub struct MachineCrossConnectionState {
-    machine_identification_unique: Option<MachineIdentificationUnique>,
-    is_available: bool,
-}
-
-pub struct CrossConnection {
-    pub src: MachineIdentificationUnique,
-    pub dest: MachineIdentificationUnique,
+pub struct MachineSubscriptionRequest {
+    pub subscriber: MachineIdentificationUnique,
+    pub publisher:  MachineIdentificationUnique,
 }
 
 pub enum AsyncThreadMessage {
     NoMsg,
-    ConnectOneWayRequest(CrossConnection),
-    DisconnectMachines(CrossConnection),
+    SubscribeToMachine(MachineSubscriptionRequest),
+    UnsubscribeFromMachine(MachineSubscriptionRequest),
 }
 
 pub struct MachineNewParams<
@@ -312,6 +309,32 @@ pub trait MachineApi {
 pub trait Machine: MachineAct + MachineApi + Any + Debug + Send + Sync {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique;
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>>;
+
+    fn state_generation(&self) -> u64 { 0 }
+
+    fn refresh_data(
+        &self, 
+        data: &mut MachinesData, 
+        refresh_state: bool, 
+        refresh_live_values: bool
+    )
+    {
+        _ = data;
+        _ = refresh_state;
+        _ = refresh_live_values;
+    }
+
+    fn receive_machines_data(&mut self, data: &MachinesData) {
+        _ = data;
+    }
+
+    fn subscribed_to_machine(&mut self, uid: MachineIdentificationUnique) {
+        _ = uid;
+    }
+
+    fn unsubscribed_from_machine(&mut self, uid: MachineIdentificationUnique) {
+        _ = uid;
+    }
 }
 
 pub trait AnyGetters: Any {

--- a/machines/src/machine_data.rs
+++ b/machines/src/machine_data.rs
@@ -1,0 +1,8 @@
+use crate::laser::api::{LiveValuesEvent as LaserLiveValues, StateEvent as LaserState};
+
+#[derive(Debug, Clone)]
+pub enum MachinesData
+{
+    Laser(LaserState, LaserLiveValues),
+    None,
+}

--- a/machines/src/machine_data.rs
+++ b/machines/src/machine_data.rs
@@ -1,7 +1,7 @@
 use crate::laser::api::{LiveValuesEvent as LaserLiveValues, StateEvent as LaserState};
 
 #[derive(Debug, Clone)]
-pub enum MachinesData
+pub enum MachineData
 {
     Laser(LaserState, LaserLiveValues),
     None,

--- a/machines/src/machine_data.rs
+++ b/machines/src/machine_data.rs
@@ -1,8 +1,7 @@
 use crate::laser::api::{LiveValuesEvent as LaserLiveValues, StateEvent as LaserState};
 
 #[derive(Debug, Clone)]
-pub enum MachineData
-{
+pub enum MachineData {
     Laser(LaserState, LaserLiveValues),
     None,
 }

--- a/machines/src/machine_identification.rs
+++ b/machines/src/machine_identification.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// Identifies a specific machine
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct MachineIdentificationUnique {
     pub machine_identification: MachineIdentification,
     pub serial: u16,
@@ -30,7 +30,7 @@ impl Display for MachineIdentificationUnique {
 }
 
 /// Identifies a machine
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct MachineIdentification {
     pub vendor: u16,
     pub machine: u16,

--- a/machines/src/minimal_machines/analog_input_test_machine/act.rs
+++ b/machines/src/minimal_machines/analog_input_test_machine/act.rs
@@ -17,8 +17,6 @@ impl MachineAct for AnalogInputTestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            crate::MachineMessage::ConnectToMachine(_machine_connection) => {}
-            MachineMessage::DisconnectMachine(_machine_connection) => {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/digital_input_test_machine/act.rs
+++ b/machines/src/minimal_machines/digital_input_test_machine/act.rs
@@ -25,12 +25,6 @@ impl MachineAct for DigitalInputTestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/ip20_test_machine/act.rs
+++ b/machines/src/minimal_machines/ip20_test_machine/act.rs
@@ -36,12 +36,6 @@ impl MachineAct for IP20TestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/mock/act.rs
+++ b/machines/src/minimal_machines/mock/act.rs
@@ -47,16 +47,6 @@ impl MachineAct for MockMachine {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) =>
-            /*Doesnt connect to any Machine so do nothing*/
-            {
-                ()
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-            /*Doesnt connect to any Machine so do nothing*/
-            {
-                ()
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/test_machine/act.rs
+++ b/machines/src/minimal_machines/test_machine/act.rs
@@ -25,12 +25,6 @@ impl MachineAct for TestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/test_machine_stepper/act.rs
+++ b/machines/src/minimal_machines/test_machine_stepper/act.rs
@@ -25,8 +25,6 @@ impl MachineAct for TestMachineStepper {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {}
-            MachineMessage::DisconnectMachine(_machine_connection) => {}
             MachineMessage::RequestValues(_sender) => {}
         }
     }

--- a/machines/src/minimal_machines/wago_750_430_di_machine/act.rs
+++ b/machines/src/minimal_machines/wago_750_430_di_machine/act.rs
@@ -25,12 +25,6 @@ impl MachineAct for Wago750_430DiMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/wago_750_501_test_machine/act.rs
+++ b/machines/src/minimal_machines/wago_750_501_test_machine/act.rs
@@ -25,12 +25,6 @@ impl MachineAct for Wago750_501TestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/wago_8ch_dio_test_machine/act.rs
+++ b/machines/src/minimal_machines/wago_8ch_dio_test_machine/act.rs
@@ -25,12 +25,6 @@ impl MachineAct for Wago8chDigitalIOTestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/wago_ai_test_machine/act.rs
+++ b/machines/src/minimal_machines/wago_ai_test_machine/act.rs
@@ -17,8 +17,6 @@ impl MachineAct for WagoAiTestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            crate::MachineMessage::ConnectToMachine(_machine_connection) => {}
-            MachineMessage::DisconnectMachine(_machine_connection) => {}
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/minimal_machines/wago_do_test_machine/act.rs
+++ b/machines/src/minimal_machines/wago_do_test_machine/act.rs
@@ -25,12 +25,6 @@ impl MachineAct for WagoDOTestMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/wago_serial_machine/act.rs
+++ b/machines/src/wago_serial_machine/act.rs
@@ -35,12 +35,6 @@ impl MachineAct for WagoSerialMachine {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                // Does not connect to any Machine; do nothing
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/winder2/act.rs
+++ b/machines/src/winder2/act.rs
@@ -47,20 +47,6 @@ impl MachineAct for Winder2 {
                 use crate::MachineApi;
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(machine_connection) => {
-                if self.connected_machines.len() >= self.max_connected_machines {
-                    tracing::debug!(
-                        "Refusing to add Machine Connection {:?}, since self.connected_machines would be over the limit of {:?}",
-                        machine_connection,
-                        self.max_connected_machines
-                    );
-                    return;
-                }
-                self.connected_machines.push(machine_connection);
-            }
-            MachineMessage::DisconnectMachine(_machine_connection) => {
-                self.connected_machines.clear();
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -235,9 +235,9 @@ pub struct PullerState {
     /// Minimum meters between consecutive adjustments
     pub adaptive_adjustment_distance: f64,
     /// Step size per adjustment as a percentage of base speed (0.0–100.0)
-    pub adaptive_increase_per_step: f64,
+    pub adaptive_change_per_step: f64,
     /// Inner deadzone: max deviation from target (mm) that requires no correction
-    pub adaptive_tolerance_limit: f64,
+    pub allowed_diameter_deviation: f64,
     pub adaptive_reference_machine: Option<MachineIdentificationUnique>,
 }
 

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -365,7 +365,8 @@ impl MachineApi for Winder2 {
             Mutation::SetSpoolAutomaticAction(mode) => self.set_spool_automatic_mode(mode),
             Mutation::ResetSpoolProgress => self.stop_or_pull_spool_reset(Instant::now()),
             Mutation::ZeroTensionArmAngle => self.tension_arm_zero(),
-            Mutation::SetConnectedMachine(machine_identification_unique) => {
+            Mutation::SetConnectedMachine(machine_uid) => 
+            {
                 let main_sender = match &self.main_sender {
                     Some(sender) => sender,
                     None => {

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -48,9 +48,9 @@ mod winder2_imports {
 use smol::channel::Sender;
 pub use winder2_imports::*;
 
+use crate::machine_identification::MachineIdentificationUnique;
 #[cfg(not(feature = "mock-machine"))]
 use crate::{MachineApi, MachineMessage};
-use crate::{machine_identification::MachineIdentificationUnique};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub enum Mode {
@@ -368,12 +368,13 @@ impl MachineApi for Winder2 {
             Mutation::ZeroTensionArmAngle => self.tension_arm_zero(),
 
             // puller adaptive speed algorithm
-            Mutation::SetPullerAdaptiveSpeedBase(v) =>
-                self.puller_set_adaptive_speed_base(v),
-            Mutation::SetPullerAdaptiveDeviationLimit(v) => 
-                self.puller_set_adaptive_deviation_limit(v),
-            Mutation::SetPullerAdaptiveReferenceMachine(v) => 
-                self.puller_set_adaptive_reference_machine(v)?,
+            Mutation::SetPullerAdaptiveSpeedBase(v) => self.puller_set_adaptive_speed_base(v),
+            Mutation::SetPullerAdaptiveDeviationLimit(v) => {
+                self.puller_set_adaptive_deviation_limit(v)
+            }
+            Mutation::SetPullerAdaptiveReferenceMachine(v) => {
+                self.puller_set_adaptive_reference_machine(v)?
+            }
         }
         Ok(())
     }

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -50,7 +50,7 @@ pub use winder2_imports::*;
 
 #[cfg(not(feature = "mock-machine"))]
 use crate::{MachineApi, MachineMessage};
-use crate::{MachineCrossConnectionState, machine_identification::MachineIdentificationUnique};
+use crate::{machine_identification::MachineIdentificationUnique};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub enum Mode {
@@ -132,11 +132,10 @@ pub enum Mutation {
     // Mode
     SetMode(Mode),
 
-    // Connected Machine
-    SetConnectedMachine(MachineIdentificationUnique),
-
-    // Disconnect Machine
-    DisconnectMachine(MachineIdentificationUnique),
+    // Set puller adapative reference machine
+    SetPullerAdaptiveSpeedBase(f64),
+    SetPullerAdaptiveDeviationLimit(f64),
+    SetPullerAdaptiveReferenceMachine(Option<MachineIdentificationUnique>),
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
@@ -175,7 +174,7 @@ pub struct StateEvent {
     /// spool speed controller state
     pub spool_speed_controller_state: SpoolSpeedControllerState,
     /// Is a Machine Connected?
-    pub connected_machine_state: MachineCrossConnectionState,
+    pub puller_reference_machine: Option<MachineIdentificationUnique>,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
@@ -218,12 +217,14 @@ pub struct PullerState {
     pub regulation: PullerRegulationMode,
     /// target speed in m/min
     pub target_speed: f64,
-    /// target diameter in mm
-    pub target_diameter: f64,
     /// forward rotation direction
     pub forward: bool,
     /// gear ratio for winding speed
     pub gear_ratio: GearRatio,
+
+    pub adaptive_speed_base: f64,
+    pub adaptive_deviation_limit: f64,
+    pub adaptive_reference_machine: Option<MachineIdentificationUnique>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
@@ -365,34 +366,14 @@ impl MachineApi for Winder2 {
             Mutation::SetSpoolAutomaticAction(mode) => self.set_spool_automatic_mode(mode),
             Mutation::ResetSpoolProgress => self.stop_or_pull_spool_reset(Instant::now()),
             Mutation::ZeroTensionArmAngle => self.tension_arm_zero(),
-            Mutation::SetConnectedMachine(machine_uid) => 
-            {
-                let main_sender = match &self.main_sender {
-                    Some(sender) => sender,
-                    None => {
-                        return Err(anyhow::anyhow!(
-                            "Machine cannot connect to others! {:?}",
-                            self.get_machine_identification_unique()
-                        ));
-                    }
-                };
-                main_sender.try_send(crate::AsyncThreadMessage::ConnectOneWayRequest(
-                    crate::CrossConnection {
-                        src: self.get_machine_identification_unique(),
-                        dest: machine_identification_unique,
-                    },
-                ))?;
-                self.emit_state();
-            }
-            Mutation::DisconnectMachine(_machine_identification_unique) => {
-                self.connected_machines.clear();
-                /*let main_sender = match &self.main_sender {
-                    Some(sender) => sender,
-                    None => return Err(anyhow::anyhow!("[DisconnectMachine] Machine cannot connect to others! {:?}", self.machine_identification_unique)),
-                };*/
-                //main_sender.try_send(crate::AsyncThreadMessage::ConnectOneWayRequest(crate::CrossConnection { src: self.get_machine_identification_unique(), dest: machine_identification_unique }))?;
-                self.emit_state();
-            }
+
+            // puller adaptive speed algorithm
+            Mutation::SetPullerAdaptiveSpeedBase(v) =>
+                self.puller_set_adaptive_speed_base(v),
+            Mutation::SetPullerAdaptiveDeviationLimit(v) => 
+                self.puller_set_adaptive_deviation_limit(v),
+            Mutation::SetPullerAdaptiveReferenceMachine(v) => 
+                self.puller_set_adaptive_reference_machine(v)?,
         }
         Ok(())
     }

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -231,13 +231,13 @@ pub struct PullerState {
 
     pub adaptive_speed_base: f64,
     /// Maximum speed change as a percentage of base speed (0.0–100.0)
-    pub adaptive_max_speed_change_percent: f64,
+    pub adaptive_speed_delta_max: f64,
     /// Minimum meters between consecutive adjustments
-    pub adaptive_adjustment_interval_meters: f64,
+    pub adaptive_adjustment_distance: f64,
     /// Step size per adjustment as a percentage of base speed (0.0–100.0)
-    pub adaptive_step_percent: f64,
+    pub adaptive_increase_per_step: f64,
     /// Inner deadzone: max deviation from target (mm) that requires no correction
-    pub adaptive_accepted_difference: f64,
+    pub adaptive_tolerance_limit: f64,
     pub adaptive_reference_machine: Option<MachineIdentificationUnique>,
 }
 

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -133,7 +133,6 @@ pub enum Mutation {
     SetMode(Mode),
 
     // Set puller adaptive reference machine
-    SetPullerAdaptiveSpeedBase(f64),
     /// Maximum speed change as a percentage of base speed (0.0–100.0)
     SetPullerAdaptiveMaxSpeedChangePercent(f64),
     /// Minimum meters between consecutive adjustments
@@ -229,7 +228,6 @@ pub struct PullerState {
     /// gear ratio for winding speed
     pub gear_ratio: GearRatio,
 
-    pub adaptive_speed_base: f64,
     /// Maximum speed change as a percentage of base speed (0.0–100.0)
     pub adaptive_speed_delta_max: f64,
     /// Minimum meters between consecutive adjustments
@@ -380,7 +378,6 @@ impl MachineApi for Winder2 {
             Mutation::ZeroTensionArmAngle => self.tension_arm_zero(),
 
             // puller adaptive speed algorithm
-            Mutation::SetPullerAdaptiveSpeedBase(v) => self.puller_set_adaptive_speed_base(v),
             Mutation::SetPullerAdaptiveMaxSpeedChangePercent(v) => {
                 self.puller_set_adaptive_max_speed_change_percent(v)
             }

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -132,9 +132,16 @@ pub enum Mutation {
     // Mode
     SetMode(Mode),
 
-    // Set puller adapative reference machine
+    // Set puller adaptive reference machine
     SetPullerAdaptiveSpeedBase(f64),
-    SetPullerAdaptiveDeviationLimit(f64),
+    /// Maximum speed change as a percentage of base speed (0.0–100.0)
+    SetPullerAdaptiveMaxSpeedChangePercent(f64),
+    /// Minimum meters between consecutive adjustments
+    SetPullerAdaptiveAdjustmentIntervalMeters(f64),
+    /// Step size per adjustment as a percentage of base speed (0.0–100.0)
+    SetPullerAdaptiveStepPercent(f64),
+    /// Inner deadzone: max deviation from target (mm) that requires no correction
+    SetPullerAdaptiveAcceptedDifference(f64),
     SetPullerAdaptiveReferenceMachine(Option<MachineIdentificationUnique>),
 }
 
@@ -223,7 +230,14 @@ pub struct PullerState {
     pub gear_ratio: GearRatio,
 
     pub adaptive_speed_base: f64,
-    pub adaptive_deviation_limit: f64,
+    /// Maximum speed change as a percentage of base speed (0.0–100.0)
+    pub adaptive_max_speed_change_percent: f64,
+    /// Minimum meters between consecutive adjustments
+    pub adaptive_adjustment_interval_meters: f64,
+    /// Step size per adjustment as a percentage of base speed (0.0–100.0)
+    pub adaptive_step_percent: f64,
+    /// Inner deadzone: max deviation from target (mm) that requires no correction
+    pub adaptive_accepted_difference: f64,
     pub adaptive_reference_machine: Option<MachineIdentificationUnique>,
 }
 
@@ -367,8 +381,15 @@ impl MachineApi for Winder2 {
 
             // puller adaptive speed algorithm
             Mutation::SetPullerAdaptiveSpeedBase(v) => self.puller_set_adaptive_speed_base(v),
-            Mutation::SetPullerAdaptiveDeviationLimit(v) => {
-                self.puller_set_adaptive_deviation_limit(v)
+            Mutation::SetPullerAdaptiveMaxSpeedChangePercent(v) => {
+                self.puller_set_adaptive_max_speed_change_percent(v)
+            }
+            Mutation::SetPullerAdaptiveAdjustmentIntervalMeters(v) => {
+                self.puller_set_adaptive_adjustment_interval_meters(v)
+            }
+            Mutation::SetPullerAdaptiveStepPercent(v) => self.puller_set_adaptive_step_percent(v),
+            Mutation::SetPullerAdaptiveAcceptedDifference(v) => {
+                self.puller_set_adaptive_accepted_difference(v)
             }
             Mutation::SetPullerAdaptiveReferenceMachine(v) => {
                 self.puller_set_adaptive_reference_machine(v)?

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -323,8 +323,6 @@ impl MachineApi for Winder2 {
     }
 
     fn api_mutate(&mut self, request_body: Value) -> Result<(), anyhow::Error> {
-        use crate::Machine;
-
         let mutation: Mutation = serde_json::from_value(request_body)?;
         match mutation {
             Mutation::EnableTraverseLaserpointer(enable) => self.set_laser(enable),

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -268,11 +268,11 @@ impl Winder2 {
                     .adaptive
                     .adjustment_distance()
                     .get::<meter>(),
-                adaptive_increase_per_step: self
+                adaptive_change_per_step: self
                     .puller_speed_controller
                     .adaptive
                     .increase_per_step(),
-                adaptive_tolerance_limit: self
+                allowed_diameter_deviation: self
                     .puller_speed_controller
                     .adaptive
                     .tolerance_limit()

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -262,11 +262,19 @@ impl Winder2 {
                     .adaptive
                     .speed_base()
                     .get::<meter_per_minute>(),
-                adaptive_deviation_limit: self
+                adaptive_max_speed_change_percent: self
                     .puller_speed_controller
                     .adaptive
-                    .deviation_limit()
-                    .get::<meter_per_minute>(),
+                    .max_speed_change_percent(),
+                adaptive_adjustment_interval_meters: self
+                    .puller_speed_controller
+                    .adaptive
+                    .adjustment_interval_meters(),
+                adaptive_step_percent: self.puller_speed_controller.adaptive.step_percent(),
+                adaptive_accepted_difference: self
+                    .puller_speed_controller
+                    .adaptive
+                    .accepted_difference(),
                 adaptive_reference_machine: self.puller_reference_machine,
             },
             mode_state: ModeState {
@@ -509,11 +517,31 @@ impl Winder2 {
         self.emit_state();
     }
 
-    pub fn puller_set_adaptive_deviation_limit(&mut self, value: f64) {
-        let speed = Velocity::new::<meter_per_minute>(value);
+    pub fn puller_set_adaptive_max_speed_change_percent(&mut self, value: f64) {
         self.puller_speed_controller
             .adaptive
-            .set_deviation_limit(speed);
+            .set_max_speed_change_percent(value);
+        self.emit_state();
+    }
+
+    pub fn puller_set_adaptive_adjustment_interval_meters(&mut self, value: f64) {
+        self.puller_speed_controller
+            .adaptive
+            .set_adjustment_interval_meters(value);
+        self.emit_state();
+    }
+
+    pub fn puller_set_adaptive_step_percent(&mut self, value: f64) {
+        self.puller_speed_controller
+            .adaptive
+            .set_step_percent(value);
+        self.emit_state();
+    }
+
+    pub fn puller_set_adaptive_accepted_difference(&mut self, value: f64) {
+        self.puller_speed_controller
+            .adaptive
+            .set_accepted_difference(value);
         self.emit_state();
     }
 

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -262,19 +262,21 @@ impl Winder2 {
                     .adaptive
                     .speed_base()
                     .get::<meter_per_minute>(),
-                adaptive_max_speed_change_percent: self
+                adaptive_speed_delta_max: self.puller_speed_controller.adaptive.speed_delta_max(),
+                adaptive_adjustment_distance: self
                     .puller_speed_controller
                     .adaptive
-                    .max_speed_change_percent(),
-                adaptive_adjustment_interval_meters: self
+                    .adjustment_distance()
+                    .get::<meter>(),
+                adaptive_increase_per_step: self
                     .puller_speed_controller
                     .adaptive
-                    .adjustment_interval_meters(),
-                adaptive_step_percent: self.puller_speed_controller.adaptive.step_percent(),
-                adaptive_accepted_difference: self
+                    .increase_per_step(),
+                adaptive_tolerance_limit: self
                     .puller_speed_controller
                     .adaptive
-                    .accepted_difference(),
+                    .tolerance_limit()
+                    .get::<millimeter>(),
                 adaptive_reference_machine: self.puller_reference_machine,
             },
             mode_state: ModeState {
@@ -520,28 +522,28 @@ impl Winder2 {
     pub fn puller_set_adaptive_max_speed_change_percent(&mut self, value: f64) {
         self.puller_speed_controller
             .adaptive
-            .set_max_speed_change_percent(value);
+            .set_speed_delta_max(value);
         self.emit_state();
     }
 
     pub fn puller_set_adaptive_adjustment_interval_meters(&mut self, value: f64) {
         self.puller_speed_controller
             .adaptive
-            .set_adjustment_interval_meters(value);
+            .set_adjustment_distance(Length::new::<meter>(value));
         self.emit_state();
     }
 
     pub fn puller_set_adaptive_step_percent(&mut self, value: f64) {
         self.puller_speed_controller
             .adaptive
-            .set_step_percent(value);
+            .set_increase_per_step(value);
         self.emit_state();
     }
 
     pub fn puller_set_adaptive_accepted_difference(&mut self, value: f64) {
         self.puller_speed_controller
             .adaptive
-            .set_accepted_difference(value);
+            .set_tolerance_limit(Length::new::<millimeter>(value));
         self.emit_state();
     }
 

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -499,12 +499,14 @@ impl Winder2
     {
         let speed = Velocity::new::<meter_per_minute>(value);
         self.puller_speed_controller.adaptive.set_speed_base(speed);
+        self.emit_state();
     }
 
     pub fn puller_set_adaptive_deviation_limit(&mut self, value: f64)
     {
         let speed = Velocity::new::<meter_per_minute>(value);
         self.puller_speed_controller.adaptive.set_deviation_limit(speed);
+        self.emit_state();
     }
 
     pub fn puller_set_adaptive_reference_machine(

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -23,9 +23,9 @@ mod winder2_imports {
 #[cfg(not(feature = "mock-machine"))]
 pub use winder2_imports::*;
 
-use crate::{AsyncThreadMessage, MachineSubscriptionRequest};
 #[cfg(not(feature = "mock-machine"))]
 use crate::machine_identification::MachineIdentificationUnique;
+use crate::{AsyncThreadMessage, MachineSubscriptionRequest};
 
 #[cfg(not(feature = "mock-machine"))]
 impl Winder2 {
@@ -214,7 +214,6 @@ impl Winder2 {
     }
 
     pub fn build_state_event(&mut self) -> StateEvent {
-
         StateEvent {
             is_default_state: !std::mem::replace(&mut self.emitted_default_state, true),
             traverse_state: TraverseState {
@@ -254,10 +253,16 @@ impl Winder2 {
                     .get::<meter_per_minute>(),
                 forward: self.puller_speed_controller.forward,
                 gear_ratio: self.puller_speed_controller.gear_ratio,
-                adaptive_speed_base:        
-                    self.puller_speed_controller.adaptive.speed_base().get::<meter_per_minute>(),
-                adaptive_deviation_limit:   
-                    self.puller_speed_controller.adaptive.deviation_limit().get::<meter_per_minute>(),
+                adaptive_speed_base: self
+                    .puller_speed_controller
+                    .adaptive
+                    .speed_base()
+                    .get::<meter_per_minute>(),
+                adaptive_deviation_limit: self
+                    .puller_speed_controller
+                    .adaptive
+                    .deviation_limit()
+                    .get::<meter_per_minute>(),
                 adaptive_reference_machine: self.puller_reference_machine,
             },
             mode_state: ModeState {
@@ -491,43 +496,38 @@ impl Winder2 {
     }
 }
 
-
 // Winder2 Extension
-impl Winder2
-{
-    pub fn puller_set_adaptive_speed_base(&mut self, value: f64)
-    {
+impl Winder2 {
+    pub fn puller_set_adaptive_speed_base(&mut self, value: f64) {
         let speed = Velocity::new::<meter_per_minute>(value);
         self.puller_speed_controller.adaptive.set_speed_base(speed);
         self.emit_state();
     }
 
-    pub fn puller_set_adaptive_deviation_limit(&mut self, value: f64)
-    {
+    pub fn puller_set_adaptive_deviation_limit(&mut self, value: f64) {
         let speed = Velocity::new::<meter_per_minute>(value);
-        self.puller_speed_controller.adaptive.set_deviation_limit(speed);
+        self.puller_speed_controller
+            .adaptive
+            .set_deviation_limit(speed);
         self.emit_state();
     }
 
     pub fn puller_set_adaptive_reference_machine(
-        &mut self, 
-        machine_uid: Option<MachineIdentificationUnique>
-    ) -> Result<(), anyhow::Error>
-    {
-        match machine_uid
-        {
-            Some(machine_uid) => 
-            {
-                if self.puller_reference_machine.as_ref()
+        &mut self,
+        machine_uid: Option<MachineIdentificationUnique>,
+    ) -> Result<(), anyhow::Error> {
+        match machine_uid {
+            Some(machine_uid) => {
+                if self
+                    .puller_reference_machine
+                    .as_ref()
                     .is_some_and(|x| *x == machine_uid)
                 {
                     return Ok(());
                 }
-                let main_sender = match &self.main_sender 
-                {
+                let main_sender = match &self.main_sender {
                     Some(v) => v,
-                    None => 
-                    {
+                    None => {
                         return Err(anyhow::anyhow!(
                             "{:?} Failed to connect to {:?}",
                             self.machine_identification_unique,
@@ -538,21 +538,16 @@ impl Winder2
                 main_sender.try_send(AsyncThreadMessage::SubscribeToMachine(
                     MachineSubscriptionRequest {
                         subscriber: self.machine_identification_unique,
-                        publisher:  machine_uid,
+                        publisher: machine_uid,
                     },
                 ))?;
-            },
-            None => 
-            {
-                match self.puller_reference_machine.take()
-                {
-                    Some(machine_uid) => 
-                    {
-                        let main_sender = match &self.main_sender 
-                        {
+            }
+            None => {
+                match self.puller_reference_machine.take() {
+                    Some(machine_uid) => {
+                        let main_sender = match &self.main_sender {
                             Some(v) => v,
-                            None => 
-                            {
+                            None => {
                                 return Err(anyhow::anyhow!(
                                     "{:?} Failed to connect to {:?}",
                                     self.machine_identification_unique,
@@ -563,13 +558,13 @@ impl Winder2
                         main_sender.try_send(AsyncThreadMessage::UnsubscribeFromMachine(
                             MachineSubscriptionRequest {
                                 subscriber: self.machine_identification_unique,
-                                publisher:  machine_uid,
+                                publisher: machine_uid,
                             },
                         ))?;
-                    },
+                    }
                     None => return Ok(()), // nothing to do
                 }
-            },
+            }
         }
         self.emit_state();
         Ok(())

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -16,16 +16,20 @@ mod winder2_imports {
         angular_velocity::revolution_per_minute,
         f64::*,
         length::{meter, millimeter},
-        velocity::meter_per_minute,
     };
+
+    pub use units::Velocity;
+    pub use units::velocity::meter_per_minute;
 }
 
 #[cfg(not(feature = "mock-machine"))]
 pub use winder2_imports::*;
 
 #[cfg(not(feature = "mock-machine"))]
-use crate::machine_identification::MachineIdentificationUnique;
 use crate::{AsyncThreadMessage, MachineSubscriptionRequest};
+
+#[cfg(not(feature = "mock-machine"))]
+use crate::MachineIdentificationUnique;
 
 #[cfg(not(feature = "mock-machine"))]
 impl Winder2 {
@@ -497,6 +501,7 @@ impl Winder2 {
 }
 
 // Winder2 Extension
+#[cfg(not(feature = "mock-machine"))]
 impl Winder2 {
     pub fn puller_set_adaptive_speed_base(&mut self, value: f64) {
         let speed = Velocity::new::<meter_per_minute>(value);

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -23,6 +23,10 @@ mod winder2_imports {
 #[cfg(not(feature = "mock-machine"))]
 pub use winder2_imports::*;
 
+use crate::{AsyncThreadMessage, MachineSubscriptionRequest};
+#[cfg(not(feature = "mock-machine"))]
+use crate::machine_identification::MachineIdentificationUnique;
+
 #[cfg(not(feature = "mock-machine"))]
 impl Winder2 {
     /// Implement Spool
@@ -210,17 +214,6 @@ impl Winder2 {
     }
 
     pub fn build_state_event(&mut self) -> StateEvent {
-        use crate::MachineCrossConnectionState;
-
-        let connected_machine = self.connected_machines.get(0);
-        let ident = match connected_machine {
-            Some(machine) => Some(machine.ident.clone()),
-            None => None,
-        };
-        let cross_conn = MachineCrossConnectionState {
-            machine_identification_unique: ident,
-            is_available: connected_machine.is_some(),
-        };
 
         StateEvent {
             is_default_state: !std::mem::replace(&mut self.emitted_default_state, true),
@@ -259,12 +252,13 @@ impl Winder2 {
                     .puller_speed_controller
                     .target_speed
                     .get::<meter_per_minute>(),
-                target_diameter: self
-                    .puller_speed_controller
-                    .target_diameter
-                    .get::<millimeter>(),
                 forward: self.puller_speed_controller.forward,
                 gear_ratio: self.puller_speed_controller.gear_ratio,
+                adaptive_speed_base:        
+                    self.puller_speed_controller.adaptive.speed_base().get::<meter_per_minute>(),
+                adaptive_deviation_limit:   
+                    self.puller_speed_controller.adaptive.deviation_limit().get::<meter_per_minute>(),
+                adaptive_reference_machine: self.puller_reference_machine,
             },
             mode_state: ModeState {
                 mode: self.mode.clone().into(),
@@ -302,7 +296,7 @@ impl Winder2 {
                 spool_required_meters: self.spool_automatic_action.target_length.get::<meter>(),
                 spool_automatic_action_mode: self.spool_automatic_action.mode.clone(),
             },
-            connected_machine_state: cross_conn,
+            puller_reference_machine: self.puller_reference_machine,
         }
     }
 
@@ -413,15 +407,6 @@ impl Winder2 {
         self.emit_state();
     }
 
-    /// Set target diameter in mm
-    pub fn puller_set_target_diameter(&mut self, target_diameter: f64) {
-        // Convert m/min to velocity
-        let target_diameter = Length::new::<millimeter>(target_diameter);
-        self.puller_speed_controller
-            .set_target_diameter(target_diameter);
-        self.emit_state();
-    }
-
     /// Set forward direction
     pub fn puller_set_forward(&mut self, forward: bool) {
         self.puller_speed_controller.set_forward(forward);
@@ -503,5 +488,88 @@ impl Winder2 {
     pub fn spool_set_forward(&mut self, forward: bool) {
         self.spool_speed_controller.set_forward(forward);
         self.emit_state();
+    }
+}
+
+
+// Winder2 Extension
+impl Winder2
+{
+    pub fn puller_set_adaptive_speed_base(&mut self, value: f64)
+    {
+        let speed = Velocity::new::<meter_per_minute>(value);
+        self.puller_speed_controller.adaptive.set_speed_base(speed);
+    }
+
+    pub fn puller_set_adaptive_deviation_limit(&mut self, value: f64)
+    {
+        let speed = Velocity::new::<meter_per_minute>(value);
+        self.puller_speed_controller.adaptive.set_deviation_limit(speed);
+    }
+
+    pub fn puller_set_adaptive_reference_machine(
+        &mut self, 
+        machine_uid: Option<MachineIdentificationUnique>
+    ) -> Result<(), anyhow::Error>
+    {
+        match machine_uid
+        {
+            Some(machine_uid) => 
+            {
+                if self.puller_reference_machine.as_ref()
+                    .is_some_and(|x| *x == machine_uid)
+                {
+                    return Ok(());
+                }
+                let main_sender = match &self.main_sender 
+                {
+                    Some(v) => v,
+                    None => 
+                    {
+                        return Err(anyhow::anyhow!(
+                            "{:?} Failed to connect to {:?}",
+                            self.machine_identification_unique,
+                            machine_uid,
+                        ));
+                    }
+                };
+                main_sender.try_send(AsyncThreadMessage::SubscribeToMachine(
+                    MachineSubscriptionRequest {
+                        subscriber: self.machine_identification_unique,
+                        publisher:  machine_uid,
+                    },
+                ))?;
+            },
+            None => 
+            {
+                match self.puller_reference_machine.take()
+                {
+                    Some(machine_uid) => 
+                    {
+                        let main_sender = match &self.main_sender 
+                        {
+                            Some(v) => v,
+                            None => 
+                            {
+                                return Err(anyhow::anyhow!(
+                                    "{:?} Failed to connect to {:?}",
+                                    self.machine_identification_unique,
+                                    machine_uid,
+                                ));
+                            }
+                        };
+                        main_sender.try_send(AsyncThreadMessage::UnsubscribeFromMachine(
+                            MachineSubscriptionRequest {
+                                subscriber: self.machine_identification_unique,
+                                publisher:  machine_uid,
+                            },
+                        ))?;
+                    },
+                    None => return Ok(()), // nothing to do
+                }
+            },
+        }
+        self.emit_state();
+        Ok(())
     }
 }

--- a/machines/src/winder2/emit.rs
+++ b/machines/src/winder2/emit.rs
@@ -257,21 +257,13 @@ impl Winder2 {
                     .get::<meter_per_minute>(),
                 forward: self.puller_speed_controller.forward,
                 gear_ratio: self.puller_speed_controller.gear_ratio,
-                adaptive_speed_base: self
-                    .puller_speed_controller
-                    .adaptive
-                    .speed_base()
-                    .get::<meter_per_minute>(),
                 adaptive_speed_delta_max: self.puller_speed_controller.adaptive.speed_delta_max(),
                 adaptive_adjustment_distance: self
                     .puller_speed_controller
                     .adaptive
                     .adjustment_distance()
                     .get::<meter>(),
-                adaptive_change_per_step: self
-                    .puller_speed_controller
-                    .adaptive
-                    .increase_per_step(),
+                adaptive_change_per_step: self.puller_speed_controller.adaptive.increase_per_step(),
                 allowed_diameter_deviation: self
                     .puller_speed_controller
                     .adaptive
@@ -513,12 +505,6 @@ impl Winder2 {
 // Winder2 Extension
 #[cfg(not(feature = "mock-machine"))]
 impl Winder2 {
-    pub fn puller_set_adaptive_speed_base(&mut self, value: f64) {
-        let speed = Velocity::new::<meter_per_minute>(value);
-        self.puller_speed_controller.adaptive.set_speed_base(speed);
-        self.emit_state();
-    }
-
     pub fn puller_set_adaptive_max_speed_change_percent(&mut self, value: f64) {
         self.puller_speed_controller
             .adaptive

--- a/machines/src/winder2/mock/act.rs
+++ b/machines/src/winder2/mock/act.rs
@@ -33,12 +33,6 @@ impl MachineAct for Winder2 {
 
                 let _res = self.api_mutate(value);
             }
-            MachineMessage::ConnectToMachine(_machine_connection) => (),
-            MachineMessage::DisconnectMachine(_machine_connection) =>
-            /*Doesnt connec to any Machine do nothing*/
-            {
-                ()
-            }
             MachineMessage::RequestValues(sender) => {
                 sender
                     .send_blocking(MachineValues {

--- a/machines/src/winder2/mock/api.rs
+++ b/machines/src/winder2/mock/api.rs
@@ -48,7 +48,6 @@ impl MachineApi for Winder2 {
             Mutation::ZeroTensionArmAngle => self.tension_arm_zero(),
 
             // puller adaptive speed algorithm
-            Mutation::SetPullerAdaptiveSpeedBase(_) => self.emit_state(),
             Mutation::SetPullerAdaptiveMaxSpeedChangePercent(_) => self.emit_state(),
             Mutation::SetPullerAdaptiveAdjustmentIntervalMeters(_) => self.emit_state(),
             Mutation::SetPullerAdaptiveStepPercent(_) => self.emit_state(),

--- a/machines/src/winder2/mock/api.rs
+++ b/machines/src/winder2/mock/api.rs
@@ -49,9 +49,10 @@ impl MachineApi for Winder2 {
 
             // puller adaptive speed algorithm
             Mutation::SetPullerAdaptiveSpeedBase(_) => self.emit_state(),
-            Mutation::SetPullerAdaptiveDeviationLimit(_) => {
-                self.emit_state(); // not implementing this...
-            }
+            Mutation::SetPullerAdaptiveMaxSpeedChangePercent(_) => self.emit_state(),
+            Mutation::SetPullerAdaptiveAdjustmentIntervalMeters(_) => self.emit_state(),
+            Mutation::SetPullerAdaptiveStepPercent(_) => self.emit_state(),
+            Mutation::SetPullerAdaptiveAcceptedDifference(_) => self.emit_state(),
             Mutation::SetPullerAdaptiveReferenceMachine(_) => {
                 self.emit_state(); // not implementing this...
             }

--- a/machines/src/winder2/mock/api.rs
+++ b/machines/src/winder2/mock/api.rs
@@ -46,11 +46,14 @@ impl MachineApi for Winder2 {
             Mutation::SetSpoolAutomaticAction(mode) => self.set_spool_automatic_mode(mode),
             Mutation::ResetSpoolProgress => self.stop_or_pull_spool_reset(Instant::now()),
             Mutation::ZeroTensionArmAngle => self.tension_arm_zero(),
-            Mutation::SetConnectedMachine(machine_identification_unique) => {
-                self.set_connected_buffer(machine_identification_unique)
+
+            // puller adaptive speed algorithm
+            Mutation::SetPullerAdaptiveSpeedBase(_) => self.emit_state(),
+            Mutation::SetPullerAdaptiveDeviationLimit(_) => {
+                self.emit_state(); // not implementing this...
             }
-            Mutation::DisconnectMachine(machine_identification_unique) => {
-                self.disconnect_buffer(machine_identification_unique)
+            Mutation::SetPullerAdaptiveReferenceMachine(_) => {
+                self.emit_state(); // not implementing this...
             }
         }
         Ok(())

--- a/machines/src/winder2/mock/mock_emit.rs
+++ b/machines/src/winder2/mock/mock_emit.rs
@@ -84,20 +84,6 @@ impl Winder2 {
     }
 
     pub fn build_state_event(&mut self) -> StateEvent {
-        use crate::MachineCrossConnectionState;
-
-        let connected_machine = self.connected_machines.get(0);
-
-        let ident = match connected_machine {
-            Some(machine) => Some(machine.ident.clone()),
-            None => None,
-        };
-
-        let cross_conn = MachineCrossConnectionState {
-            machine_identification_unique: ident,
-            is_available: connected_machine.is_some(),
-        };
-
         StateEvent {
             is_default_state: self.is_default_state,
             traverse_state: self.traverse_state.clone(),
@@ -106,7 +92,7 @@ impl Winder2 {
             mode_state: self.mode_state.clone(),
             tension_arm_state: self.tension_arm_state.clone(),
             spool_speed_controller_state: self.spool_speed_controller_state.clone(),
-            connected_machine_state: cross_conn,
+            puller_reference_machine: None,
         }
     }
 
@@ -153,12 +139,6 @@ impl Winder2 {
     /// Set target speed in m/min
     pub fn puller_set_target_speed(&mut self, target_speed: f64) {
         self.puller_state.target_speed = target_speed;
-        self.emit_state();
-    }
-
-    /// Set target diameter in mm
-    pub fn puller_set_target_diameter(&mut self, target_diameter: f64) {
-        self.puller_state.target_diameter = target_diameter;
         self.emit_state();
     }
 

--- a/machines/src/winder2/mod.rs
+++ b/machines/src/winder2/mod.rs
@@ -139,7 +139,13 @@ impl Winder2
         if current < target {
             let min = lower_bound;
             let max = target;
-            -((current - min) / (max - min))
+            let normalized = (current - min) / (max - min);
+            // currently we reach 1.0 when closest to target
+            // but since we want to return 0 when closest and
+            // -1.0 when furthest we invert it from 0..1 to 1..0
+            let inverted = 1.0 - normalized;
+            // now flip sign
+            -inverted
         } else {
             let min = target;
             let max = upper_bound;

--- a/machines/src/winder2/mod.rs
+++ b/machines/src/winder2/mod.rs
@@ -91,8 +91,6 @@ pub struct Winder2 {
     api_sender: Sender<MachineMessage>,
     main_sender: Option<Sender<AsyncThreadMessage>>,
 
-    connected_machines: Vec<MachineConnection>,
-    max_connected_machines: usize,
     // drivers
     pub traverse: StepperVelocityEL70x1,
     pub puller: StepperVelocityEL70x1,
@@ -124,6 +122,9 @@ pub struct Winder2 {
 
     // control circuit puller
     pub puller_speed_controller: PullerSpeedController,
+
+    // reference machine for adapative mode
+    puller_reference_machine: Option<MachineIdentificationUnique>,
 
     /// Will be initialized as false and set to true by emit_state
     /// This way we can signal to the client that the first state emission is a default state

--- a/machines/src/winder2/mod.rs
+++ b/machines/src/winder2/mod.rs
@@ -94,10 +94,18 @@ impl Machine for Winder2 {
                 let target = state.laser_state.target_diameter;
                 let lower = state.laser_state.lower_tolerance;
                 let upper = state.laser_state.higher_tolerance;
-                let modulation = Self::compute_modulation(current, target, lower, upper);
+                let last_speed = self.puller_speed_controller.last_speed;
 
-                let algorithm = &mut self.puller_speed_controller.adaptive;
-                algorithm.set_modulation(modulation);
+                self.puller_speed_controller
+                    .adaptive
+                    .update_with_measurement(
+                        current,
+                        target,
+                        lower,
+                        upper,
+                        last_speed,
+                        Instant::now(),
+                    );
             }
             None => tracing::error!("Received MachineData::None"),
         };
@@ -116,37 +124,6 @@ impl Machine for Winder2 {
         }
 
         self.emit_state();
-    }
-}
-
-// utils
-impl Winder2 {
-    fn compute_modulation(current: f64, target: f64, lower: f64, upper: f64) -> f64 {
-        let lower_bound = target - lower;
-        let upper_bound = target + upper;
-
-        if current <= lower_bound {
-            return -1.0;
-        };
-        if current >= upper_bound {
-            return 1.0;
-        };
-
-        if current < target {
-            let min = lower_bound;
-            let max = target;
-            let normalized = (current - min) / (max - min);
-            // currently we reach 1.0 when closest to target
-            // but since we want to return 0 when closest and
-            // -1.0 when furthest we invert it from 0..1 to 1..0
-            let inverted = 1.0 - normalized;
-            // now flip sign
-            -inverted
-        } else {
-            let min = target;
-            let max = upper_bound;
-            (current - min) / (max - min)
-        }
     }
 }
 

--- a/machines/src/winder2/mod.rs
+++ b/machines/src/winder2/mod.rs
@@ -50,7 +50,8 @@ pub use winder2_imports::*;
 
 #[cfg(not(feature = "mock-machine"))]
 use crate::{
-    MACHINE_WINDER_V1, MachineConnection, MachineData, MachineMessage, VENDOR_QITECH, machine_identification::{MachineIdentification, MachineIdentificationUnique}
+    MACHINE_WINDER_V1, MachineConnection, MachineData, MachineMessage, VENDOR_QITECH,
+    machine_identification::{MachineIdentification, MachineIdentificationUnique},
 };
 
 #[derive(Debug)]
@@ -82,59 +83,54 @@ impl Machine for Winder2 {
         self.main_sender.clone()
     }
 
-    fn receive_machines_data(&mut self, data: &MachineData) 
-    {
+    fn receive_machines_data(&mut self, data: &MachineData) {
         use MachineData::*;
 
         debug_assert!(self.puller_reference_machine.is_some());
 
-        match data
-        {
-            Laser(state, live_values) => 
-            {
+        match data {
+            Laser(state, live_values) => {
                 let current = live_values.diameter;
-                let target  = state.laser_state.target_diameter;
-                let lower   = state.laser_state.lower_tolerance;
-                let upper   = state.laser_state.higher_tolerance;
+                let target = state.laser_state.target_diameter;
+                let lower = state.laser_state.lower_tolerance;
+                let upper = state.laser_state.higher_tolerance;
                 let modulation = Self::compute_modulation(current, target, lower, upper);
 
                 let algorithm = &mut self.puller_speed_controller.adaptive;
                 algorithm.set_modulation(modulation);
-            },
+            }
             None => tracing::error!("Received MachineData::None"),
         };
     }
 
-    fn subscribed_to_machine(&mut self, uid: MachineIdentificationUnique)
-    {
+    fn subscribed_to_machine(&mut self, uid: MachineIdentificationUnique) {
         self.puller_reference_machine = Some(uid);
         self.emit_state();
     }
 
-    fn unsubscribed_from_machine(&mut self, uid: MachineIdentificationUnique) 
-    {
-        if let Some(current_uid) = self.puller_reference_machine
-        {
-            if current_uid == uid
-            {
+    fn unsubscribed_from_machine(&mut self, uid: MachineIdentificationUnique) {
+        if let Some(current_uid) = self.puller_reference_machine {
+            if current_uid == uid {
                 self.puller_reference_machine = None;
             }
         }
-        
+
         self.emit_state();
     }
 }
 
 // utils
-impl Winder2
-{
-    fn compute_modulation(current: f64, target: f64, lower: f64, upper: f64) -> f64 
-    {
+impl Winder2 {
+    fn compute_modulation(current: f64, target: f64, lower: f64, upper: f64) -> f64 {
         let lower_bound = target - lower;
         let upper_bound = target + upper;
 
-        if current <= lower_bound { return -1.0 };
-        if current >= upper_bound { return 1.0 };
+        if current <= lower_bound {
+            return -1.0;
+        };
+        if current >= upper_bound {
+            return 1.0;
+        };
 
         if current < target {
             let min = lower_bound;

--- a/machines/src/winder2/mod.rs
+++ b/machines/src/winder2/mod.rs
@@ -50,8 +50,7 @@ pub use winder2_imports::*;
 
 #[cfg(not(feature = "mock-machine"))]
 use crate::{
-    MACHINE_WINDER_V1, MachineConnection, MachineMessage, VENDOR_QITECH,
-    machine_identification::{MachineIdentification, MachineIdentificationUnique},
+    MACHINE_WINDER_V1, MachineConnection, MachineData, MachineMessage, VENDOR_QITECH, machine_identification::{MachineIdentification, MachineIdentificationUnique}
 };
 
 #[derive(Debug)]
@@ -81,6 +80,71 @@ impl Machine for Winder2 {
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {
         self.main_sender.clone()
+    }
+
+    fn receive_machines_data(&mut self, data: &MachineData) 
+    {
+        use MachineData::*;
+
+        debug_assert!(self.puller_reference_machine.is_some());
+
+        match data
+        {
+            Laser(state, live_values) => 
+            {
+                let current = live_values.diameter;
+                let target  = state.laser_state.target_diameter;
+                let lower   = state.laser_state.lower_tolerance;
+                let upper   = state.laser_state.higher_tolerance;
+                let modulation = Self::compute_modulation(current, target, lower, upper);
+
+                let algorithm = &mut self.puller_speed_controller.adaptive;
+                algorithm.set_modulation(modulation);
+            },
+            None => tracing::error!("Received MachineData::None"),
+        };
+    }
+
+    fn subscribed_to_machine(&mut self, uid: MachineIdentificationUnique)
+    {
+        self.puller_reference_machine = Some(uid);
+        self.emit_state();
+    }
+
+    fn unsubscribed_from_machine(&mut self, uid: MachineIdentificationUnique) 
+    {
+        if let Some(current_uid) = self.puller_reference_machine
+        {
+            if current_uid == uid
+            {
+                self.puller_reference_machine = None;
+            }
+        }
+        
+        self.emit_state();
+    }
+}
+
+// utils
+impl Winder2
+{
+    fn compute_modulation(current: f64, target: f64, lower: f64, upper: f64) -> f64 
+    {
+        let lower_bound = target - lower;
+        let upper_bound = target + upper;
+
+        if current <= lower_bound { return -1.0 };
+        if current >= upper_bound { return 1.0 };
+
+        if current < target {
+            let min = lower_bound;
+            let max = target;
+            -((current - min) / (max - min))
+        } else {
+            let min = target;
+            let max = upper_bound;
+            (current - min) / (max - min)
+        }
     }
 }
 

--- a/machines/src/winder2/mod.rs
+++ b/machines/src/winder2/mod.rs
@@ -50,7 +50,7 @@ pub use winder2_imports::*;
 
 #[cfg(not(feature = "mock-machine"))]
 use crate::{
-    MACHINE_WINDER_V1, MachineConnection, MachineData, MachineMessage, VENDOR_QITECH,
+    MACHINE_WINDER_V1, MachineData, MachineMessage, VENDOR_QITECH,
     machine_identification::{MachineIdentification, MachineIdentificationUnique},
 };
 

--- a/machines/src/winder2/new.rs
+++ b/machines/src/winder2/new.rs
@@ -199,7 +199,6 @@ impl MachineNewTrait for Winder2 {
             let (sender, receiver) = smol::channel::unbounded();
             let mut new = Self {
                 main_sender: params.main_thread_channel.clone(),
-                max_connected_machines: 2,
                 api_receiver: receiver,
                 api_sender: sender,
                 traverse: StepperVelocityEL70x1::new(el7031.clone(), EL7031StepperPort::STM1),
@@ -232,6 +231,7 @@ impl MachineNewTrait for Winder2 {
                         Length::new::<centimeter>(8.0), // 8cm diameter of the puller wheel
                     ),
                 ),
+                puller_reference_machine: None,
                 traverse_controller: TraverseController::new(
                     Length::new::<millimeter>(22.0), // Default inner limit
                     Length::new::<millimeter>(92.0), // Default outer limit
@@ -245,7 +245,6 @@ impl MachineNewTrait for Winder2 {
                     mode: super::api::SpoolAutomaticActionMode::NoAction,
                 },
                 machine_identification_unique: machine_id,
-                connected_machines: vec![],
             };
 
             // initalize events

--- a/machines/src/winder2/new.rs
+++ b/machines/src/winder2/new.rs
@@ -225,7 +225,6 @@ impl MachineNewTrait for Winder2 {
                 puller_mode: mode.into(),
                 puller_speed_controller: PullerSpeedController::new(
                     Velocity::new::<meter_per_minute>(1.0),
-                    Length::new::<millimeter>(1.75),
                     LinearStepConverter::from_diameter(
                         200,                            // Assuming 200 steps per revolution for the puller stepper,
                         Length::new::<centimeter>(8.0), // 8cm diameter of the puller wheel

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -188,10 +188,10 @@ impl AdaptiveSpeedAlgorithm {
 
     pub fn set_deviation_limit(&mut self, deviation_limit: Velocity) {
         self.deviation_limit =
-            // ensure > 0
+            // ensure >= 0
             if deviation_limit < Velocity::ZERO
                 { Velocity::ZERO }
-            // ensure base - deviation can't below zero
+            // ensure base - deviation can't go below zero
             else if deviation_limit > self.speed_base
                 { self.speed_base }
             // ensure base + deviation can't exceed max

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -64,9 +64,9 @@ impl PullerSpeedController {
 
         let mut adaptive = AdaptiveSpeedAlgorithm::default();
         adaptive.set_speed_base(target_speed);
-        adaptive.set_speed_delta_max(0.25);
-        adaptive.set_increase_per_step(0.05);
-        adaptive.set_tolerance_limit(Length::new::<millimeter>(0.02));
+        adaptive.set_speed_delta_max(0.33);
+        adaptive.set_increase_per_step(0.033);
+        adaptive.set_tolerance_limit(Length::new::<millimeter>(0.01));
         adaptive.set_adjustment_distance(Length::new::<meter>(0.5));
 
         Self {

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -39,7 +39,9 @@ impl Default for GearRatio {
 pub struct PullerSpeedController {
     enabled: bool,
     pub target_speed: Velocity,
-    pub target_diameter: Length,
+
+    pub adaptive: AdaptiveSpeedAlgorithm,
+
     pub regulation_mode: PullerRegulationMode,
     /// Forward rotation direction. If false, applies negative sign to speed
     pub forward: bool,
@@ -55,17 +57,23 @@ pub struct PullerSpeedController {
 impl PullerSpeedController {
     pub fn new(
         target_speed: Velocity,
-        target_diameter: Length,
         converter: LinearStepConverter,
     ) -> Self {
         let acceleration = Acceleration::new::<meter_per_minute_per_second>(5.0);
         let jerk = Jerk::new::<meter_per_minute_per_second_squared>(10.0);
         let speed = Velocity::new::<meter_per_minute>(50.0);
 
+        let adaptive = AdaptiveSpeedAlgorithm {
+            speed_max:       speed,
+            speed_base:      target_speed,
+            deviation_limit: Velocity::ZERO,
+            modulation:      0.0,
+        };
+
         Self {
             enabled: false,
             target_speed,
-            target_diameter,
+            adaptive,
             regulation_mode: PullerRegulationMode::Speed,
             forward: true,
             gear_ratio: GearRatio::default(),
@@ -85,10 +93,6 @@ impl PullerSpeedController {
 
     pub fn set_target_speed(&mut self, target: Velocity) {
         self.target_speed = target;
-    }
-
-    pub fn set_target_diameter(&mut self, target: Length) {
-        self.target_diameter = target;
     }
 
     pub const fn set_regulation_mode(&mut self, regulation: PullerRegulationMode) {
@@ -111,7 +115,7 @@ impl PullerSpeedController {
         let base_speed = match self.enabled {
             true => match self.regulation_mode {
                 PullerRegulationMode::Speed => self.target_speed,
-                PullerRegulationMode::Diameter => unimplemented!(),
+                PullerRegulationMode::Diameter => self.adaptive.compute(),
             },
             false => Velocity::ZERO,
         };
@@ -152,4 +156,61 @@ pub enum PullerRegulationMode {
     #[default]
     Speed,
     Diameter,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AdaptiveSpeedAlgorithm 
+{
+    speed_max:  Velocity,
+    speed_base: Velocity,
+    deviation_limit: Velocity,
+    modulation: f64, // (-1.0 to 1.0)
+}
+
+impl AdaptiveSpeedAlgorithm
+{
+    pub fn compute(&self) -> Velocity
+    {
+        self.speed_base + (self.deviation_limit * self.modulation)
+    }
+
+    pub fn speed_base(&self) -> Velocity {
+        self.speed_base
+    }
+
+    pub fn set_speed_base(&mut self, speed: Velocity) {
+        self.speed_base = speed
+            .min(self.speed_max) // ensure < max
+            .max(Velocity::ZERO) // ensure > 0
+            ;
+
+        // update deviation limit as well
+        self.set_deviation_limit(self.deviation_limit);
+    }
+
+    pub fn deviation_limit(&self) -> Velocity {
+        self.deviation_limit
+    }
+
+    pub fn set_deviation_limit(&mut self, deviation_limit: Velocity) 
+    {
+        self.deviation_limit = 
+            // ensure > 0
+            if deviation_limit < Velocity::ZERO
+                { Velocity::ZERO }
+            // ensure base - deviation can't below zero
+            else if deviation_limit > self.speed_base 
+                { self.speed_base } 
+            // ensure base + deviation can't exceed max
+            else if self.speed_base + deviation_limit > self.speed_max 
+                { self.speed_max - self.speed_base }
+            // in valid range
+            else 
+                { deviation_limit };
+    }
+
+    pub fn set_modulation(&mut self, modulation: f64) 
+    {
+        self.modulation = modulation.clamp(-1.0, 1.0);
+    }
 }

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -63,7 +63,6 @@ impl PullerSpeedController {
         let speed = Velocity::new::<meter_per_minute>(50.0);
 
         let mut adaptive = AdaptiveSpeedAlgorithm::default();
-        adaptive.set_speed_base(target_speed);
         adaptive.set_speed_delta_max(0.33);
         adaptive.set_increase_per_step(0.033);
         adaptive.set_tolerance_limit(Length::new::<millimeter>(0.01));
@@ -94,7 +93,12 @@ impl PullerSpeedController {
         self.target_speed = target;
     }
 
-    pub const fn set_regulation_mode(&mut self, regulation: PullerRegulationMode) {
+    pub fn set_regulation_mode(&mut self, regulation: PullerRegulationMode) {
+        // Reset adaptive modulation when switching to Diameter mode
+        // so it starts from the current target_speed without jumps
+        if matches!(regulation, PullerRegulationMode::Diameter) {
+            self.adaptive.reset_modulation();
+        }
         self.regulation_mode = regulation;
     }
 
@@ -114,7 +118,7 @@ impl PullerSpeedController {
         let base_speed = match self.enabled {
             true => match self.regulation_mode {
                 PullerRegulationMode::Speed => self.target_speed,
-                PullerRegulationMode::Diameter => self.adaptive.compute(),
+                PullerRegulationMode::Diameter => self.adaptive.compute(self.target_speed),
             },
             false => Velocity::ZERO,
         };
@@ -174,7 +178,6 @@ pub enum PullerRegulationMode {
 #[derive(Debug, Clone)]
 pub struct AdaptiveSpeedAlgorithm {
     // config
-    speed_base: Velocity,
     speed_delta_max: f64,
     increase_per_step: f64,
     tolerance_limit: Length,
@@ -189,7 +192,6 @@ pub struct AdaptiveSpeedAlgorithm {
 impl Default for AdaptiveSpeedAlgorithm {
     fn default() -> Self {
         Self {
-            speed_base: Velocity::ZERO,
             speed_delta_max: 0.0,
             increase_per_step: 0.0,
             adjustment_distance: Length::ZERO,
@@ -203,9 +205,9 @@ impl Default for AdaptiveSpeedAlgorithm {
 
 // public interface
 impl AdaptiveSpeedAlgorithm {
-    pub fn compute(&self) -> Velocity {
+    pub fn compute(&self, base_speed: Velocity) -> Velocity {
         let factor = 1.0 + self.modulation * self.speed_delta_max;
-        (self.speed_base * factor).max(Velocity::ZERO)
+        (base_speed * factor).max(Velocity::ZERO)
     }
 
     pub fn update_with_measurement(
@@ -255,14 +257,6 @@ impl AdaptiveSpeedAlgorithm {
 
 // getters + setters
 impl AdaptiveSpeedAlgorithm {
-    pub fn speed_base(&self) -> Velocity {
-        self.speed_base
-    }
-
-    pub fn set_speed_base(&mut self, value: Velocity) {
-        self.speed_base = value.max(Velocity::ZERO);
-    }
-
     pub fn speed_delta_max(&self) -> f64 {
         self.speed_delta_max
     }
@@ -298,5 +292,11 @@ impl AdaptiveSpeedAlgorithm {
     /// Current modulation level in [-1.0, 1.0].
     pub fn modulation(&self) -> f64 {
         self.modulation
+    }
+
+    /// Reset modulation to zero so the algorithm starts fresh from the base speed.
+    pub fn reset_modulation(&mut self) {
+        self.modulation = 0.0;
+        self.distance_since_last_adjustment = Length::ZERO;
     }
 }

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -7,8 +7,10 @@ use control_core::{
 use serde::{Deserialize, Serialize};
 use units::ConstZero;
 use units::acceleration::meter_per_minute_per_second;
+use units::f64::Length;
 use units::f64::*;
 use units::jerk::meter_per_minute_per_second_squared;
+use units::length::{meter, millimeter};
 use units::velocity::{meter_per_minute, meter_per_second};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
@@ -60,21 +62,17 @@ impl PullerSpeedController {
         let jerk = Jerk::new::<meter_per_minute_per_second_squared>(10.0);
         let speed = Velocity::new::<meter_per_minute>(50.0);
 
-        let adaptive = AdaptiveSpeedAlgorithm {
-            speed_base: target_speed,
-            max_speed_change_percent: 5.0,
-            adjustment_interval_meters: 20.0,
-            step_percent: 1.0,
-            accepted_difference: 0.03,
-            modulation: 0.0,
-            meters_since_last_adjustment: 0.0,
-            last_update: Instant::now(),
-        };
+        let mut adaptive = AdaptiveSpeedAlgorithm::default();
+        adaptive.set_speed_base(target_speed);
+        adaptive.set_speed_delta_max(20.0);
+        adaptive.set_increase_per_step(0.1);
+        adaptive.set_tolerance_limit(Length::new::<millimeter>(0.02));
+        adaptive.set_adjustment_distance(Length::new::<meter>(20.0));
 
         Self {
             enabled: false,
             target_speed,
-            adaptive,
+            adaptive: AdaptiveSpeedAlgorithm::default(),
             regulation_mode: PullerRegulationMode::Speed,
             forward: true,
             gear_ratio: GearRatio::default(),
@@ -175,91 +173,41 @@ pub enum PullerRegulationMode {
 ///   more than `max_speed_change_percent` % from the base speed.
 #[derive(Debug, Clone)]
 pub struct AdaptiveSpeedAlgorithm {
-    // --- Configurable (Control Page) ---
-    /// Base puller speed; all modulation is relative to this.
-    pub speed_base: Velocity,
+    // config
+    speed_base: Velocity,
+    speed_delta_max: f64,
+    increase_per_step: f64,
+    tolerance_limit: Length,
+    adjustment_distance: Length,
 
-    // --- Configurable (Settings Page) ---
-    /// Maximum allowed speed change as a percentage of base speed (0.0–100.0).
-    pub max_speed_change_percent: f64,
-    /// Minimum meters the puller must travel between consecutive adjustments.
-    pub adjustment_interval_meters: f64,
-    /// Step size per adjustment as a percentage of base speed (0.0–100.0).
-    pub step_percent: f64,
-    /// Inner deadzone: maximum deviation from target (mm) that is considered
-    /// acceptable.  No adjustment is made while `|current − target| ≤ this`.
-    pub accepted_difference: f64,
-
-    // --- Internal state (not exposed to the frontend) ---
-    /// Current modulation in [-1.0, 1.0].
-    /// Output = speed_base × (1 + modulation × max_speed_change_percent / 100)
+    // internal state
     modulation: f64,
-    /// Meters accumulated while outside the inner deadzone since the last adjustment.
-    meters_since_last_adjustment: f64,
-    /// Timestamp of the previous `update_with_measurement` call for computing Δt.
-    last_update: Instant,
+    distance_since_last_adjustment: Length,
+    time_since_last_update: Instant,
 }
 
+impl Default for AdaptiveSpeedAlgorithm {
+    fn default() -> Self {
+        Self {
+            speed_base: Velocity::ZERO,
+            speed_delta_max: 0.0,
+            increase_per_step: 0.0,
+            adjustment_distance: Length::ZERO,
+            tolerance_limit: Length::ZERO,
+            modulation: 0.0,
+            distance_since_last_adjustment: Length::ZERO,
+            time_since_last_update: Instant::now(),
+        }
+    }
+}
+
+// public interface
 impl AdaptiveSpeedAlgorithm {
-    /// Compute the current target speed after applying the active modulation.
     pub fn compute(&self) -> Velocity {
-        let factor = 1.0 + self.modulation * self.max_speed_change_percent / 100.0;
+        let factor = 1.0 + self.modulation * self.speed_delta_max;
         (self.speed_base * factor).max(Velocity::ZERO)
     }
 
-    pub fn speed_base(&self) -> Velocity {
-        self.speed_base
-    }
-
-    pub fn set_speed_base(&mut self, speed: Velocity) {
-        self.speed_base = speed.max(Velocity::ZERO);
-    }
-
-    /// Current modulation level in [-1.0, 1.0].
-    pub fn modulation(&self) -> f64 {
-        self.modulation
-    }
-
-    pub fn max_speed_change_percent(&self) -> f64 {
-        self.max_speed_change_percent
-    }
-
-    pub fn set_max_speed_change_percent(&mut self, percent: f64) {
-        self.max_speed_change_percent = percent.max(0.0);
-    }
-
-    pub fn adjustment_interval_meters(&self) -> f64 {
-        self.adjustment_interval_meters
-    }
-
-    pub fn set_adjustment_interval_meters(&mut self, meters: f64) {
-        self.adjustment_interval_meters = meters.max(0.0);
-    }
-
-    pub fn step_percent(&self) -> f64 {
-        self.step_percent
-    }
-
-    pub fn set_step_percent(&mut self, percent: f64) {
-        self.step_percent = percent.clamp(0.0, 100.0);
-    }
-
-    pub fn accepted_difference(&self) -> f64 {
-        self.accepted_difference
-    }
-
-    pub fn set_accepted_difference(&mut self, mm: f64) {
-        self.accepted_difference = mm.max(0.0);
-    }
-
-    /// Process a new laser diameter measurement.
-    ///
-    /// `current`    — measured diameter (mm)
-    /// `target`     — target diameter (mm)
-    /// `lower`      — lower tolerance relative to target (mm, positive value)
-    /// `upper`      — upper tolerance relative to target (mm, positive value)
-    /// `last_speed` — puller speed at the previous cycle, used to convert Δt → metres
-    /// `now`        — current instant (enables deterministic testing)
     pub fn update_with_measurement(
         &mut self,
         current: f64,
@@ -269,8 +217,10 @@ impl AdaptiveSpeedAlgorithm {
         last_speed: Velocity,
         now: Instant,
     ) {
-        let dt = now.duration_since(self.last_update).as_secs_f64();
-        self.last_update = now;
+        let dt = now
+            .duration_since(self.time_since_last_update)
+            .as_secs_f64();
+        self.time_since_last_update = now;
 
         let lower_bound = target - lower;
         let upper_bound = target + upper;
@@ -279,26 +229,74 @@ impl AdaptiveSpeedAlgorithm {
         // ── Inner deadzone (accepted_difference) ────────────────────────────────
         // If the diameter is within ±accepted_difference of the target it is
         // acceptable.  Reset the accumulator so the delay always starts fresh.
-        if (current - target).abs() <= self.accepted_difference {
-            self.meters_since_last_adjustment = 0.0;
+        if (current - target).abs() <= self.tolerance_limit.get::<millimeter>() {
+            self.distance_since_last_adjustment = Length::ZERO;
             return;
         }
 
         // ── Accumulate metres ───────────────────────────────────────────────────
         let meters_added = last_speed.abs().get::<meter_per_second>() * dt;
-        self.meters_since_last_adjustment += meters_added;
+        self.distance_since_last_adjustment += Length::new::<meter>(meters_added);
 
         // ── Wait for the interval to elapse ─────────────────────────────────────
-        if self.meters_since_last_adjustment < self.adjustment_interval_meters {
+        if self.distance_since_last_adjustment < self.adjustment_distance {
             return;
         }
 
         // ── Apply one step in the required direction ─────────────────────────────
         // Diameter too large  → speed up the puller (positive modulation)
         // Diameter too small  → slow down the puller (negative modulation)
-        let direction = if current > target { 1.0_f64 } else { -1.0_f64 };
-        let step = self.step_percent / 100.0;
-        self.modulation = (self.modulation + direction * step).clamp(-1.0, 1.0);
-        self.meters_since_last_adjustment = 0.0;
+        let correction_sign: f64 = if current > target { 1.0 } else { -1.0 };
+        let step = self.increase_per_step * correction_sign;
+        self.modulation = (self.modulation + step).clamp(-1.0, 1.0);
+        self.distance_since_last_adjustment = Length::ZERO;
+    }
+}
+
+// getters + setters
+impl AdaptiveSpeedAlgorithm {
+    pub fn speed_base(&self) -> Velocity {
+        self.speed_base
+    }
+
+    pub fn set_speed_base(&mut self, value: Velocity) {
+        self.speed_base = value.max(Velocity::ZERO);
+    }
+
+    pub fn speed_delta_max(&self) -> f64 {
+        self.speed_delta_max
+    }
+
+    pub fn set_speed_delta_max(&mut self, value: f64) {
+        self.speed_delta_max = value.max(0.0);
+    }
+
+    pub fn increase_per_step(&self) -> f64 {
+        self.increase_per_step
+    }
+
+    pub fn set_increase_per_step(&mut self, value: f64) {
+        self.increase_per_step = value.max(0.0).min(1.0);
+    }
+
+    pub fn adjustment_distance(&self) -> Length {
+        self.adjustment_distance
+    }
+
+    pub fn set_adjustment_distance(&mut self, value: Length) {
+        self.adjustment_distance = value.max(Length::ZERO);
+    }
+
+    pub fn tolerance_limit(&self) -> Length {
+        self.tolerance_limit
+    }
+
+    pub fn set_tolerance_limit(&mut self, value: Length) {
+        self.tolerance_limit = value.max(Length::ZERO);
+    }
+
+    /// Current modulation level in [-1.0, 1.0].
+    pub fn modulation(&self) -> f64 {
+        self.modulation
     }
 }

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -55,19 +55,16 @@ pub struct PullerSpeedController {
 }
 
 impl PullerSpeedController {
-    pub fn new(
-        target_speed: Velocity,
-        converter: LinearStepConverter,
-    ) -> Self {
+    pub fn new(target_speed: Velocity, converter: LinearStepConverter) -> Self {
         let acceleration = Acceleration::new::<meter_per_minute_per_second>(5.0);
         let jerk = Jerk::new::<meter_per_minute_per_second_squared>(10.0);
         let speed = Velocity::new::<meter_per_minute>(50.0);
 
         let adaptive = AdaptiveSpeedAlgorithm {
-            speed_max:       speed,
-            speed_base:      target_speed,
+            speed_max: speed,
+            speed_base: target_speed,
             deviation_limit: Velocity::ZERO,
-            modulation:      0.0,
+            modulation: 0.0,
         };
 
         Self {
@@ -159,18 +156,15 @@ pub enum PullerRegulationMode {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct AdaptiveSpeedAlgorithm 
-{
-    speed_max:  Velocity,
+pub struct AdaptiveSpeedAlgorithm {
+    speed_max: Velocity,
     speed_base: Velocity,
     deviation_limit: Velocity,
     modulation: f64, // (-1.0 to 1.0)
 }
 
-impl AdaptiveSpeedAlgorithm
-{
-    pub fn compute(&self) -> Velocity
-    {
+impl AdaptiveSpeedAlgorithm {
+    pub fn compute(&self) -> Velocity {
         self.speed_base + (self.deviation_limit * self.modulation)
     }
 
@@ -192,25 +186,23 @@ impl AdaptiveSpeedAlgorithm
         self.deviation_limit
     }
 
-    pub fn set_deviation_limit(&mut self, deviation_limit: Velocity) 
-    {
-        self.deviation_limit = 
+    pub fn set_deviation_limit(&mut self, deviation_limit: Velocity) {
+        self.deviation_limit =
             // ensure > 0
             if deviation_limit < Velocity::ZERO
                 { Velocity::ZERO }
             // ensure base - deviation can't below zero
-            else if deviation_limit > self.speed_base 
-                { self.speed_base } 
+            else if deviation_limit > self.speed_base
+                { self.speed_base }
             // ensure base + deviation can't exceed max
-            else if self.speed_base + deviation_limit > self.speed_max 
+            else if self.speed_base + deviation_limit > self.speed_max
                 { self.speed_max - self.speed_base }
             // in valid range
-            else 
+            else
                 { deviation_limit };
     }
 
-    pub fn set_modulation(&mut self, modulation: f64) 
-    {
+    pub fn set_modulation(&mut self, modulation: f64) {
         self.modulation = modulation.clamp(-1.0, 1.0);
     }
 }

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -64,15 +64,15 @@ impl PullerSpeedController {
 
         let mut adaptive = AdaptiveSpeedAlgorithm::default();
         adaptive.set_speed_base(target_speed);
-        adaptive.set_speed_delta_max(20.0);
-        adaptive.set_increase_per_step(0.1);
+        adaptive.set_speed_delta_max(0.25);
+        adaptive.set_increase_per_step(0.05);
         adaptive.set_tolerance_limit(Length::new::<millimeter>(0.02));
-        adaptive.set_adjustment_distance(Length::new::<meter>(20.0));
+        adaptive.set_adjustment_distance(Length::new::<meter>(0.5));
 
         Self {
             enabled: false,
             target_speed,
-            adaptive: AdaptiveSpeedAlgorithm::default(),
+            adaptive,
             regulation_mode: PullerRegulationMode::Speed,
             forward: true,
             gear_ratio: GearRatio::default(),

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -9,7 +9,7 @@ use units::ConstZero;
 use units::acceleration::meter_per_minute_per_second;
 use units::f64::*;
 use units::jerk::meter_per_minute_per_second_squared;
-use units::velocity::meter_per_minute;
+use units::velocity::{meter_per_minute, meter_per_second};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum GearRatio {
@@ -61,10 +61,14 @@ impl PullerSpeedController {
         let speed = Velocity::new::<meter_per_minute>(50.0);
 
         let adaptive = AdaptiveSpeedAlgorithm {
-            speed_max: speed,
             speed_base: target_speed,
-            deviation_limit: Velocity::ZERO,
+            max_speed_change_percent: 5.0,
+            adjustment_interval_meters: 20.0,
+            step_percent: 1.0,
+            accepted_difference: 0.03,
             modulation: 0.0,
+            meters_since_last_adjustment: 0.0,
+            last_update: Instant::now(),
         };
 
         Self {
@@ -155,17 +159,52 @@ pub enum PullerRegulationMode {
     Diameter,
 }
 
-#[derive(Debug, Clone, Copy)]
+/// Controls adaptive puller speed based on laser diameter feedback.
+///
+/// # Behaviour
+/// - **Inner deadzone** (`accepted_difference`): if `|current − target| ≤
+///   accepted_difference` (mm) the measurement is considered close enough to the
+///   target and no adjustment is made.  The meter accumulator is reset so the
+///   delay always restarts when re-entering this zone.
+/// - **Outer boundary** (`lower` / `upper` tolerances from the laser): if the
+///   diameter leaves the inner deadzone, meters are accumulated.  After
+///   `adjustment_interval_meters` have elapsed the modulation is nudged by
+///   ±`step_percent` in the direction that brings the diameter back toward
+///   target, and the accumulator is reset.
+/// - **Soft limit**: modulation is clamped so the output speed never deviates
+///   more than `max_speed_change_percent` % from the base speed.
+#[derive(Debug, Clone)]
 pub struct AdaptiveSpeedAlgorithm {
-    speed_max: Velocity,
-    speed_base: Velocity,
-    deviation_limit: Velocity,
-    modulation: f64, // (-1.0 to 1.0)
+    // --- Configurable (Control Page) ---
+    /// Base puller speed; all modulation is relative to this.
+    pub speed_base: Velocity,
+
+    // --- Configurable (Settings Page) ---
+    /// Maximum allowed speed change as a percentage of base speed (0.0–100.0).
+    pub max_speed_change_percent: f64,
+    /// Minimum meters the puller must travel between consecutive adjustments.
+    pub adjustment_interval_meters: f64,
+    /// Step size per adjustment as a percentage of base speed (0.0–100.0).
+    pub step_percent: f64,
+    /// Inner deadzone: maximum deviation from target (mm) that is considered
+    /// acceptable.  No adjustment is made while `|current − target| ≤ this`.
+    pub accepted_difference: f64,
+
+    // --- Internal state (not exposed to the frontend) ---
+    /// Current modulation in [-1.0, 1.0].
+    /// Output = speed_base × (1 + modulation × max_speed_change_percent / 100)
+    modulation: f64,
+    /// Meters accumulated while outside the inner deadzone since the last adjustment.
+    meters_since_last_adjustment: f64,
+    /// Timestamp of the previous `update_with_measurement` call for computing Δt.
+    last_update: Instant,
 }
 
 impl AdaptiveSpeedAlgorithm {
+    /// Compute the current target speed after applying the active modulation.
     pub fn compute(&self) -> Velocity {
-        self.speed_base + (self.deviation_limit * self.modulation)
+        let factor = 1.0 + self.modulation * self.max_speed_change_percent / 100.0;
+        (self.speed_base * factor).max(Velocity::ZERO)
     }
 
     pub fn speed_base(&self) -> Velocity {
@@ -173,36 +212,93 @@ impl AdaptiveSpeedAlgorithm {
     }
 
     pub fn set_speed_base(&mut self, speed: Velocity) {
-        self.speed_base = speed
-            .min(self.speed_max) // ensure < max
-            .max(Velocity::ZERO) // ensure > 0
-            ;
-
-        // update deviation limit as well
-        self.set_deviation_limit(self.deviation_limit);
+        self.speed_base = speed.max(Velocity::ZERO);
     }
 
-    pub fn deviation_limit(&self) -> Velocity {
-        self.deviation_limit
+    /// Current modulation level in [-1.0, 1.0].
+    pub fn modulation(&self) -> f64 {
+        self.modulation
     }
 
-    pub fn set_deviation_limit(&mut self, deviation_limit: Velocity) {
-        self.deviation_limit =
-            // ensure >= 0
-            if deviation_limit < Velocity::ZERO
-                { Velocity::ZERO }
-            // ensure base - deviation can't go below zero
-            else if deviation_limit > self.speed_base
-                { self.speed_base }
-            // ensure base + deviation can't exceed max
-            else if self.speed_base + deviation_limit > self.speed_max
-                { self.speed_max - self.speed_base }
-            // in valid range
-            else
-                { deviation_limit };
+    pub fn max_speed_change_percent(&self) -> f64 {
+        self.max_speed_change_percent
     }
 
-    pub fn set_modulation(&mut self, modulation: f64) {
-        self.modulation = modulation.clamp(-1.0, 1.0);
+    pub fn set_max_speed_change_percent(&mut self, percent: f64) {
+        self.max_speed_change_percent = percent.max(0.0);
+    }
+
+    pub fn adjustment_interval_meters(&self) -> f64 {
+        self.adjustment_interval_meters
+    }
+
+    pub fn set_adjustment_interval_meters(&mut self, meters: f64) {
+        self.adjustment_interval_meters = meters.max(0.0);
+    }
+
+    pub fn step_percent(&self) -> f64 {
+        self.step_percent
+    }
+
+    pub fn set_step_percent(&mut self, percent: f64) {
+        self.step_percent = percent.clamp(0.0, 100.0);
+    }
+
+    pub fn accepted_difference(&self) -> f64 {
+        self.accepted_difference
+    }
+
+    pub fn set_accepted_difference(&mut self, mm: f64) {
+        self.accepted_difference = mm.max(0.0);
+    }
+
+    /// Process a new laser diameter measurement.
+    ///
+    /// `current`    — measured diameter (mm)
+    /// `target`     — target diameter (mm)
+    /// `lower`      — lower tolerance relative to target (mm, positive value)
+    /// `upper`      — upper tolerance relative to target (mm, positive value)
+    /// `last_speed` — puller speed at the previous cycle, used to convert Δt → metres
+    /// `now`        — current instant (enables deterministic testing)
+    pub fn update_with_measurement(
+        &mut self,
+        current: f64,
+        target: f64,
+        lower: f64,
+        upper: f64,
+        last_speed: Velocity,
+        now: Instant,
+    ) {
+        let dt = now.duration_since(self.last_update).as_secs_f64();
+        self.last_update = now;
+
+        let lower_bound = target - lower;
+        let upper_bound = target + upper;
+        let _ = (lower_bound, upper_bound); // kept for future use (e.g. trend detection)
+
+        // ── Inner deadzone (accepted_difference) ────────────────────────────────
+        // If the diameter is within ±accepted_difference of the target it is
+        // acceptable.  Reset the accumulator so the delay always starts fresh.
+        if (current - target).abs() <= self.accepted_difference {
+            self.meters_since_last_adjustment = 0.0;
+            return;
+        }
+
+        // ── Accumulate metres ───────────────────────────────────────────────────
+        let meters_added = last_speed.abs().get::<meter_per_second>() * dt;
+        self.meters_since_last_adjustment += meters_added;
+
+        // ── Wait for the interval to elapse ─────────────────────────────────────
+        if self.meters_since_last_adjustment < self.adjustment_interval_meters {
+            return;
+        }
+
+        // ── Apply one step in the required direction ─────────────────────────────
+        // Diameter too large  → speed up the puller (positive modulation)
+        // Diameter too small  → slow down the puller (negative modulation)
+        let direction = if current > target { 1.0_f64 } else { -1.0_f64 };
+        let step = self.step_percent / 100.0;
+        self.modulation = (self.modulation + direction * step).clamp(-1.0, 1.0);
+        self.meters_since_last_adjustment = 0.0;
     }
 }

--- a/server/src/app_state.rs
+++ b/server/src/app_state.rs
@@ -11,7 +11,7 @@ use ethercrab::subdevice_group::HasDc;
 use ethercrab::{MainDevice, SubDeviceGroup, subdevice_group::Op};
 use machines::machine_identification::{DeviceIdentification, MachineIdentificationUnique};
 use machines::serial::registry::SERIAL_DEVICE_REGISTRY;
-use machines::{Machine, MachineMessage};
+use machines::{Machine, MachineMessage, MachineSubscriptionRequest};
 use serde::{Deserialize, Serialize};
 use smol::channel::{Receiver, Sender};
 use smol::lock::{Mutex, RwLock};
@@ -45,6 +45,8 @@ pub enum HotThreadMessage {
     AddEtherCatSetup(EthercatSetup),
     WriteMachineDeviceInfo(MachineDeviceInfoRequest),
     DeleteMachine(MachineIdentificationUnique),
+    SubscriptionEstablish(MachineSubscriptionRequest),
+    SubscriptionTerminate(MachineSubscriptionRequest),
 }
 
 use crate::AsyncThreadMessage;

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -72,7 +72,6 @@ pub fn start_loop_thread(
             }
 
             let mut ethercat_perf = EthercatPerformanceMetrics::new();
-            let mut machines: Vec<Box<dyn Machine>> = vec![];
             let mut last_iter_start: Option<Instant> = None;
             let mut rt_loop_inputs = RtLoopInputs {
                 machine_manager: MachineManager::default(),

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -12,9 +12,9 @@ use spin_sleep::SpinSleeper;
 use std::time::Duration;
 use std::time::Instant;
 
+use crate::MachineManager;
 use crate::metrics::jitter::record_machines_loop_jitter;
 use crate::metrics::preemption::set_rt_loop_tid;
-use crate::MachineManager;
 
 pub struct RtLoopInputs<'a> {
     pub machine_manager: MachineManager,
@@ -110,14 +110,16 @@ pub fn start_loop_thread(
                             }
                         }
                     }
-                    DeleteMachine(uid) =>
-                        rt_loop_inputs.machine_manager.remove_machine(uid),
-                    AddMachines(new_machines) => 
-                        rt_loop_inputs.machine_manager.add_machines(new_machines),
-                    SubscriptionEstablish(request) => 
-                        rt_loop_inputs.machine_manager.subscription_establish(request),
-                    SubscriptionTerminate(request) => 
-                        rt_loop_inputs.machine_manager.subscription_terminate(request),
+                    DeleteMachine(uid) => rt_loop_inputs.machine_manager.remove_machine(uid),
+                    AddMachines(new_machines) => {
+                        rt_loop_inputs.machine_manager.add_machines(new_machines)
+                    }
+                    SubscriptionEstablish(request) => rt_loop_inputs
+                        .machine_manager
+                        .subscription_establish(request),
+                    SubscriptionTerminate(request) => rt_loop_inputs
+                        .machine_manager
+                        .subscription_terminate(request),
                 }
                 let iter_start = Instant::now();
                 if let Some(prev) = last_iter_start {

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -6,7 +6,6 @@ use control_core::realtime::set_core_affinity;
 use control_core::realtime::set_realtime_priority;
 use ethercrab::TxRxResponse;
 use ethercrab::subdevice_group::CycleInfo;
-use machines::Machine;
 use machines::machine_identification::write_machine_device_identification;
 use smol::channel::Receiver;
 use spin_sleep::SpinSleeper;
@@ -15,8 +14,10 @@ use std::time::Instant;
 
 use crate::metrics::jitter::record_machines_loop_jitter;
 use crate::metrics::preemption::set_rt_loop_tid;
+use crate::MachineManager;
+
 pub struct RtLoopInputs<'a> {
-    pub machines: &'a mut Vec<Box<dyn Machine>>,
+    pub machine_manager: MachineManager,
     pub ethercat_setup: Option<Box<EthercatSetup>>,
     pub ethercat_perf_metrics: Option<&'a mut EthercatPerformanceMetrics>,
     pub sleeper: SpinSleeper,
@@ -74,7 +75,7 @@ pub fn start_loop_thread(
             let mut machines: Vec<Box<dyn Machine>> = vec![];
             let mut last_iter_start: Option<Instant> = None;
             let mut rt_loop_inputs = RtLoopInputs {
-                machines: &mut machines,
+                machine_manager: MachineManager::default(),
                 ethercat_setup: None,
                 sleeper,
                 cycle_target,
@@ -82,17 +83,19 @@ pub fn start_loop_thread(
             };
 
             loop {
+                use HotThreadMessage::*;
+
                 let msg = match rt_receiver.try_recv() {
                     Ok(msg) => msg,
-                    Err(_) => HotThreadMessage::NoMsg,
+                    Err(_) => NoMsg,
                 };
 
                 match msg {
-                    HotThreadMessage::NoMsg => {}
-                    HotThreadMessage::AddEtherCatSetup(ethercat_setup) => {
+                    NoMsg => {}
+                    AddEtherCatSetup(ethercat_setup) => {
                         rt_loop_inputs.ethercat_setup = Some(Box::new(ethercat_setup));
                     }
-                    HotThreadMessage::WriteMachineDeviceInfo(info_request) => {
+                    WriteMachineDeviceInfo(info_request) => {
                         if let Some(ethercat_setup) = &rt_loop_inputs.ethercat_setup {
                             if let Ok(subdevice) = ethercat_setup.group.subdevice(
                                 &ethercat_setup.maindevice,
@@ -108,23 +111,14 @@ pub fn start_loop_thread(
                             }
                         }
                     }
-                    HotThreadMessage::DeleteMachine(unique_id) => {
-                        rt_loop_inputs
-                            .machines
-                            .retain(|m| m.get_machine_identification_unique() != unique_id);
-                    }
-                    HotThreadMessage::AddMachines(machine_vec) => {
-                        for new_machine in machine_vec {
-                            let id = new_machine.get_machine_identification_unique();
-                            if !rt_loop_inputs
-                                .machines
-                                .iter()
-                                .any(|m| m.get_machine_identification_unique() == id)
-                            {
-                                rt_loop_inputs.machines.push(new_machine);
-                            }
-                        }
-                    }
+                    DeleteMachine(uid) =>
+                        rt_loop_inputs.machine_manager.remove_machine(uid),
+                    AddMachines(new_machines) => 
+                        rt_loop_inputs.machine_manager.add_machines(new_machines),
+                    SubscriptionEstablish(request) => 
+                        rt_loop_inputs.machine_manager.subscription_establish(request),
+                    SubscriptionTerminate(request) => 
+                        rt_loop_inputs.machine_manager.subscription_terminate(request),
                 }
                 let iter_start = Instant::now();
                 if let Some(prev) = last_iter_start {
@@ -284,12 +278,6 @@ pub async fn copy_ethercat_outputs(
     Ok(())
 }
 
-pub fn execute_machines(machines: &mut Vec<Box<dyn Machine>>) {
-    let now = Instant::now();
-    for machine in machines.iter_mut() {
-        machine.act(now);
-    }
-}
 // No more logging in loop_once
 pub fn loop_once<'maindevice>(inputs: &mut RtLoopInputs<'_>) -> Result<(), anyhow::Error> {
     let loop_once_start = std::time::Instant::now();
@@ -309,7 +297,7 @@ pub fn loop_once<'maindevice>(inputs: &mut RtLoopInputs<'_>) -> Result<(), anyho
         };
     }
 
-    execute_machines(&mut inputs.machines);
+    inputs.machine_manager.execute_machines();
 
     if inputs.ethercat_setup.is_some() && inputs.ethercat_perf_metrics.is_some() {
         let res = smol::block_on(copy_ethercat_outputs(inputs.ethercat_setup.as_deref()));

--- a/server/src/machine_manager.rs
+++ b/server/src/machine_manager.rs
@@ -1,62 +1,62 @@
-use std::{collections::{HashMap, HashSet}, time::{Duration, Instant}};
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
 
-use machines::{Machine, MachineData, MachineSubscriptionRequest, machine_identification::MachineIdentificationUnique as MachineUID};
+use machines::{
+    Machine, MachineData, MachineSubscriptionRequest,
+    machine_identification::MachineIdentificationUnique as MachineUID,
+};
 
 #[derive(Default)]
-pub struct MachineManager
-{
+pub struct MachineManager {
     pub machine_entries: Vec<MachineEntry>,
     pub data_registry: HashMap<MachineUID, DataEntry>,
 }
 
-impl MachineManager
-{
-    pub fn subscription_establish(&mut self, request: MachineSubscriptionRequest)
-    {
-        let entry = self.machine_entries
+impl MachineManager {
+    pub fn subscription_establish(&mut self, request: MachineSubscriptionRequest) {
+        let entry = self
+            .machine_entries
             .iter_mut()
             .find(|entry| entry.uid == request.subscriber)
             .expect("No such machine");
 
-        if entry.subscriptions.insert(request.publisher)
-        {
+        if entry.subscriptions.insert(request.publisher) {
             entry.machine.subscribed_to_machine(request.publisher);
         }
     }
 
-    pub fn subscription_terminate(&mut self, request: MachineSubscriptionRequest)
-    {
-        let entry = self.machine_entries
+    pub fn subscription_terminate(&mut self, request: MachineSubscriptionRequest) {
+        let entry = self
+            .machine_entries
             .iter_mut()
             .find(|entry| entry.uid == request.subscriber)
             .expect("No such machine");
 
-        if entry.subscriptions.remove(&request.publisher)
-        {
+        if entry.subscriptions.remove(&request.publisher) {
             entry.machine.unsubscribed_from_machine(request.publisher);
         }
     }
 
-    pub fn add_machines(&mut self, new_machines: Vec<Box<dyn Machine + 'static>>)
-    {
-        for machine in new_machines 
-        {
+    pub fn add_machines(&mut self, new_machines: Vec<Box<dyn Machine + 'static>>) {
+        for machine in new_machines {
             let uid = machine.get_machine_identification_unique();
 
             if self.data_registry.contains_key(&uid) {
                 continue;
             }
 
-            let data_entry = DataEntry { 
-                mutation_counter: machine.mutation_counter(), 
-                last_live_values: Instant::now(), 
-                data: MachineData::None
+            let data_entry = DataEntry {
+                mutation_counter: machine.mutation_counter(),
+                last_live_values: Instant::now(),
+                data: MachineData::None,
             };
 
-            let machine_entry = MachineEntry { 
-                uid, 
-                machine, 
-                subscriptions: HashSet::new()
+            let machine_entry = MachineEntry {
+                uid,
+                machine,
+                subscriptions: HashSet::new(),
             };
 
             self.machine_entries.push(machine_entry);
@@ -64,29 +64,28 @@ impl MachineManager
         }
     }
 
-    pub fn remove_machine(&mut self, uid: MachineUID)
-    {
-        self.machine_entries.retain(|entry| entry.machine.get_machine_identification_unique() != uid);
+    pub fn remove_machine(&mut self, uid: MachineUID) {
+        self.machine_entries
+            .retain(|entry| entry.machine.get_machine_identification_unique() != uid);
     }
 
-    pub fn execute_machines(&mut self)
-    {
+    pub fn execute_machines(&mut self) {
         let now = Instant::now();
 
-        for entry in self.machine_entries.iter_mut() 
-        {
+        for entry in self.machine_entries.iter_mut() {
             // Fuck you rust - jsentity
             let (refresh_state, refresh_live_values) = {
-                let data_entry = self.data_registry.get_mut(&entry.uid)
+                let data_entry = self
+                    .data_registry
+                    .get_mut(&entry.uid)
                     .expect("entries must match registry");
 
                 // update if generation out of sync
-                let refresh_state = 
-                    entry.machine.mutation_counter() != data_entry.mutation_counter;
+                let refresh_state = entry.machine.mutation_counter() != data_entry.mutation_counter;
 
                 // update once per 1/30s
-                let refresh_live_values =
-                    now.duration_since(data_entry.last_live_values) > Duration::from_secs_f64(1.0 / 30.0);
+                let refresh_live_values = now.duration_since(data_entry.last_live_values)
+                    > Duration::from_secs_f64(1.0 / 30.0);
 
                 if refresh_live_values {
                     data_entry.last_live_values = now;
@@ -95,9 +94,10 @@ impl MachineManager
                 (refresh_state, refresh_live_values)
             };
 
-            for uid in &entry.subscriptions
-            {
-                let subscribed_data = self.data_registry.get_mut(uid)
+            for uid in &entry.subscriptions {
+                let subscribed_data = self
+                    .data_registry
+                    .get_mut(uid)
                     .expect("entries must match registry");
 
                 entry.machine.receive_machines_data(&subscribed_data.data);
@@ -106,18 +106,23 @@ impl MachineManager
             entry.machine.act(now);
 
             // oh hey, the same fuckin ass lookup in the same function... thanks rust :D
-            let data_entry = self.data_registry.get_mut(&entry.uid)
+            let data_entry = self
+                .data_registry
+                .get_mut(&entry.uid)
                 .expect("entries must match registry");
 
             if refresh_state || refresh_live_values {
-                entry.machine.update_machine_data(&mut data_entry.data, refresh_state, refresh_live_values);
+                entry.machine.update_machine_data(
+                    &mut data_entry.data,
+                    refresh_state,
+                    refresh_live_values,
+                );
             }
         }
     }
 }
 
-pub struct MachineEntry
-{
+pub struct MachineEntry {
     pub uid: MachineUID,
 
     pub machine: Box<dyn Machine>,
@@ -126,7 +131,8 @@ pub struct MachineEntry
     pub subscriptions: HashSet<MachineUID>,
 }
 
-pub struct DataEntry // Fuck you rust - jsentity
+pub struct DataEntry
+// Fuck you rust - jsentity
 {
     /// generation counter of the machines state data
     /// is incremented internally in the machine when

--- a/server/src/machine_manager.rs
+++ b/server/src/machine_manager.rs
@@ -73,7 +73,6 @@ impl MachineManager
     {
         let now = Instant::now();
 
-        // borrow 1
         for entry in self.machine_entries.iter_mut() 
         {
             // Fuck you rust - jsentity
@@ -111,7 +110,7 @@ impl MachineManager
                 .expect("entries must match registry");
 
             if refresh_state || refresh_live_values {
-                entry.machine.update_machines_data(&mut data_entry.data, refresh_state, refresh_live_values);
+                entry.machine.update_machine_data(&mut data_entry.data, refresh_state, refresh_live_values);
             }
         }
     }

--- a/server/src/machine_manager.rs
+++ b/server/src/machine_manager.rs
@@ -1,6 +1,6 @@
 use std::{collections::{HashMap, HashSet}, time::{Duration, Instant}};
 
-use machines::{Machine, MachinesData, MachineSubscriptionRequest, machine_identification::MachineIdentificationUnique as MachineUID};
+use machines::{Machine, MachineData, MachineSubscriptionRequest, machine_identification::MachineIdentificationUnique as MachineUID};
 
 #[derive(Default)]
 pub struct MachineManager
@@ -48,9 +48,9 @@ impl MachineManager
             }
 
             let data_entry = DataEntry { 
-                state_generation: machine.state_generation(), 
+                mutation_counter: machine.mutation_counter(), 
                 last_live_values: Instant::now(), 
-                data: MachinesData::None
+                data: MachineData::None
             };
 
             let machine_entry = MachineEntry { 
@@ -83,7 +83,7 @@ impl MachineManager
 
                 // update if generation out of sync
                 let refresh_state = 
-                    entry.machine.state_generation() != data_entry.state_generation;
+                    entry.machine.mutation_counter() != data_entry.mutation_counter;
 
                 // update once per 1/30s
                 let refresh_live_values =
@@ -133,12 +133,12 @@ pub struct DataEntry // Fuck you rust - jsentity
     /// is incremented internally in the machine when
     /// it's state is mutated. Comparing the generation
     /// reveals if we are out of sync
-    pub state_generation: u64,
+    pub mutation_counter: u64,
 
     /// tracks time since last time we checked live values
     /// to ensure we poll only as often as neded
     pub last_live_values: Instant,
 
     /// the data
-    pub data: MachinesData,
+    pub data: MachineData,
 }

--- a/server/src/machine_manager.rs
+++ b/server/src/machine_manager.rs
@@ -1,0 +1,144 @@
+use std::{collections::{HashMap, HashSet}, time::{Duration, Instant}};
+
+use machines::{Machine, MachinesData, MachineSubscriptionRequest, machine_identification::MachineIdentificationUnique as MachineUID};
+
+#[derive(Default)]
+pub struct MachineManager
+{
+    pub machine_entries: Vec<MachineEntry>,
+    pub data_registry: HashMap<MachineUID, DataEntry>,
+}
+
+impl MachineManager
+{
+    pub fn subscription_establish(&mut self, request: MachineSubscriptionRequest)
+    {
+        let entry = self.machine_entries
+            .iter_mut()
+            .find(|entry| entry.uid == request.subscriber)
+            .expect("No such machine");
+
+        if entry.subscriptions.insert(request.publisher)
+        {
+            entry.machine.subscribed_to_machine(request.publisher);
+        }
+    }
+
+    pub fn subscription_terminate(&mut self, request: MachineSubscriptionRequest)
+    {
+        let entry = self.machine_entries
+            .iter_mut()
+            .find(|entry| entry.uid == request.subscriber)
+            .expect("No such machine");
+
+        if entry.subscriptions.remove(&request.publisher)
+        {
+            entry.machine.unsubscribed_from_machine(request.publisher);
+        }
+    }
+
+    pub fn add_machines(&mut self, new_machines: Vec<Box<dyn Machine + 'static>>)
+    {
+        for machine in new_machines 
+        {
+            let uid = machine.get_machine_identification_unique();
+
+            if self.data_registry.contains_key(&uid) {
+                continue;
+            }
+
+            let data_entry = DataEntry { 
+                state_generation: machine.state_generation(), 
+                last_live_values: Instant::now(), 
+                data: MachinesData::None
+            };
+
+            let machine_entry = MachineEntry { 
+                uid, 
+                machine, 
+                subscriptions: HashSet::new()
+            };
+
+            self.machine_entries.push(machine_entry);
+            self.data_registry.insert(uid, data_entry);
+        }
+    }
+
+    pub fn remove_machine(&mut self, uid: MachineUID)
+    {
+        self.machine_entries.retain(|entry| entry.machine.get_machine_identification_unique() != uid);
+    }
+
+    pub fn execute_machines(&mut self)
+    {
+        let now = Instant::now();
+
+        // borrow 1
+        for entry in self.machine_entries.iter_mut() 
+        {
+            // Fuck you rust - jsentity
+            let (refresh_state, refresh_live_values) = {
+                let data_entry = self.data_registry.get_mut(&entry.uid)
+                    .expect("entries must match registry");
+
+                // update if generation out of sync
+                let refresh_state = 
+                    entry.machine.state_generation() != data_entry.state_generation;
+
+                // update once per 1/30s
+                let refresh_live_values =
+                    now.duration_since(data_entry.last_live_values) > Duration::from_secs_f64(1.0 / 30.0);
+
+                if refresh_live_values {
+                    data_entry.last_live_values = now;
+                }
+
+                (refresh_state, refresh_live_values)
+            };
+
+            for uid in &entry.subscriptions
+            {
+                let subscribed_data = self.data_registry.get_mut(uid)
+                    .expect("entries must match registry");
+
+                entry.machine.receive_machines_data(&subscribed_data.data);
+            }
+
+            entry.machine.act(now);
+
+            // oh hey, the same fuckin ass lookup in the same function... thanks rust :D
+            let data_entry = self.data_registry.get_mut(&entry.uid)
+                .expect("entries must match registry");
+
+            if refresh_state || refresh_live_values {
+                entry.machine.update_machines_data(&mut data_entry.data, refresh_state, refresh_live_values);
+            }
+        }
+    }
+}
+
+pub struct MachineEntry
+{
+    pub uid: MachineUID,
+
+    pub machine: Box<dyn Machine>,
+
+    /// other machines this one is subscribed to
+    pub subscriptions: HashSet<MachineUID>,
+}
+
+pub struct DataEntry // Fuck you rust - jsentity
+{
+    /// generation counter of the machines state data
+    /// is incremented internally in the machine when
+    /// it's state is mutated. Comparing the generation
+    /// reveals if we are out of sync
+    pub state_generation: u64,
+
+    /// tracks time since last time we checked live values
+    /// to ensure we poll only as often as neded
+    pub last_live_values: Instant,
+
+    /// the data
+    pub data: MachinesData,
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,8 +2,8 @@ use crate::{
     metrics::collector::{RuntimeMetricsConfig, spawn_runtime_metrics_sampler},
     socketio::main_namespace::machines_event::MachineObj,
 };
-use control_core::socketio::namespace::NamespaceCacheingLogic;
 use control_core::socketio::event::GenericEvent;
+use control_core::socketio::namespace::NamespaceCacheingLogic;
 use machines::{
     AsyncThreadMessage, MachineConnection, MachineNewHardware, MachineNewHardwareSerial,
     MachineNewParams, SerialDevice, SerialDeviceIdentification, SerialDeviceNew,
@@ -255,27 +255,22 @@ pub async fn handle_serial_device_hotplug(
     }
 }
 
-async fn handle_async_requests(
-    recv: Receiver<AsyncThreadMessage>, 
-    shared_state: Arc<SharedState>
-) {
+async fn handle_async_requests(recv: Receiver<AsyncThreadMessage>, shared_state: Arc<SharedState>) {
     use AsyncThreadMessage::*;
 
-    while let Ok(message) = recv.recv().await 
-    {
-        match message 
-        {
+    while let Ok(message) = recv.recv().await {
+        match message {
             NoMsg => (),
-            SubscribeToMachine(request) => 
-            {
-                shared_state.rt_machine_creation_channel
+            SubscribeToMachine(request) => {
+                shared_state
+                    .rt_machine_creation_channel
                     .send(HotThreadMessage::SubscriptionEstablish(request))
                     .await
                     .expect("Could not send to real-time channel");
-            },
-            UnsubscribeFromMachine(request) => 
-            {
-                shared_state.rt_machine_creation_channel
+            }
+            UnsubscribeFromMachine(request) => {
+                shared_state
+                    .rt_machine_creation_channel
                     .send(HotThreadMessage::SubscriptionTerminate(request))
                     .await
                     .expect("Could not send to real-time channel");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,9 +5,8 @@ use crate::{
 use control_core::socketio::event::GenericEvent;
 use control_core::socketio::namespace::NamespaceCacheingLogic;
 use machines::{
-    AsyncThreadMessage, MachineNewHardware, MachineNewHardwareSerial,
-    MachineNewParams, SerialDevice, SerialDeviceIdentification, SerialDeviceNew,
-    SerialDeviceNewParams,
+    AsyncThreadMessage, MachineNewHardware, MachineNewHardwareSerial, MachineNewParams,
+    SerialDevice, SerialDeviceIdentification, SerialDeviceNew, SerialDeviceNewParams,
     laser::LaserMachine,
     machine_identification::{
         DeviceIdentification, DeviceIdentificationIdentified, MachineIdentificationUnique,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,6 +3,7 @@ use crate::{
     socketio::main_namespace::machines_event::MachineObj,
 };
 use control_core::socketio::namespace::NamespaceCacheingLogic;
+use control_core::socketio::event::GenericEvent;
 use machines::{
     AsyncThreadMessage, MachineConnection, MachineNewHardware, MachineNewHardwareSerial,
     MachineNewParams, SerialDevice, SerialDeviceIdentification, SerialDeviceNew,
@@ -13,7 +14,6 @@ use machines::{
     },
     registry::{MACHINE_REGISTRY, MachineRegistry},
     serial::{devices::laser::Laser, init::SerialDetection},
-    winder2::api::GenericEvent,
 };
 use socketio::{
     main_namespace::{MainNamespaceEvents, ethercat_devices_event::EthercatDevicesEventBuilder},
@@ -70,6 +70,9 @@ pub mod performance_metrics;
 pub mod rest;
 pub mod socketio;
 pub mod utils;
+
+mod machine_manager;
+pub use machine_manager::MachineManager;
 
 pub async fn send_empty_machines_event(shared_state: Arc<SharedState>) {
     shared_state.current_machines_meta.lock().await.clear();
@@ -252,70 +255,30 @@ pub async fn handle_serial_device_hotplug(
     }
 }
 
-async fn handle_async_requests(recv: Receiver<AsyncThreadMessage>, shared_state: Arc<SharedState>) {
-    while let Ok(message) = recv.recv().await {
-        match message {
-            AsyncThreadMessage::NoMsg => (),
-            AsyncThreadMessage::ConnectOneWayRequest(cross_connection) => {
-                let api_machines_guard = shared_state.api_machines.lock().await;
-                // The Src Connection is from the machine that recvs the request to connect
-                // The Dest Connection the machine to which should be connected
-                let src_ident = cross_connection.src;
-                let dest_ident = cross_connection.dest;
-                let src_sender = match api_machines_guard.get(&src_ident) {
-                    Some(sender) => sender,
-                    None => continue,
-                };
+async fn handle_async_requests(
+    recv: Receiver<AsyncThreadMessage>, 
+    shared_state: Arc<SharedState>
+) {
+    use AsyncThreadMessage::*;
 
-                let dest_sender = match api_machines_guard.get(&dest_ident) {
-                    Some(sender) => sender,
-                    None => continue,
-                };
-                let connection = MachineConnection {
-                    ident: dest_ident,
-                    connection: dest_sender.clone(),
-                };
-                let res = src_sender
-                    .send(machines::MachineMessage::ConnectToMachine(connection))
-                    .await;
-                match res {
-                    Ok(_) => (),
-                    Err(_) => tracing::error!("Failed to send MachineConnection"),
-                }
-            }
-            AsyncThreadMessage::DisconnectMachines(cross_connection) => {
-                let api_machines_guard = shared_state.api_machines.lock().await;
-                // The Src Connection is from the machine that recvs the request to connect
-                // The Dest Connection the machine to which should be connected
-                let src_ident = cross_connection.src;
-                let dest_ident = cross_connection.dest;
-                let src_sender = match api_machines_guard.get(&src_ident) {
-                    Some(sender) => sender,
-                    None => continue,
-                };
-
-                let dest_sender = match api_machines_guard.get(&dest_ident) {
-                    Some(sender) => sender,
-                    None => continue,
-                };
-
-                let connection = MachineConnection {
-                    ident: dest_ident.clone(),
-                    connection: dest_sender.clone(),
-                };
-
-                let res = src_sender
-                    .send(machines::MachineMessage::DisconnectMachine(connection))
-                    .await;
-                match res {
-                    Ok(_) => (),
-                    Err(e) => tracing::error!(
-                        "AsyncThreadMessage::DisconnectMachines src:{:?} dest:{:?} error:{:?}",
-                        src_ident,
-                        dest_ident,
-                        e
-                    ),
-                }
+    while let Ok(message) = recv.recv().await 
+    {
+        match message 
+        {
+            NoMsg => (),
+            SubscribeToMachine(request) => 
+            {
+                shared_state.rt_machine_creation_channel
+                    .send(HotThreadMessage::SubscriptionEstablish(request))
+                    .await
+                    .expect("Could not send to real-time channel");
+            },
+            UnsubscribeFromMachine(request) => 
+            {
+                shared_state.rt_machine_creation_channel
+                    .send(HotThreadMessage::SubscriptionTerminate(request))
+                    .await
+                    .expect("Could not send to real-time channel");
             }
         }
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,7 +5,7 @@ use crate::{
 use control_core::socketio::event::GenericEvent;
 use control_core::socketio::namespace::NamespaceCacheingLogic;
 use machines::{
-    AsyncThreadMessage, MachineConnection, MachineNewHardware, MachineNewHardwareSerial,
+    AsyncThreadMessage, MachineNewHardware, MachineNewHardwareSerial,
     MachineNewParams, SerialDevice, SerialDeviceIdentification, SerialDeviceNew,
     SerialDeviceNewParams,
     laser::LaserMachine,


### PR DESCRIPTION
## What does this PR do / add / change?

Adds the capability for a machine to subscribe to another machine and receive it's live values as well as state data.
This is achieved via a machine manager handling machines and their subscriptions with minimal overhead.

Using this new system, the winder2 can now seamlessly subscribe to the laser to receive it's data whenever it is modified.

Additionally, removed all MachineMessage::ConnectToMachine and MachineMessage::DisconnectMachine since it is now superseded by the new system and wasn't utilized by any machine either way.

## Screenshots
<img width="747" height="1600" alt="image" src="https://github.com/user-attachments/assets/52bf6a20-af11-4c17-af44-78e5a000a4a5" />

## Checklist before opening the pr

- [*] Tested locally
- [*] Tested on the machine (if hardware interaction is involved)
- [*] No format errors (`cargo fmt` / `npm run format`)
- [*] No build errors (`cargo build` / `npm run build`)
