### PR TITLE
Fix typo in validation function name from 'validate_no_role_dublicates' to 'validate_no_role_duplicates'

### DIFF
--- a/machines/src/aquapath1/new.rs
+++ b/machines/src/aquapath1/new.rs
@@ -1,6 +1,6 @@
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 use super::{
@@ -40,7 +40,7 @@ impl MachineNewTrait for AquaPathV1 {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/buffer1/new.rs
+++ b/machines/src/buffer1/new.rs
@@ -21,7 +21,7 @@ use crate::{
     MachineNewHardware, MachineNewHardwareEthercat, MachineNewParams, MachineNewTrait,
     buffer1::BufferV1Mode, get_ethercat_device, validate_same_machine_identification_unique,
 };
-use crate::{buffer1::buffer_tower_controller::BufferTowerController, validate_no_role_dublicates};
+use crate::{buffer1::buffer_tower_controller::BufferTowerController, validate_no_role_duplicates};
 
 use super::{BufferV1, api::Buffer1Namespace};
 
@@ -32,7 +32,7 @@ impl MachineNewTrait for BufferV1 {
         // validate general stuff
         let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware: &&MachineNewHardwareEthercat<'_, '_, '_> = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/extruder1/new.rs
+++ b/machines/src/extruder1/new.rs
@@ -60,13 +60,13 @@ impl MachineNewTrait for ExtruderV2 {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
         use crate::{
-            MachineNewHardware, MachineNewHardwareEthercat, validate_no_role_dublicates,
+            MachineNewHardware, MachineNewHardwareEthercat, validate_no_role_duplicates,
             validate_same_machine_identification_unique,
         };
 
         let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware: &&MachineNewHardwareEthercat<'_, '_, '_> = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/extruder2/new.rs
+++ b/machines/src/extruder2/new.rs
@@ -56,14 +56,14 @@ impl MachineNewTrait for ExtruderV3 {
         // validate general stuff
 
         use crate::{
-            MachineNewHardware, MachineNewHardwareEthercat, validate_no_role_dublicates,
+            MachineNewHardware, MachineNewHardwareEthercat, validate_no_role_duplicates,
             validate_same_machine_identification_unique,
         };
 
         let device_identification = params.device_group.to_vec();
 
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware: &&MachineNewHardwareEthercat<'_, '_, '_> = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -195,14 +195,14 @@ pub fn validate_same_machine_identification_unique(
 }
 
 /// validates that every role is unique
-pub fn validate_no_role_dublicates(
+pub fn validate_no_role_duplicates(
     identified_device_group: &Vec<DeviceIdentificationIdentified>,
 ) -> Result<(), Error> {
     let mut roles = vec![];
     for device in identified_device_group.iter() {
         if roles.contains(&device.device_machine_identification.role) {
             return Err(anyhow::anyhow!(
-                "[{}::validate_no_role_dublicates] Role dublicate",
+                "[{}::validate_no_role_duplicates] Role duplicate",
                 module_path!(),
             ));
         }

--- a/machines/src/minimal_machines/BOILERPLATE_TEMPLATE/new.rs
+++ b/machines/src/minimal_machines/BOILERPLATE_TEMPLATE/new.rs
@@ -18,7 +18,7 @@ use smol::block_on;
 
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait,
-    get_ethercat_device, validate_no_role_dublicates, validate_same_machine_identification_unique,
+    get_ethercat_device, validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 use super::{MyMachine, api::MyMachineNamespace};
 
@@ -47,7 +47,7 @@ impl MachineNewTrait for MyMachine {
             .map(|d| d.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         // --- Require EtherCAT hardware (mandatory for EtherCAT machines) ----
         let hardware = match &params.hardware {

--- a/machines/src/minimal_machines/analog_input_test_machine/new.rs
+++ b/machines/src/minimal_machines/analog_input_test_machine/new.rs
@@ -10,7 +10,7 @@ use smol::{block_on, channel::unbounded};
 use super::{AnalogInputTestMachine, api::AnalogInputTestMachineNamespace};
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 impl MachineNewTrait for AnalogInputTestMachine {
@@ -22,7 +22,7 @@ impl MachineNewTrait for AnalogInputTestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/digital_input_test_machine/new.rs
+++ b/machines/src/minimal_machines/digital_input_test_machine/new.rs
@@ -14,7 +14,7 @@ use smol::{block_on, lock::RwLock};
 use super::{DigitalInputTestMachine, api::DigitalInputTestMachineNamespace};
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 impl MachineNewTrait for DigitalInputTestMachine {
@@ -26,7 +26,7 @@ impl MachineNewTrait for DigitalInputTestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/ip20_test_machine/new.rs
+++ b/machines/src/minimal_machines/ip20_test_machine/new.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 use anyhow::Error;
@@ -24,7 +24,7 @@ impl MachineNewTrait for IP20TestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/motor_test_machine/new.rs
+++ b/machines/src/minimal_machines/motor_test_machine/new.rs
@@ -1,7 +1,7 @@
 use super::{MotorState, MotorTestMachine, api::BeckhoffNamespace};
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 use anyhow::Error;
 
@@ -21,7 +21,7 @@ impl MachineNewTrait for MotorTestMachine {
         println!("[{}::new] Creating new MotorTestMachine", module_path!());
         let device_identification = params.device_group.iter().cloned().collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/test_machine/new.rs
+++ b/machines/src/minimal_machines/test_machine/new.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 use anyhow::Error;
@@ -29,7 +29,7 @@ impl MachineNewTrait for TestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/test_machine_stepper/new.rs
+++ b/machines/src/minimal_machines/test_machine_stepper/new.rs
@@ -14,7 +14,7 @@ use std::{sync::Arc, time::Instant};
 
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 use anyhow::Error;
@@ -28,7 +28,7 @@ impl MachineNewTrait for TestMachineStepper {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/wago_750_430_di_machine/new.rs
+++ b/machines/src/minimal_machines/wago_750_430_di_machine/new.rs
@@ -14,7 +14,7 @@ use smol::{block_on, lock::RwLock};
 use super::{Wago750_430DiMachine, api::Wago750_430DiMachineNamespace};
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 impl MachineNewTrait for Wago750_430DiMachine {
@@ -25,7 +25,7 @@ impl MachineNewTrait for Wago750_430DiMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/wago_750_501_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_750_501_test_machine/new.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 use anyhow::Error;
@@ -24,7 +24,7 @@ impl MachineNewTrait for Wago750_501TestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/wago_8ch_dio_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_8ch_dio_test_machine/new.rs
@@ -16,7 +16,7 @@ use smol::{block_on, lock::RwLock};
 use super::{Wago8chDigitalIOTestMachine, api::Wago8chDigitalIOTestMachineNamespace};
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 impl MachineNewTrait for Wago8chDigitalIOTestMachine {
@@ -28,7 +28,7 @@ impl MachineNewTrait for Wago8chDigitalIOTestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/wago_ai_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_ai_test_machine/new.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use super::{WagoAiTestMachine, api::WagoAiTestMachineNamespace};
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 impl MachineNewTrait for WagoAiTestMachine {
@@ -27,7 +27,7 @@ impl MachineNewTrait for WagoAiTestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/minimal_machines/wago_do_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_do_test_machine/new.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 
 use anyhow::Error;
@@ -24,7 +24,7 @@ impl MachineNewTrait for WagoDOTestMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/wago_serial_machine/new.rs
+++ b/machines/src/wago_serial_machine/new.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use crate::{
     MachineNewHardware, MachineNewParams, MachineNewTrait, get_ethercat_device,
-    validate_no_role_dublicates, validate_same_machine_identification_unique,
+    validate_no_role_duplicates, validate_same_machine_identification_unique,
 };
 use anyhow::Error;
 use ethercat_hal::devices::wago_750_354::{WAGO_750_354_IDENTITY_A, Wago750_354};
@@ -24,7 +24,7 @@ impl MachineNewTrait for WagoSerialMachine {
             .map(|device_identification| device_identification.clone())
             .collect::<Vec<_>>();
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,

--- a/machines/src/winder2/new.rs
+++ b/machines/src/winder2/new.rs
@@ -7,7 +7,7 @@ mod winder2_imports {
     pub use crate::winder2::spool_speed_controller::SpoolSpeedController;
     pub use crate::winder2::traverse_controller::TraverseController;
     pub use crate::{
-        MachineNewHardware, MachineNewParams, MachineNewTrait, validate_no_role_dublicates,
+        MachineNewHardware, MachineNewParams, MachineNewTrait, validate_no_role_duplicates,
         validate_same_machine_identification_unique,
     };
     pub use anyhow::Error;
@@ -60,7 +60,7 @@ impl MachineNewTrait for Winder2 {
         let device_identification = params.device_group.to_vec();
 
         validate_same_machine_identification_unique(&device_identification)?;
-        validate_no_role_dublicates(&device_identification)?;
+        validate_no_role_duplicates(&device_identification)?;
 
         let hardware = match &params.hardware {
             MachineNewHardware::Ethercat(x) => x,


### PR DESCRIPTION
## What does this PR do / add / change?
Fixes an typo: "dublicate" to "duplicate"

## Checklist before opening the pr

- [x] Tested locally
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
- [ ] Tested on the machine (if hardware interaction is involved)
