### PR TITLE
Set FloatingControlPanel to be expanded by default

### DIFF
--- a/electron/src/components/graph/GraphControls.tsx
+++ b/electron/src/components/graph/GraphControls.tsx
@@ -131,7 +131,7 @@ export function FloatingControlPanel({
   showFromTimestamp,
   onShowFromChange,
 }: ControlProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(true);
 
   const getSelectedTimeWindowLabel = () => {
     // If Show from Time is set, display "Show All" for the time window


### PR DESCRIPTION
## What does this PR do / add / change?
Graph Controls are now opened by default

## Screenshots
<img width="504" height="118" alt="grafik" src="https://github.com/user-attachments/assets/f67a76cd-ac94-43ca-8f6a-ba5345396c69" />


## Checklist before opening the pr

- [x] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
