### PR TITLE
Auto fix rust linting issues

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+cargo fmt
+# Fail if fmt modified any staged files, so you can review and re-stage them
+if ! git diff --quiet -- $(git diff --name-only --cached); then
+    echo "cargo fmt made changes to staged files. Review and re-stage them."
+    exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,2 @@
+#!/bin/sh
+cargo clippy -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           profile: minimal
           override: true
-          components: rustfmt
+          components: rustfmt, clippy
 
       - &cargo-cache
         name: Cache Rust dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: Format
         run: cargo fmt --check --verbose
 
-  test:
+  lint-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -74,7 +74,10 @@ jobs:
       - *setup-rust
       - *cargo-cache
 
-      - name: Run tests
+      - name: Linting
+        run: cargo clippy -- -D warnings
+
+      - name: Tests
         run: cargo test --verbose
 
   mock:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           profile: minimal
           override: true
-          components: rustfmt, clippy
+          components: rustfmt
 
       - &cargo-cache
         name: Cache Rust dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: Format
         run: cargo fmt --check --verbose
 
-  lint-and-test:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -74,10 +74,7 @@ jobs:
       - *setup-rust
       - *cargo-cache
 
-      - name: Linting
-        run: cargo clippy -- -D warnings
-
-      - name: Tests
+      - name: Run tests
         run: cargo test --verbose
 
   mock:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ suspicious = { level = "warn", priority = -1 }
 complexity = { level = "warn", priority = -1 }
 perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
-pendantic = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ QiTech Control powers 10+ production machines for filament extrusion, winding, m
 
 This is an open-source project. Contributions are welcome! Please see the [wiki](https://github.com/qitechgmbh/control/wiki) for development guidelines.
 
+### Development Setup
+
+After cloning the repo, enable the git hooks:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This installs two hooks:
+- **pre-commit** — runs `cargo fmt --check` (commit is blocked if code is not formatted)
+- **pre-push** — runs `cargo clippy -- -D warnings` (push is blocked if there are clippy warnings)
 
 
 ## Additional Videos

--- a/control-core/src/controllers/clamping_timeagnostic_pid.rs
+++ b/control-core/src/controllers/clamping_timeagnostic_pid.rs
@@ -33,6 +33,7 @@ pub struct ClampingTimeagnosticPidController {
 }
 
 impl ClampingTimeagnosticPidController {
+    #[must_use]
     pub const fn new(
         kp: f64,
         ki: f64,
@@ -65,6 +66,7 @@ impl ClampingTimeagnosticPidController {
         }
     }
 
+    #[must_use]
     pub const fn simple_new(kp: f64, ki: f64, kd: f64) -> Self {
         Self {
             kp,
@@ -85,14 +87,17 @@ impl ClampingTimeagnosticPidController {
         }
     }
 
+    #[must_use]
     pub const fn get_kp(&self) -> f64 {
         self.kp
     }
 
+    #[must_use]
     pub const fn get_ki(&self) -> f64 {
         self.ki
     }
 
+    #[must_use]
     pub const fn get_kd(&self) -> f64 {
         self.kd
     }
@@ -104,6 +109,7 @@ impl ClampingTimeagnosticPidController {
         self.kd = kd;
     }
 
+    #[must_use]
     pub const fn optional_clamp(value: f64, min: Option<f64>, max: Option<f64>) -> f64 {
         match (min, max) {
             (Some(min), Some(max)) => value.clamp(min, max),

--- a/control-core/src/controllers/first_degree_motion/acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/acceleration_speed_controller.rs
@@ -22,6 +22,7 @@ pub struct AccelerationSpeedController {
 }
 
 impl AccelerationSpeedController {
+    #[must_use]
     pub const fn new(
         min_speed: Option<f64>,
         max_speed: Option<f64>,
@@ -40,8 +41,9 @@ impl AccelerationSpeedController {
     }
 
     /// Creates a new acceleration speed controller with simplified parameters.
-    /// Sets min_acceleration to -max_acceleration for symmetric behavior.
+    /// Sets `min_acceleration` to -`max_acceleration` for symmetric behavior.
     /// No speed limits are applied.
+    #[must_use]
     pub fn new_simple(max_acceleration: f64, initial_speed: f64) -> Self {
         Self::new(
             None,              // min_speed
@@ -121,10 +123,12 @@ impl AccelerationSpeedController {
         limited_speed
     }
 
+    #[must_use]
     pub const fn get_min_speed(&self) -> Option<f64> {
         self.min_speed
     }
 
+    #[must_use]
     pub const fn get_max_speed(&self) -> Option<f64> {
         self.max_speed
     }

--- a/control-core/src/controllers/first_degree_motion/acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/acceleration_speed_controller.rs
@@ -209,7 +209,7 @@ mod tests {
         let dt = 0.1;
         let t2 = future_instant(t1, dt);
 
-        let expected_speed = (10.0 + (-15.0 * dt)).max(5.0); // Should decelerate by max_deceleration * dt, floored at target
+        let expected_speed = (-15.0f64).mul_add(dt, 10.0).max(5.0); // Should decelerate by max_deceleration * dt, floored at target
 
         let actual_speed = controller.update(5.0, t2);
 

--- a/control-core/src/controllers/first_degree_motion/angular_acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/angular_acceleration_speed_controller.rs
@@ -16,6 +16,7 @@ pub struct AngularAccelerationSpeedController {
 }
 
 impl AngularAccelerationSpeedController {
+    #[must_use]
     pub fn new(
         min_speed: Option<AngularVelocity>,
         max_speed: Option<AngularVelocity>,
@@ -35,8 +36,9 @@ impl AngularAccelerationSpeedController {
     }
 
     /// Creates a new angular acceleration speed controller with simplified parameters.
-    /// Sets min_acceleration to -max_acceleration for symmetric behavior.
+    /// Sets `min_acceleration` to -`max_acceleration` for symmetric behavior.
     /// No speed limits are applied.
+    #[must_use]
     pub fn new_simple(
         max_acceleration: AngularAcceleration,
         initial_speed: AngularVelocity,

--- a/control-core/src/controllers/first_degree_motion/linear_acceleration_speed_controller.rs
+++ b/control-core/src/controllers/first_degree_motion/linear_acceleration_speed_controller.rs
@@ -16,6 +16,7 @@ pub struct LinearAccelerationLimitingController {
 }
 
 impl LinearAccelerationLimitingController {
+    #[must_use]
     pub fn new(
         min_speed: Option<Velocity>,
         max_speed: Option<Velocity>,
@@ -36,6 +37,7 @@ impl LinearAccelerationLimitingController {
     /// Creates a new linear acceleration speed controller with simplified parameters.
     /// Sets deceleration to -acceleration for symmetric behavior.
     /// No speed limits are applied.
+    #[must_use]
     pub fn new_simple(acceleration: Acceleration, initial_speed: Velocity) -> Self {
         Self::new(
             None,          // min_speed

--- a/control-core/src/controllers/pid.rs
+++ b/control-core/src/controllers/pid.rs
@@ -21,6 +21,7 @@ pub struct PidController {
 }
 
 impl PidController {
+    #[must_use]
     pub const fn new(kp: f64, ki: f64, kd: f64) -> Self {
         Self {
             kp,
@@ -40,14 +41,17 @@ impl PidController {
         self.kd = kd;
     }
 
+    #[must_use]
     pub const fn get_kp(&self) -> f64 {
         self.kp
     }
 
+    #[must_use]
     pub const fn get_ki(&self) -> f64 {
         self.ki
     }
 
+    #[must_use]
     pub const fn get_kd(&self) -> f64 {
         self.kd
     }

--- a/control-core/src/controllers/pid_autotuner.rs
+++ b/control-core/src/controllers/pid_autotuner.rs
@@ -446,7 +446,7 @@ mod tests {
 
             if cycle % 3 == 0 {
                 let progress = tuner.get_progress_percent();
-                println!("Cycle {}: Progress {}%", cycle, progress);
+                println!("Cycle {cycle}: Progress {progress}%");
             }
         }
 

--- a/control-core/src/controllers/pid_autotuner.rs
+++ b/control-core/src/controllers/pid_autotuner.rs
@@ -13,7 +13,7 @@
 //!
 //! This tuner is generic and can be used for any physical quantity (pressure in
 //! bar, temperature in °C, etc.).  The caller is responsible for mapping the
-//! returned duty-cycle (0.0 … max_power) to the actual actuator output.
+//! returned duty-cycle (0.0 … `max_power`) to the actual actuator output.
 
 use std::time::{Duration, Instant};
 
@@ -115,6 +115,7 @@ pub struct PidAutoTuner {
 
 impl PidAutoTuner {
     /// Create a new PID auto-tuner with the given configuration
+    #[must_use]
     pub fn new(config: AutoTuneConfig) -> Self {
         Self {
             config,
@@ -294,27 +295,32 @@ impl PidAutoTuner {
     }
 
     /// Returns `true` when auto-tuning completed successfully
+    #[must_use]
     pub fn is_completed(&self) -> bool {
         self.state == AutoTuneState::Completed
     }
 
     /// Returns `true` when auto-tuning failed (timeout or insufficient data)
+    #[must_use]
     pub fn is_failed(&self) -> bool {
         self.state == AutoTuneState::Failed
     }
 
     /// Returns `true` when auto-tuning is currently running
+    #[must_use]
     pub fn is_running(&self) -> bool {
         self.state == AutoTuneState::Running
     }
 
     /// Returns `true` while the tuner drives the actuator at high output.
-    pub fn is_driving_high_output(&self) -> bool {
+    #[must_use]
+    pub const fn is_driving_high_output(&self) -> bool {
         self.driving_high_output
     }
 
     /// Current state as a static string slice
-    pub fn state(&self) -> &str {
+    #[must_use]
+    pub const fn state(&self) -> &str {
         match self.state {
             AutoTuneState::NotStarted => "not_started",
             AutoTuneState::Running => "running",
@@ -333,6 +339,7 @@ impl PidAutoTuner {
     }
 
     /// Progress as a percentage in the range 0 – 100
+    #[must_use]
     pub fn get_progress_percent(&self) -> f64 {
         match self.state {
             AutoTuneState::Completed => 100.0,

--- a/control-core/src/controllers/second_degree_motion/acceleration_position_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/acceleration_position_controller.rs
@@ -156,7 +156,7 @@ pub enum MotionPhase {
     DecreasingSpeed,
 }
 
-/// Builder for creating AccelerationPositionController with validation
+/// Builder for creating `AccelerationPositionController` with validation
 pub struct ControllerBuilder {
     min_speed: Option<f64>,
     max_speed: Option<f64>,
@@ -170,6 +170,7 @@ pub struct ControllerBuilder {
 
 impl ControllerBuilder {
     /// Create a new builder
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             min_speed: None,
@@ -183,14 +184,16 @@ impl ControllerBuilder {
         }
     }
 
-    /// Set speed limits (min_speed ≤ 0, max_speed ≥ 0)
+    /// Set speed limits (`min_speed` ≤ 0, `max_speed` ≥ 0)
+    #[must_use]
     pub const fn speed_limits(mut self, min_speed: f64, max_speed: f64) -> Self {
         self.min_speed = Some(min_speed);
         self.max_speed = Some(max_speed);
         self
     }
 
-    /// Set acceleration limits (min_acceleration < 0, max_acceleration > 0)
+    /// Set acceleration limits (`min_acceleration` < 0, `max_acceleration` > 0)
+    #[must_use]
     pub const fn acceleration_limits(
         mut self,
         min_acceleration: f64,
@@ -202,6 +205,7 @@ impl ControllerBuilder {
     }
 
     /// Set position limits (optional)
+    #[must_use]
     pub const fn position_limits(
         mut self,
         min_position: Option<f64>,
@@ -213,6 +217,7 @@ impl ControllerBuilder {
     }
 
     /// Set tolerances for position and speed comparisons
+    #[must_use]
     pub const fn tolerances(mut self, position_tolerance: f64, speed_tolerance: f64) -> Self {
         self.position_tolerance = position_tolerance;
         self.speed_tolerance = speed_tolerance;
@@ -273,9 +278,9 @@ impl AccelerationPositionController {
     /// Returns `Ok(AccelerationPositionController)` on success, or `Err(MotionControllerError)` if parameters are invalid.
     ///
     /// # Errors
-    /// - `InvalidSpeedLimits`: If min_speed > 0 or max_speed < 0
-    /// - `InvalidAccelerationLimits`: If min_acceleration ≥ 0 or max_acceleration ≤ 0  
-    /// - `InvalidPositionLimits`: If min_position > max_position
+    /// - `InvalidSpeedLimits`: If `min_speed` > 0 or `max_speed` < 0
+    /// - `InvalidAccelerationLimits`: If `min_acceleration` ≥ 0 or `max_acceleration` ≤ 0  
+    /// - `InvalidPositionLimits`: If `min_position` > `max_position`
     ///
     /// # Example
     /// ```ignore
@@ -379,13 +384,14 @@ impl AccelerationPositionController {
             -acceleration,              // min_acceleration
             acceleration,               // max_acceleration
             position.map(|p| -p.abs()), // min_position
-            position.map(|p| p.abs()),  // max_position
+            position.map(f64::abs),     // max_position
             1e-6,                       // position_tolerance (default)
             1e-6,                       // speed_tolerance (default)
         )
     }
 
     /// Create a new builder for the controller
+    #[must_use]
     pub const fn builder() -> ControllerBuilder {
         ControllerBuilder::new()
     }
@@ -555,7 +561,7 @@ impl AccelerationPositionController {
         let abs_position_change = position_change.abs();
 
         // Calculate current speed in the direction of motion
-        let current_speed_in_direction = self.current_speed * direction as f64;
+        let current_speed_in_direction = self.current_speed * f64::from(direction);
 
         // Calculate stopping distance from current speed
         if current_speed_in_direction > 0.0 {
@@ -643,7 +649,8 @@ impl AccelerationPositionController {
         match self.motion_phase {
             MotionPhase::IncreasingSpeed => {
                 // Apply acceleration to increase speed
-                self.current_acceleration = self.config.max_acceleration * self.direction as f64;
+                self.current_acceleration =
+                    self.config.max_acceleration * f64::from(self.direction);
 
                 // Update speed
                 let new_speed = self.current_acceleration.mul_add(dt, self.current_speed);
@@ -674,7 +681,8 @@ impl AccelerationPositionController {
 
             MotionPhase::DecreasingSpeed => {
                 // Apply deceleration
-                self.current_acceleration = self.config.min_acceleration * self.direction as f64;
+                self.current_acceleration =
+                    self.config.min_acceleration * f64::from(self.direction);
 
                 // Update speed
                 let new_speed = self.current_acceleration.mul_add(dt, self.current_speed);
@@ -754,6 +762,7 @@ impl AccelerationPositionController {
     ///
     /// Returns the current position of the controlled object.
     /// This value is updated with each call to `update()`.
+    #[must_use]
     pub const fn get_position(&self) -> f64 {
         self.current_position
     }
@@ -763,6 +772,7 @@ impl AccelerationPositionController {
     /// Returns the current speed (velocity) of the controlled object.
     /// Positive values indicate motion towards increasing position,
     /// negative values indicate motion towards decreasing position.
+    #[must_use]
     pub const fn get_speed(&self) -> f64 {
         self.current_speed
     }
@@ -771,41 +781,49 @@ impl AccelerationPositionController {
     ///
     /// Returns the current acceleration of the controlled object.
     /// Positive values indicate increasing speed, negative values indicate decreasing speed.
+    #[must_use]
     pub const fn get_acceleration(&self) -> f64 {
         self.current_acceleration
     }
 
     /// Get the target position
+    #[must_use]
     pub const fn get_target_position(&self) -> f64 {
         self.target_position
     }
 
     /// Get the current motion phase
+    #[must_use]
     pub const fn get_motion_phase(&self) -> MotionPhase {
         self.motion_phase
     }
 
     /// Get the direction of motion
+    #[must_use]
     pub const fn get_direction(&self) -> i8 {
         self.direction
     }
 
     /// Get the calculated peak speed for current motion
+    #[must_use]
     pub const fn get_peak_speed(&self) -> f64 {
         self.peak_speed
     }
 
     /// Get the position at which deceleration will begin
+    #[must_use]
     pub const fn get_deceleration_position(&self) -> f64 {
         self.deceleration_position
     }
 
     /// Calculate remaining distance to target
+    #[must_use]
     pub fn get_remaining_distance(&self) -> f64 {
         (self.target_position - self.current_position).abs()
     }
 
     /// Calculate estimated time to reach target (approximate)
+    #[must_use]
     pub fn get_estimated_time_to_target(&self) -> f64 {
         if self.motion_phase == MotionPhase::Idle {
             return 0.0;
@@ -832,12 +850,14 @@ impl AccelerationPositionController {
     }
 
     /// Check if the controller is currently moving
+    #[must_use]
     pub fn is_moving(&self) -> bool {
         self.motion_phase != MotionPhase::Idle
             || !self.approx_equal(self.current_speed.abs(), 0.0, self.config.speed_tolerance)
     }
 
     /// Check if the controller has reached the target
+    #[must_use]
     pub fn is_at_target(&self) -> bool {
         self.motion_phase == MotionPhase::Idle
             && self.approx_equal(
@@ -1018,31 +1038,37 @@ impl AccelerationPositionController {
     }
 
     /// Get the minimum speed limit
+    #[must_use]
     pub const fn get_min_speed(&self) -> f64 {
         self.config.min_speed
     }
 
     /// Get the maximum speed limit
+    #[must_use]
     pub const fn get_max_speed(&self) -> f64 {
         self.config.max_speed
     }
 
     /// Get the minimum acceleration limit
+    #[must_use]
     pub const fn get_min_acceleration(&self) -> f64 {
         self.config.min_acceleration
     }
 
     /// Get the maximum acceleration limit
+    #[must_use]
     pub const fn get_max_acceleration(&self) -> f64 {
         self.config.max_acceleration
     }
 
     /// Get the minimum position limit
+    #[must_use]
     pub const fn get_min_position(&self) -> Option<f64> {
         self.config.min_position
     }
 
     /// Get the maximum position limit
+    #[must_use]
     pub const fn get_max_position(&self) -> Option<f64> {
         self.config.max_position
     }
@@ -1080,11 +1106,13 @@ impl AccelerationPositionController {
     }
 
     /// Get the position tolerance
+    #[must_use]
     pub const fn get_position_tolerance(&self) -> f64 {
         self.config.position_tolerance
     }
 
     /// Get the speed tolerance
+    #[must_use]
     pub const fn get_speed_tolerance(&self) -> f64 {
         self.config.speed_tolerance
     }

--- a/control-core/src/controllers/second_degree_motion/angular_acceleration_position_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/angular_acceleration_position_controller.rs
@@ -20,6 +20,7 @@ pub struct AngularAccelerationPositionController {
 
 impl AngularAccelerationPositionController {
     /// Create a new angular position controller with acceleration limits
+    #[must_use]
     pub fn new(
         min_position: Option<Angle>,
         max_position: Option<Angle>,
@@ -56,6 +57,7 @@ impl AngularAccelerationPositionController {
     /// - `position`: Optional maximum position magnitude (None for no limits, Some(x) creates [-x, +x])
     /// - `speed`: Maximum angular velocity magnitude (creates limits [-speed, +speed])
     /// - `acceleration`: Maximum angular acceleration magnitude (creates limits [-acceleration, +acceleration])
+    #[must_use]
     pub fn new_simple(
         position: Option<Angle>,
         speed: AngularVelocity,
@@ -91,11 +93,13 @@ impl AngularAccelerationPositionController {
     }
 
     /// Get the current angle position
+    #[must_use]
     pub fn get_position(&self) -> Angle {
         Angle::new::<radian>(self.controller.get_position())
     }
 
     /// Get the target angle
+    #[must_use]
     pub fn get_target_position(&self) -> Angle {
         Angle::new::<radian>(self.controller.get_target_position())
     }
@@ -129,6 +133,7 @@ impl AngularAccelerationPositionController {
     }
 
     /// Get the current angular velocity
+    #[must_use]
     pub fn get_speed(&self) -> AngularVelocity {
         AngularVelocity::new::<radian_per_second>(self.controller.get_speed())
     }
@@ -152,6 +157,7 @@ impl AngularAccelerationPositionController {
     }
 
     /// Get the current angular acceleration
+    #[must_use]
     pub fn get_acceleration(&self) -> AngularAcceleration {
         AngularAcceleration::new::<radian_per_second_squared>(self.controller.get_acceleration())
     }

--- a/control-core/src/controllers/second_degree_motion/angular_jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/angular_jerk_speed_controller.rs
@@ -13,8 +13,8 @@ use super::jerk_speed_controller::JerkSpeedController;
 /// Angular Jerk Speed Controller with proper physical units
 ///
 /// This controller provides angular motion control with proper SI units for rotational systems.
-/// It wraps the core JerkSpeedController and provides unit-typed interfaces for angular velocity
-/// (AngularVelocity), angular acceleration (AngularAcceleration), and angular jerk (AngularJerk).
+/// It wraps the core `JerkSpeedController` and provides unit-typed interfaces for angular velocity
+/// (`AngularVelocity`), angular acceleration (`AngularAcceleration`), and angular jerk (`AngularJerk`).
 ///
 /// The controller manages smooth rotational speed profiles with configurable limits and tolerances,
 /// ensuring that angular velocity, acceleration, and jerk constraints are respected during motion.
@@ -61,7 +61,7 @@ impl AngularJerkSpeedController {
     /// * `max_jerk` - Maximum angular jerk for increasing acceleration (typically positive)
     ///
     /// # Returns
-    /// A new AngularJerkSpeedController instance
+    /// A new `AngularJerkSpeedController` instance
     ///
     /// # Example
     /// ```ignore
@@ -82,6 +82,7 @@ impl AngularJerkSpeedController {
     ///     AngularJerk::new::<revolution_per_minute_per_second_squared>(600.0),  // Max jerk
     /// );
     /// ```
+    #[must_use]
     pub fn new(
         min_speed: Option<AngularVelocity>,
         max_speed: Option<AngularVelocity>,
@@ -120,7 +121,7 @@ impl AngularJerkSpeedController {
     /// * `jerk` - Maximum angular jerk magnitude (creates limits [-jerk, +jerk])
     ///
     /// # Returns
-    /// A new AngularJerkSpeedController instance
+    /// A new `AngularJerkSpeedController` instance
     ///
     /// # Panics
     /// Panics if acceleration or jerk values are negative or zero
@@ -152,6 +153,7 @@ impl AngularJerkSpeedController {
     ///     max_jerk,   // Angular jerk limits: [-500, +500] RPM/s²
     /// );
     /// ```
+    #[must_use]
     pub fn new_simple(
         speed: Option<AngularVelocity>,
         acceleration: AngularAcceleration,
@@ -212,7 +214,8 @@ impl AngularJerkSpeedController {
     /// Returns the controller's current angular velocity in the motion profile.
     ///
     /// # Returns
-    /// Current angular velocity as an AngularVelocity value
+    /// Current angular velocity as an `AngularVelocity` value
+    #[must_use]
     pub fn get_speed(&self) -> AngularVelocity {
         AngularVelocity::new::<radian_per_second>(self.controller.get_speed())
     }
@@ -222,7 +225,8 @@ impl AngularJerkSpeedController {
     /// Returns the current target angular velocity that the controller is trying to reach.
     ///
     /// # Returns
-    /// Target angular velocity as an AngularVelocity value
+    /// Target angular velocity as an `AngularVelocity` value
+    #[must_use]
     pub fn get_target_speed(&self) -> AngularVelocity {
         AngularVelocity::new::<radian_per_second>(self.controller.get_target_speed())
     }
@@ -270,6 +274,7 @@ impl AngularJerkSpeedController {
     }
 
     /// Get the current angular acceleration
+    #[must_use]
     pub fn get_acceleration(&self) -> AngularAcceleration {
         AngularAcceleration::new::<radian_per_second_squared>(self.controller.get_acceleration())
     }
@@ -293,6 +298,7 @@ impl AngularJerkSpeedController {
     }
 
     /// Get the current angular jerk
+    #[must_use]
     pub fn get_jerk(&self) -> AngularJerk {
         AngularJerk::new::<radian_per_second_cubed>(self.controller.get_jerk())
     }

--- a/control-core/src/controllers/second_degree_motion/jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/jerk_speed_controller.rs
@@ -6,7 +6,7 @@ use super::acceleration_position_controller::{
 ///
 /// This controller manages motion profiles where speed is the primary controlled variable,
 /// with constraints on acceleration (rate of change of speed) and jerk (rate of change of acceleration).
-/// It wraps an AccelerationPositionController but remaps the parameters to represent one higher
+/// It wraps an `AccelerationPositionController` but remaps the parameters to represent one higher
 /// degree of derivation in the motion hierarchy.
 ///
 /// The control hierarchy is:
@@ -50,10 +50,10 @@ impl JerkSpeedController {
     /// * `max_jerk` - Maximum jerk for increasing acceleration (typically positive)
     ///
     /// # Returns
-    /// A new JerkSpeedController instance
+    /// A new `JerkSpeedController` instance
     ///
     /// # Panics
-    /// Panics if the underlying AccelerationPositionController cannot be created with the given parameters
+    /// Panics if the underlying `AccelerationPositionController` cannot be created with the given parameters
     ///
     /// # Example
     /// ```ignore
@@ -67,6 +67,7 @@ impl JerkSpeedController {
     ///     25.0,         // Max jerk: +25 units/s³
     /// );
     /// ```
+    #[must_use]
     pub fn new(
         min_speed: Option<f64>,
         max_speed: Option<f64>,
@@ -108,7 +109,7 @@ impl JerkSpeedController {
     /// * `jerk` - Maximum jerk magnitude (creates limits [-jerk, +jerk])
     ///
     /// # Returns
-    /// A new JerkSpeedController instance
+    /// A new `JerkSpeedController` instance
     ///
     /// # Panics
     /// Panics if acceleration or jerk values are negative or zero
@@ -129,10 +130,12 @@ impl JerkSpeedController {
     ///     15.0,    // Jerk limits: [-15, +15] units/s³
     /// );
     /// ```
+    #[must_use]
     pub fn new_simple(speed: Option<f64>, acceleration: f64, jerk: f64) -> Self {
-        if acceleration <= 0.0 || jerk <= 0.0 {
-            panic!("Acceleration and jerk must be positive values");
-        }
+        assert!(
+            !(acceleration <= 0.0 || jerk <= 0.0),
+            "Acceleration and jerk must be positive values"
+        );
 
         Self::new(
             speed.map(|s| -s), // min_speed
@@ -183,6 +186,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Current speed as a floating-point value
+    #[must_use]
     pub const fn get_speed(&self) -> f64 {
         self.base_controller.get_position()
     }
@@ -193,6 +197,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Current acceleration as a floating-point value
+    #[must_use]
     pub const fn get_acceleration(&self) -> f64 {
         self.base_controller.get_speed()
     }
@@ -203,6 +208,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Current jerk as a floating-point value
+    #[must_use]
     pub const fn get_jerk(&self) -> f64 {
         self.base_controller.get_acceleration()
     }
@@ -213,6 +219,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Target speed as a floating-point value
+    #[must_use]
     pub const fn get_target_speed(&self) -> f64 {
         self.base_controller.get_target_position()
     }
@@ -223,6 +230,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Minimum speed limit as an Option<f64>, None if no limit is set
+    #[must_use]
     pub const fn get_min_speed(&self) -> Option<f64> {
         self.base_controller.get_min_position()
     }
@@ -233,6 +241,7 @@ impl JerkSpeedController {
     ///
     /// # Returns
     /// Maximum speed limit as an Option<f64>, None if no limit is set
+    #[must_use]
     pub const fn get_max_speed(&self) -> Option<f64> {
         self.base_controller.get_max_position()
     }
@@ -248,7 +257,7 @@ impl JerkSpeedController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., greater than the maximum speed limit)
     pub fn set_min_speed(&mut self, min_speed: Option<f64>) -> Result<(), MotionControllerError> {
         self.base_controller.set_min_position(min_speed)
@@ -265,7 +274,7 @@ impl JerkSpeedController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., less than the minimum speed limit)
     pub fn set_max_speed(&mut self, max_speed: Option<f64>) -> Result<(), MotionControllerError> {
         self.base_controller.set_max_position(max_speed)
@@ -282,7 +291,7 @@ impl JerkSpeedController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., greater than the maximum acceleration limit)
     pub fn set_min_acceleration(
         &mut self,
@@ -302,7 +311,7 @@ impl JerkSpeedController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., less than the minimum acceleration limit or negative/zero value)
     pub fn set_max_acceleration(
         &mut self,
@@ -322,7 +331,7 @@ impl JerkSpeedController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., greater than the maximum jerk limit)
     pub fn set_min_jerk(&mut self, min_jerk: f64) -> Result<(), MotionControllerError> {
         self.base_controller.set_min_acceleration(min_jerk)
@@ -339,7 +348,7 @@ impl JerkSpeedController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., less than the minimum jerk limit or negative/zero value)
     pub fn set_max_jerk(&mut self, max_jerk: f64) -> Result<(), MotionControllerError> {
         self.base_controller.set_max_acceleration(max_jerk)
@@ -358,7 +367,7 @@ impl JerkSpeedController {
     /// Result indicating success or failure of the reset operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the speed is outside the configured limits
+    /// Returns `MotionControllerError` if the speed is outside the configured limits
     ///
     /// # Example
     /// ```ignore

--- a/control-core/src/controllers/second_degree_motion/linear_acceleration_position_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/linear_acceleration_position_controller.rs
@@ -14,7 +14,7 @@ use super::acceleration_position_controller::{
 /// Linear Acceleration Position Controller with proper physical units
 ///
 /// This controller provides linear motion control with proper SI units (meters, m/s, m/s²).
-/// It wraps the core AccelerationPositionController and provides unit-typed interfaces
+/// It wraps the core `AccelerationPositionController` and provides unit-typed interfaces
 /// for position (Length), velocity (Velocity), and acceleration (Acceleration).
 ///
 /// The controller manages smooth motion profiles with configurable limits and tolerances,
@@ -53,10 +53,11 @@ impl LinearAccelerationPositionController {
     /// * `max_acceleration` - Maximum acceleration limit (typically positive)
     ///
     /// # Returns
-    /// A new LinearAccelerationPositionController instance
+    /// A new `LinearAccelerationPositionController` instance
     ///
     /// # Panics
-    /// Panics if the underlying AccelerationPositionController cannot be created with the given parameters
+    /// Panics if the underlying `AccelerationPositionController` cannot be created with the given parameters
+    #[must_use]
     pub fn new(
         min_position: Option<Length>,
         max_position: Option<Length>,
@@ -92,10 +93,10 @@ impl LinearAccelerationPositionController {
     /// * `acceleration` - Maximum acceleration limit (creates [-acceleration, +acceleration] range)
     ///
     /// # Returns
-    /// A Result containing the new controller or a MotionControllerError
+    /// A Result containing the new controller or a `MotionControllerError`
     ///
     /// # Errors
-    /// Returns MotionControllerError if:
+    /// Returns `MotionControllerError` if:
     /// - Speed or acceleration values are negative or zero
     /// - The underlying controller cannot be created with the calculated limits
     ///
@@ -184,6 +185,7 @@ impl LinearAccelerationPositionController {
     ///
     /// # Returns
     /// Current position as a Length value
+    #[must_use]
     pub fn get_position(&self) -> Length {
         Length::new::<meter>(self.controller.get_position())
     }
@@ -194,6 +196,7 @@ impl LinearAccelerationPositionController {
     ///
     /// # Returns
     /// Target position as a Length value
+    #[must_use]
     pub fn get_target_position(&self) -> Length {
         Length::new::<meter>(self.controller.get_target_position())
     }
@@ -229,7 +232,7 @@ impl LinearAccelerationPositionController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., greater than the maximum position limit)
     pub fn set_min_position(
         &mut self,
@@ -250,7 +253,7 @@ impl LinearAccelerationPositionController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., less than the minimum position limit)
     pub fn set_max_position(
         &mut self,
@@ -266,6 +269,7 @@ impl LinearAccelerationPositionController {
     ///
     /// # Returns
     /// Current velocity as a Velocity value
+    #[must_use]
     pub fn get_speed(&self) -> Velocity {
         Velocity::new::<meter_per_second>(self.controller.get_speed())
     }
@@ -281,7 +285,7 @@ impl LinearAccelerationPositionController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., greater than the maximum speed limit)
     pub fn set_min_speed(&mut self, min_speed: Velocity) -> Result<(), MotionControllerError> {
         self.controller
@@ -299,7 +303,7 @@ impl LinearAccelerationPositionController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., less than the minimum speed limit or negative/zero value)
     pub fn set_max_speed(&mut self, max_speed: Velocity) -> Result<(), MotionControllerError> {
         self.controller
@@ -312,6 +316,7 @@ impl LinearAccelerationPositionController {
     ///
     /// # Returns
     /// Current acceleration as an Acceleration value
+    #[must_use]
     pub fn get_acceleration(&self) -> Acceleration {
         Acceleration::new::<meter_per_second_squared>(self.controller.get_acceleration())
     }
@@ -327,7 +332,7 @@ impl LinearAccelerationPositionController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., greater than the maximum acceleration limit)
     pub fn set_min_acceleration(
         &mut self,
@@ -348,7 +353,7 @@ impl LinearAccelerationPositionController {
     /// Result indicating success or failure of the operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the new limit would be invalid
+    /// Returns `MotionControllerError` if the new limit would be invalid
     /// (e.g., less than the minimum acceleration limit or negative/zero value)
     pub fn set_max_acceleration(
         &mut self,
@@ -371,7 +376,7 @@ impl LinearAccelerationPositionController {
     /// Result indicating success or failure of the reset operation
     ///
     /// # Errors
-    /// Returns MotionControllerError if the position is outside the configured limits
+    /// Returns `MotionControllerError` if the position is outside the configured limits
     ///
     /// # Example
     /// ```ignore

--- a/control-core/src/controllers/second_degree_motion/linear_jerk_speed_controller.rs
+++ b/control-core/src/controllers/second_degree_motion/linear_jerk_speed_controller.rs
@@ -13,7 +13,7 @@ use super::jerk_speed_controller::JerkSpeedController;
 /// Linear Jerk Speed Controller with proper physical units
 ///
 /// This controller provides linear motion control with proper SI units for translational systems.
-/// It wraps the core JerkSpeedController and provides unit-typed interfaces for velocity (Velocity),
+/// It wraps the core `JerkSpeedController` and provides unit-typed interfaces for velocity (Velocity),
 /// acceleration (Acceleration), and jerk (Jerk).
 ///
 /// The controller manages smooth linear speed profiles with configurable limits and tolerances,
@@ -61,7 +61,7 @@ impl LinearJerkSpeedController {
     /// * `max_jerk` - Maximum jerk for increasing acceleration (typically positive)
     ///
     /// # Returns
-    /// A new LinearJerkSpeedController instance
+    /// A new `LinearJerkSpeedController` instance
     ///
     /// # Example
     /// ```ignore
@@ -82,6 +82,7 @@ impl LinearJerkSpeedController {
     ///     Jerk::new::<meter_per_second_cubed>(3.0),  // Max jerk
     /// );
     /// ```
+    #[must_use]
     pub fn new(
         min_speed: Option<Velocity>,
         max_speed: Option<Velocity>,
@@ -120,7 +121,7 @@ impl LinearJerkSpeedController {
     /// * `jerk` - Maximum jerk magnitude (creates limits [-jerk, +jerk])
     ///
     /// # Returns
-    /// A new LinearJerkSpeedController instance
+    /// A new `LinearJerkSpeedController` instance
     ///
     /// # Panics
     /// Panics if acceleration or jerk values are negative or zero
@@ -152,6 +153,7 @@ impl LinearJerkSpeedController {
     ///     max_jerk,   // Jerk limits: [-1.5, +1.5] m/s³
     /// );
     /// ```
+    #[must_use]
     pub fn new_simple(speed: Option<Velocity>, acceleration: Acceleration, jerk: Jerk) -> Self {
         let controller = JerkSpeedController::new_simple(
             speed.map(|s| s.get::<meter_per_second>()),
@@ -182,11 +184,13 @@ impl LinearJerkSpeedController {
     }
 
     /// Get the current speed
+    #[must_use]
     pub fn get_speed(&self) -> Velocity {
         Velocity::new::<meter_per_second>(self.controller.get_speed())
     }
 
     /// Get the target speed
+    #[must_use]
     pub fn get_target_speed(&self) -> Velocity {
         Velocity::new::<meter_per_second>(self.controller.get_target_speed())
     }
@@ -224,6 +228,7 @@ impl LinearJerkSpeedController {
     }
 
     /// Get the current acceleration
+    #[must_use]
     pub fn get_acceleration(&self) -> Acceleration {
         Acceleration::new::<meter_per_second_squared>(self.controller.get_acceleration())
     }
@@ -247,6 +252,7 @@ impl LinearJerkSpeedController {
     }
 
     /// Get the current jerk
+    #[must_use]
     pub fn get_jerk(&self) -> Jerk {
         Jerk::new::<meter_per_second_cubed>(self.controller.get_jerk())
     }

--- a/control-core/src/converters/angle_converter.rs
+++ b/control-core/src/converters/angle_converter.rs
@@ -246,14 +246,14 @@ mod tests {
     #[test]
     fn test_constructors() {
         let math = AngleConverter::mathematical();
-        assert_eq!(math.flip_x, false);
-        assert_eq!(math.flip_y, false);
-        assert_eq!(math.is_cw, false);
+        assert!(!math.flip_x);
+        assert!(!math.flip_y);
+        assert!(!math.is_cw);
 
         let screen = AngleConverter::screen();
-        assert_eq!(screen.flip_x, false);
-        assert_eq!(screen.flip_y, true);
-        assert_eq!(screen.is_cw, false);
+        assert!(!screen.flip_x);
+        assert!(screen.flip_y);
+        assert!(!screen.is_cw);
     }
 
     #[test]
@@ -300,8 +300,8 @@ mod tests {
         let converter = AngleConverter::screen();
 
         // Test radians_encode
-        let result = converter.radians_encode(PI as f64 / 2.0) as f64; // 90° in radians
-        let expected: f64 = 270.0f64 * PI as f64 / 180.0f64; // 270° in radians
+        let result = converter.radians_encode(f64::from(PI) / 2.0); // 90° in radians
+        let expected: f64 = 270.0f64 * f64::from(PI) / 180.0f64; // 270° in radians
         assert!((result - expected).abs() < 1e-6);
     }
 
@@ -313,6 +313,6 @@ mod tests {
         let converted = converter.degrees_encode(original);
         let roundtrip = converter.degrees_decode(converted);
 
-        assert!((original - roundtrip as f64).abs() < 1e-6);
+        assert!((original - roundtrip).abs() < 1e-6);
     }
 }

--- a/control-core/src/converters/angle_converter.rs
+++ b/control-core/src/converters/angle_converter.rs
@@ -9,6 +9,7 @@ pub struct AngleConverter {
 
 impl AngleConverter {
     /// Create a custom coordinate system
+    #[must_use]
     pub const fn new(flip_x: bool, flip_y: bool, is_cw: bool) -> Self {
         Self {
             flip_x,
@@ -18,51 +19,61 @@ impl AngleConverter {
     }
 
     /// Standard mathematical coordinate system (CCW positive, 0° at positive X)
+    #[must_use]
     pub const fn mathematical() -> Self {
         Self::new(false, false, false)
     }
 
     /// Screen/graphics coordinate system (CW positive, 0° at positive X, Y-flipped)
+    #[must_use]
     pub const fn screen() -> Self {
         Self::new(false, true, false)
     }
 
     /// System where 0° points up, clockwise positive
+    #[must_use]
     pub const fn y_up_cw() -> Self {
         Self::new(false, false, true)
     }
 
     /// System where 0° points down, counter-clockwise positive
+    #[must_use]
     pub const fn y_down_ccw() -> Self {
         Self::new(false, true, true)
     }
 
     /// System where 0° points left, clockwise positive
+    #[must_use]
     pub const fn x_left_cw() -> Self {
         Self::new(true, false, false)
     }
 
     /// System where 0° points right, counter-clockwise positive (same as mathematical)
+    #[must_use]
     pub const fn x_right_ccw() -> Self {
         Self::mathematical()
     }
 
     /// System where 0° points up, counter-clockwise positive
+    #[must_use]
     pub const fn y_up_ccw() -> Self {
         Self::new(false, false, false)
     }
 
     /// System where 0° points down, clockwise positive
+    #[must_use]
     pub const fn y_down_cw() -> Self {
         Self::new(false, true, false)
     }
 
     /// System where 0° points left, counter-clockwise positive
+    #[must_use]
     pub const fn x_left_ccw() -> Self {
         Self::new(true, false, true)
     }
 
     /// Convert angle from mathematical system to this system (f32)
+    #[must_use]
     pub fn degrees_encode(&self, math_angle_degrees: f64) -> f64 {
         let normalized_input = self.normalize_angle(math_angle_degrees);
 
@@ -85,6 +96,7 @@ impl AngleConverter {
     }
 
     /// Convert angle from this system to mathematical system (f32)
+    #[must_use]
     pub fn degrees_decode(&self, system_angle_degrees: f64) -> f64 {
         let normalized_input = self.normalize_angle(system_angle_degrees);
 
@@ -107,6 +119,7 @@ impl AngleConverter {
     }
 
     /// Convert angle in radians from mathematical system to this system (f32)
+    #[must_use]
     pub fn radians_encode(&self, math_angle_radians: f64) -> f64 {
         let degrees = math_angle_radians.to_degrees();
         let converted_degrees = self.degrees_encode(degrees);
@@ -114,6 +127,7 @@ impl AngleConverter {
     }
 
     /// Convert angle in radians from this system to mathematical system (f32)
+    #[must_use]
     pub fn radians_decode(&self, system_angle_radians: f64) -> f64 {
         let degrees = system_angle_radians.to_degrees();
         let converted_degrees = self.degrees_decode(degrees);
@@ -121,6 +135,7 @@ impl AngleConverter {
     }
 
     /// Convert angle from mathematical system to this system (f64)
+    #[must_use]
     pub fn degrees_encode_f64(&self, math_angle_degrees: f64) -> f64 {
         let normalized_input = self.normalize_angle_f64(math_angle_degrees);
 
@@ -143,6 +158,7 @@ impl AngleConverter {
     }
 
     /// Convert angle from this system to mathematical system (f64)
+    #[must_use]
     pub fn degrees_decode_f64(&self, system_angle_degrees: f64) -> f64 {
         let normalized_input = self.normalize_angle_f64(system_angle_degrees);
 
@@ -165,6 +181,7 @@ impl AngleConverter {
     }
 
     /// Convert angle in radians from mathematical system to this system (f64)
+    #[must_use]
     pub fn radians_encode_f64(&self, math_angle_radians: f64) -> f64 {
         let degrees = math_angle_radians.to_degrees();
         let converted_degrees = self.degrees_encode_f64(degrees);
@@ -172,6 +189,7 @@ impl AngleConverter {
     }
 
     /// Convert angle in radians from this system to mathematical system (f64)
+    #[must_use]
     pub fn radians_decode_f64(&self, system_angle_radians: f64) -> f64 {
         let degrees = system_angle_radians.to_degrees();
         let converted_degrees = self.degrees_decode_f64(degrees);
@@ -203,14 +221,17 @@ pub struct AngleConverterUom {
 }
 
 impl AngleConverterUom {
+    #[must_use]
     pub const fn new(angle_converter: AngleConverter) -> Self {
         Self { angle_converter }
     }
 
+    #[must_use]
     pub fn encode(&self, angle: Angle) -> Angle {
         Angle::new::<radian>(self.angle_converter.radians_encode(angle.get::<radian>()))
     }
 
+    #[must_use]
     pub fn decode(&self, angle: Angle) -> Angle {
         Angle::new::<radian>(self.angle_converter.radians_decode(angle.get::<radian>()))
     }

--- a/control-core/src/converters/angular_step_converter.rs
+++ b/control-core/src/converters/angular_step_converter.rs
@@ -18,6 +18,7 @@ pub struct AngularStepConverter {
 
 impl AngularStepConverter {
     /// Create a new converter with the specified steps per revolution
+    #[must_use]
     pub const fn new(steps_per_revolution: i16) -> Self {
         Self {
             steps_per_revolution,
@@ -26,47 +27,52 @@ impl AngularStepConverter {
 
     /// Convert steps to angle
     ///
-    /// Formula: angle (in revolutions) = steps / steps_per_revolution
+    /// Formula: angle (in revolutions) = steps / `steps_per_revolution`
+    #[must_use]
     pub fn steps_to_angle(&self, steps: f64) -> Angle {
-        let revolutions = steps / self.steps_per_revolution as f64;
+        let revolutions = steps / f64::from(self.steps_per_revolution);
         Angle::new::<revolution>(revolutions)
     }
 
     /// Convert angle to steps
     ///
-    /// Formula: steps = angle (in revolutions) * steps_per_revolution
+    /// Formula: steps = angle (in revolutions) * `steps_per_revolution`
+    #[must_use]
     pub fn angle_to_steps(&self, angle: Angle) -> f64 {
         let revolutions = angle.get::<revolution>();
-        revolutions * self.steps_per_revolution as f64
+        revolutions * f64::from(self.steps_per_revolution)
     }
 
     /// Convert steps/second to angular velocity
     ///
-    /// Formula: angular velocity (in rev/s) = steps_per_second / steps_per_revolution
+    /// Formula: angular velocity (in rev/s) = `steps_per_second` / `steps_per_revolution`
+    #[must_use]
     pub fn steps_to_angular_velocity(&self, steps_per_second: f64) -> AngularVelocity {
-        let revolutions_per_second = steps_per_second / self.steps_per_revolution as f64;
+        let revolutions_per_second = steps_per_second / f64::from(self.steps_per_revolution);
         AngularVelocity::new::<revolution_per_second>(revolutions_per_second)
     }
 
     /// Convert angular velocity to steps/second
     ///
-    /// Formula: steps_per_second = angular velocity (in rev/s) * steps_per_revolution
+    /// Formula: `steps_per_second` = angular velocity (in rev/s) * `steps_per_revolution`
+    #[must_use]
     pub fn angular_velocity_to_steps(&self, angular_velocity: AngularVelocity) -> f64 {
         let revolutions_per_second = angular_velocity.get::<revolution_per_second>();
-        revolutions_per_second * self.steps_per_revolution as f64
+        revolutions_per_second * f64::from(self.steps_per_revolution)
     }
 
     /// Convert steps/second² to angular acceleration
     ///
     /// Formula:
-    /// - revolutions_per_second² = steps_per_second² / steps_per_revolution
-    /// - angular acceleration (in rad/s²) = revolutions_per_second² * 2π
+    /// - `revolutions_per_second²` = `steps_per_second²` / `steps_per_revolution`
+    /// - angular acceleration (in rad/s²) = `revolutions_per_second²` * 2π
+    #[must_use]
     pub fn steps_to_angular_acceleration(
         &self,
         steps_per_second_squared: f64,
     ) -> AngularAcceleration {
         let revolutions_per_second_squared =
-            steps_per_second_squared / self.steps_per_revolution as f64;
+            steps_per_second_squared / f64::from(self.steps_per_revolution);
         let radians_per_second_squared =
             revolutions_per_second_squared * 2.0 * std::f64::consts::PI;
         AngularAcceleration::new::<radian_per_second_squared>(radians_per_second_squared)
@@ -75,13 +81,14 @@ impl AngularStepConverter {
     /// Convert angular acceleration to steps/second²
     ///
     /// Formula:
-    /// - revolutions_per_second² = angular acceleration (in rad/s²) / 2π
-    /// - steps_per_second² = revolutions_per_second² * steps_per_revolution
+    /// - `revolutions_per_second²` = angular acceleration (in rad/s²) / 2π
+    /// - `steps_per_second²` = `revolutions_per_second²` * `steps_per_revolution`
+    #[must_use]
     pub fn angular_acceleration_to_steps(&self, angular_acceleration: AngularAcceleration) -> f64 {
         let radians_per_second_squared = angular_acceleration.get::<radian_per_second_squared>();
         let revolutions_per_second_squared =
             radians_per_second_squared / (2.0 * std::f64::consts::PI);
-        revolutions_per_second_squared * self.steps_per_revolution as f64
+        revolutions_per_second_squared * f64::from(self.steps_per_revolution)
     }
 }
 

--- a/control-core/src/converters/circular_converter.rs
+++ b/control-core/src/converters/circular_converter.rs
@@ -43,24 +43,27 @@ pub struct CircularConverter {
 
 impl CircularConverter {
     /// Create a new converter from radius
+    #[must_use]
     pub fn from_radius(radius: Length) -> Self {
         let diameter = radius * 2.0;
         let circumference =
             Length::new::<meter>(2.0 * std::f64::consts::PI * radius.get::<meter>());
         Self {
             radius,
-            diameter,
             circumference,
+            diameter,
         }
     }
 
     /// Create a new converter from diameter
+    #[must_use]
     pub fn from_diameter(diameter: Length) -> Self {
         let radius = diameter / 2.0;
         Self::from_radius(radius)
     }
 
     /// Create a new converter from circumference
+    #[must_use]
     pub fn from_circumference(circumference: Length) -> Self {
         let radius =
             Length::new::<meter>(circumference.get::<meter>() / (2.0 * std::f64::consts::PI));
@@ -68,16 +71,19 @@ impl CircularConverter {
     }
 
     /// Get the radius
+    #[must_use]
     pub fn radius(&self) -> Length {
         self.radius
     }
 
     /// Get the diameter
+    #[must_use]
     pub fn diameter(&self) -> Length {
         self.diameter
     }
 
     /// Get the circumference
+    #[must_use]
     pub fn circumference(&self) -> Length {
         self.circumference
     }
@@ -86,6 +92,7 @@ impl CircularConverter {
 
     /// Convert linear distance to angular position
     /// Formula: angle = distance / radius
+    #[must_use]
     pub fn linear_to_angular_position(&self, distance: Length) -> Angle {
         let angle_rad = distance.get::<meter>() / self.radius.get::<meter>();
         Angle::new::<radian>(angle_rad)
@@ -93,6 +100,7 @@ impl CircularConverter {
 
     /// Convert angular position to linear distance
     /// Formula: distance = angle * radius
+    #[must_use]
     pub fn angular_to_linear_position(&self, angle: Angle) -> Length {
         let distance = angle.get::<radian>() * self.radius.get::<meter>();
         Length::new::<meter>(distance)
@@ -101,7 +109,8 @@ impl CircularConverter {
     // Linear to Angular Velocity Conversions
 
     /// Convert linear velocity to angular velocity
-    /// Formula: angular_velocity = linear_velocity / radius
+    /// Formula: `angular_velocity` = `linear_velocity` / radius
+    #[must_use]
     pub fn linear_to_angular_velocity(&self, velocity: Velocity) -> AngularVelocity {
         let angular_velocity_rad_per_s =
             velocity.get::<meter_per_second>() / self.radius.get::<meter>();
@@ -109,7 +118,8 @@ impl CircularConverter {
     }
 
     /// Convert angular velocity to linear velocity
-    /// Formula: linear_velocity = angular_velocity * radius
+    /// Formula: `linear_velocity` = `angular_velocity` * radius
+    #[must_use]
     pub fn angular_to_linear_velocity(&self, angular_velocity: AngularVelocity) -> Velocity {
         let velocity = angular_velocity.get::<radian_per_second>() * self.radius.get::<meter>();
         Velocity::new::<meter_per_second>(velocity)
@@ -118,7 +128,8 @@ impl CircularConverter {
     // Linear to Angular Acceleration Conversions
 
     /// Convert linear acceleration to angular acceleration
-    /// Formula: angular_acceleration = linear_acceleration / radius
+    /// Formula: `angular_acceleration` = `linear_acceleration` / radius
+    #[must_use]
     pub fn linear_to_angular_acceleration(
         &self,
         acceleration: Acceleration,
@@ -129,7 +140,8 @@ impl CircularConverter {
     }
 
     /// Convert angular acceleration to linear acceleration
-    /// Formula: linear_acceleration = angular_acceleration * radius
+    /// Formula: `linear_acceleration` = `angular_acceleration` * radius
+    #[must_use]
     pub fn angular_to_linear_acceleration(
         &self,
         angular_acceleration: AngularAcceleration,
@@ -142,15 +154,17 @@ impl CircularConverter {
     // Jerk Conversions (using f64 for now since UOM may not have jerk units)
 
     /// Convert linear jerk to angular jerk
-    /// Formula: angular_jerk = linear_jerk / radius
+    /// Formula: `angular_jerk` = `linear_jerk` / radius
     /// Units: rad/s³ = (m/s³) / m
+    #[must_use]
     pub fn linear_to_angular_jerk(&self, linear_jerk: f64) -> f64 {
         linear_jerk / self.radius.get::<meter>()
     }
 
     /// Convert angular jerk to linear jerk
-    /// Formula: linear_jerk = angular_jerk * radius
+    /// Formula: `linear_jerk` = `angular_jerk` * radius
     /// Units: m/s³ = (rad/s³) * m
+    #[must_use]
     pub fn angular_to_linear_jerk(&self, angular_jerk: f64) -> f64 {
         angular_jerk * self.radius.get::<meter>()
     }
@@ -158,13 +172,15 @@ impl CircularConverter {
     // Arc Length Calculations
 
     /// Calculate arc length from angle
-    /// Formula: arc_length = angle * radius
+    /// Formula: `arc_length` = angle * radius
+    #[must_use]
     pub fn angle_to_arc_length(&self, angle: Angle) -> Length {
         self.angular_to_linear_position(angle)
     }
 
     /// Calculate angle from arc length
-    /// Formula: angle = arc_length / radius
+    /// Formula: angle = `arc_length` / radius
+    #[must_use]
     pub fn arc_length_to_angle(&self, arc_length: Length) -> Angle {
         self.linear_to_angular_position(arc_length)
     }
@@ -173,24 +189,28 @@ impl CircularConverter {
 
     /// Convert linear distance to number of revolutions
     /// Formula: revolutions = distance / circumference
+    #[must_use]
     pub fn linear_distance_to_revolutions(&self, distance: Length) -> f64 {
         distance.get::<meter>() / self.circumference.get::<meter>()
     }
 
     /// Convert number of revolutions to linear distance
     /// Formula: distance = revolutions * circumference
+    #[must_use]
     pub fn revolutions_to_linear_distance(&self, revolutions: f64) -> Length {
         Length::new::<meter>(revolutions * self.circumference.get::<meter>())
     }
 
     /// Convert linear velocity to revolutions per second
     /// Formula: rps = velocity / circumference
+    #[must_use]
     pub fn linear_velocity_to_rps(&self, velocity: Velocity) -> f64 {
         velocity.get::<meter_per_second>() / self.circumference.get::<meter>()
     }
 
     /// Convert revolutions per second to linear velocity
     /// Formula: velocity = rps * circumference
+    #[must_use]
     pub fn rps_to_linear_velocity(&self, rps: f64) -> Velocity {
         Velocity::new::<meter_per_second>(rps * self.circumference.get::<meter>())
     }

--- a/control-core/src/converters/linear_step_converter.rs
+++ b/control-core/src/converters/linear_step_converter.rs
@@ -21,6 +21,7 @@ pub struct LinearStepConverter {
 // Constructor and basic getters
 impl LinearStepConverter {
     /// Create a new converter from radius and steps per revolution
+    #[must_use]
     pub fn from_radius(steps_per_revolution: i16, radius: Length) -> Self {
         Self {
             angular_step_converter: AngularStepConverter::new(steps_per_revolution),
@@ -29,6 +30,7 @@ impl LinearStepConverter {
     }
 
     /// Create a new converter from diameter and steps per revolution
+    #[must_use]
     pub fn from_diameter(steps_per_revolution: i16, diameter: Length) -> Self {
         Self {
             angular_step_converter: AngularStepConverter::new(steps_per_revolution),
@@ -37,6 +39,7 @@ impl LinearStepConverter {
     }
 
     /// Create a new converter from circumference and steps per revolution
+    #[must_use]
     pub fn from_circumference(steps_per_revolution: i16, circumference: Length) -> Self {
         Self {
             angular_step_converter: AngularStepConverter::new(steps_per_revolution),
@@ -45,21 +48,25 @@ impl LinearStepConverter {
     }
 
     /// Get the radius used by the converter
+    #[must_use]
     pub fn radius(&self) -> Length {
         self.circular_converter.radius()
     }
 
     /// Get the diameter of the system
+    #[must_use]
     pub fn diameter(&self) -> Length {
         self.circular_converter.diameter()
     }
 
     /// Get the circumference of the system
+    #[must_use]
     pub fn circumference(&self) -> Length {
         self.circular_converter.circumference()
     }
 
     /// Get the steps per revolution
+    #[must_use]
     pub const fn steps_per_revolution(&self) -> i16 {
         self.angular_step_converter.steps_per_revolution
     }
@@ -69,7 +76,8 @@ impl LinearStepConverter {
 impl LinearStepConverter {
     /// Convert linear distance to steps
     ///
-    /// Formula: steps = (distance / circumference) * steps_per_revolution
+    /// Formula: steps = (distance / circumference) * `steps_per_revolution`
+    #[must_use]
     pub fn distance_to_steps(&self, distance: Length) -> f64 {
         // Convert distance to revolutions using CircularConverter
         let revolutions = self
@@ -83,7 +91,8 @@ impl LinearStepConverter {
 
     /// Convert steps to linear distance
     ///
-    /// Formula: distance = (steps / steps_per_revolution) * circumference
+    /// Formula: distance = (steps / `steps_per_revolution`) * circumference
+    #[must_use]
     pub fn steps_to_distance(&self, steps: f64) -> Length {
         // Convert steps to angle
         let angle = self.angular_step_converter.steps_to_angle(steps);
@@ -96,7 +105,8 @@ impl LinearStepConverter {
 
     /// Convert linear velocity to steps/second
     ///
-    /// Formula: steps/second = (velocity / circumference) * steps_per_revolution
+    /// Formula: steps/second = (velocity / circumference) * `steps_per_revolution`
+    #[must_use]
     pub fn velocity_to_steps(&self, velocity: Velocity) -> f64 {
         // Convert linear velocity to revolutions per second using CircularConverter
         let rps = self.circular_converter.linear_velocity_to_rps(velocity);
@@ -109,7 +119,8 @@ impl LinearStepConverter {
 
     /// Convert steps/second to linear velocity
     ///
-    /// Formula: velocity = (steps_per_second / steps_per_revolution) * circumference
+    /// Formula: velocity = (`steps_per_second` / `steps_per_revolution`) * circumference
+    #[must_use]
     pub fn steps_to_velocity(&self, steps_per_second: f64) -> Velocity {
         // Convert steps/second to angular velocity
         let angular_velocity = self
@@ -123,7 +134,8 @@ impl LinearStepConverter {
 
     /// Convert linear acceleration to steps/second²
     ///
-    /// Formula: steps/second² = (acceleration / radius) * (steps_per_revolution / (2π))
+    /// Formula: steps/second² = (acceleration / radius) * (`steps_per_revolution` / (2π))
+    #[must_use]
     pub fn acceleration_to_steps(&self, acceleration: Acceleration) -> f64 {
         // Convert linear acceleration to angular acceleration using CircularConverter
         let angular_acceleration = self
@@ -137,7 +149,8 @@ impl LinearStepConverter {
 
     /// Convert steps/second² to linear acceleration
     ///
-    /// Formula: acceleration = (steps_per_second² / steps_per_revolution) * (2π) * radius
+    /// Formula: acceleration = (`steps_per_second²` / `steps_per_revolution`) * (2π) * radius
+    #[must_use]
     pub fn steps_to_acceleration(&self, steps_per_second_squared: f64) -> Acceleration {
         // Convert steps/second² to angular acceleration
         let angular_acceleration = self
@@ -155,6 +168,7 @@ impl LinearStepConverter {
     /// Convert linear distance to angle
     ///
     /// Formula: angle (in revolutions) = distance / circumference
+    #[must_use]
     pub fn distance_to_angle(&self, distance: Length) -> Angle {
         let revolutions = self
             .circular_converter
@@ -165,6 +179,7 @@ impl LinearStepConverter {
     /// Convert angle to linear distance
     ///
     /// Formula: distance = angle (in revolutions) * circumference
+    #[must_use]
     pub fn angle_to_distance(&self, angle: Angle) -> Length {
         let revolutions = angle.get::<revolution>();
         self.circular_converter
@@ -174,6 +189,7 @@ impl LinearStepConverter {
     /// Convert linear velocity to angular velocity
     ///
     /// Formula: angular velocity (in rev/s) = velocity / circumference
+    #[must_use]
     pub fn velocity_to_angular_velocity(&self, velocity: Velocity) -> AngularVelocity {
         let rps = self.circular_converter.linear_velocity_to_rps(velocity);
         AngularVelocity::new::<revolution_per_second>(rps)
@@ -182,6 +198,7 @@ impl LinearStepConverter {
     /// Convert angular velocity to linear velocity
     ///
     /// Formula: velocity = angular velocity (in rev/s) * circumference
+    #[must_use]
     pub fn angular_velocity_to_velocity(&self, angular_velocity: AngularVelocity) -> Velocity {
         let rps = angular_velocity.get::<revolution_per_second>();
         self.circular_converter.rps_to_linear_velocity(rps)
@@ -190,6 +207,7 @@ impl LinearStepConverter {
     /// Convert linear acceleration to angular acceleration
     ///
     /// Formula: angular acceleration (in rad/s²) = acceleration / radius
+    #[must_use]
     pub fn acceleration_to_angular_acceleration(
         &self,
         acceleration: Acceleration,
@@ -201,6 +219,7 @@ impl LinearStepConverter {
     /// Convert angular acceleration to linear acceleration
     ///
     /// Formula: acceleration = angular acceleration (in rad/s²) * radius
+    #[must_use]
     pub fn angular_acceleration_to_acceleration(
         &self,
         angular_acceleration: AngularAcceleration,
@@ -213,33 +232,39 @@ impl LinearStepConverter {
 // Forward angular to/from steps conversions from StepConverter
 impl LinearStepConverter {
     /// Convert steps to angle
+    #[must_use]
     pub fn steps_to_angle(&self, steps: f64) -> Angle {
         self.angular_step_converter.steps_to_angle(steps)
     }
 
     /// Convert angle to steps
+    #[must_use]
     pub fn angle_to_steps(&self, angle: Angle) -> f64 {
         self.angular_step_converter.angle_to_steps(angle)
     }
 
     /// Convert steps/second to angular velocity
+    #[must_use]
     pub fn steps_to_angular_velocity(&self, steps: f64) -> AngularVelocity {
         self.angular_step_converter.steps_to_angular_velocity(steps)
     }
 
     /// Convert angular velocity to steps/second
+    #[must_use]
     pub fn angular_velocity_to_steps(&self, angular_velocity: AngularVelocity) -> f64 {
         self.angular_step_converter
             .angular_velocity_to_steps(angular_velocity)
     }
 
     /// Convert steps/second² to angular acceleration
+    #[must_use]
     pub fn steps_to_angular_acceleration(&self, steps: f64) -> AngularAcceleration {
         self.angular_step_converter
             .steps_to_angular_acceleration(steps)
     }
 
     /// Convert angular acceleration to steps/second²
+    #[must_use]
     pub fn angular_acceleration_to_steps(&self, angular_acceleration: AngularAcceleration) -> f64 {
         self.angular_step_converter
             .angular_acceleration_to_steps(angular_acceleration)

--- a/control-core/src/downcast.rs
+++ b/control-core/src/downcast.rs
@@ -25,7 +25,7 @@ impl<T: 'static, U: Any + 'static> Downcast<Arc<Mutex<T>>> for Arc<Mutex<U>> {
 
             // Transmute the Arc to the desired type
             unsafe {
-                let arc = Arc::from_raw(Arc::into_raw(cloned) as *const Mutex<T>);
+                let arc = Arc::from_raw(Arc::into_raw(cloned).cast::<Mutex<T>>());
 
                 Ok(arc)
             }

--- a/control-core/src/ethercat/interface_discovery.rs
+++ b/control-core/src/ethercat/interface_discovery.rs
@@ -11,13 +11,10 @@ const IFACE_DISCOVERY_MAX_PDU_DATA: usize = PduStorage::element_size(1100);
 const IFACE_DISCOVERY_MAX_FRAMES: usize = 16;
 const IFACE_DISCOVERY_MAX_PDI_LEN: usize = 128;
 
-/// Sets a network interface to unmanaged by NetworkManager.
+/// Sets a network interface to unmanaged by `NetworkManager`.
 /// Returns true if the command succeeded.
 pub fn set_interface_managed(interface: &str, managed: bool) -> bool {
-    let managed_str = match managed {
-        true => "yes",
-        false => "no",
-    };
+    let managed_str = if managed { "yes" } else { "no" };
     tracing::info!(
         "set_interface_managed for {} managed was set to: {}",
         interface,
@@ -35,7 +32,7 @@ pub fn set_interface_managed(interface: &str, managed: bool) -> bool {
 fn is_ethernet(interface: &str) -> std::io::Result<bool> {
     #[cfg(target_os = "linux")]
     {
-        let base_path = format!("/sys/class/net/{}", interface);
+        let base_path = format!("/sys/class/net/{interface}");
         let type_path = std::path::Path::new(&base_path).join("type");
         let iface_type = std::fs::read_to_string(&type_path)?.trim().to_string();
         // 1 means Ethernet
@@ -45,7 +42,7 @@ fn is_ethernet(interface: &str) -> std::io::Result<bool> {
         let uevent = std::fs::read_to_string(&uevent_path).unwrap_or_default();
         // If "DEVTYPE=wlan" appears, it's lying
         let actually_wifi = uevent.contains("DEVTYPE=wlan");
-        return Ok(reports_as_ethernet && !actually_wifi);
+        Ok(reports_as_ethernet && !actually_wifi)
     }
     #[cfg(not(target_os = "linux"))]
     return Ok(true);
@@ -72,7 +69,7 @@ pub async fn discover_ethercat_interface() -> Result<String, anyhow::Error> {
 
     // Get eligible interfaces
     let mut interfaces = Interface::get_all()
-        .map_err(|e| anyhow::anyhow!("Failed to get network interfaces: {}", e))?
+        .map_err(|e| anyhow::anyhow!("Failed to get network interfaces: {e}"))?
         .into_iter()
         .filter(|iface| {
             iface.is_up()
@@ -91,18 +88,15 @@ pub async fn discover_ethercat_interface() -> Result<String, anyhow::Error> {
     let mut interface: Option<&str> = None;
 
     for i in 0..interfaces.len() {
-        match test_interface(&interfaces[i].name) {
-            Ok(_) => {
-                // if interface found with ethercat Exit early, we expect only one interface with ethercat
-                interface = Some(&interfaces[i].name);
-                break;
-            }
-            Err(_) => (),
+        if let Ok(()) = test_interface(&interfaces[i].name) {
+            // if interface found with ethercat Exit early, we expect only one interface with ethercat
+            interface = Some(&interfaces[i].name);
+            break;
         }
     }
 
     for i in 0..interfaces.len() {
-        if interface.is_some() && interface.unwrap() == &interfaces[i].name {
+        if interface.is_some() && interface.unwrap() == interfaces[i].name {
             set_interface_managed(&interfaces[i].name, false);
         } else {
             set_interface_managed(&interfaces[i].name, true);
@@ -113,8 +107,8 @@ pub async fn discover_ethercat_interface() -> Result<String, anyhow::Error> {
     std::panic::set_hook(default_hook);
 
     match interface {
-        Some(interface) => return Ok(interface.to_string()),
-        None => return Err(anyhow::anyhow!("No suitable EtherCAT interface found")),
+        Some(interface) => Ok(interface.to_string()),
+        None => Err(anyhow::anyhow!("No suitable EtherCAT interface found")),
     }
 }
 
@@ -127,14 +121,14 @@ fn test_interface(interface: &str) -> Result<(), anyhow::Error> {
     >::new()));
     let (tx, rx, pdu_loop) = pdu_storage
         .try_split()
-        .map_err(|e| anyhow::anyhow!("Failed to split PDU storage: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to split PDU storage: {e:?}"))?;
 
     let rt = smol::LocalExecutor::new();
 
     let result = rt.run(async {
         let tx_rx_handle = rt.spawn(
             tx_rx_task(interface, tx, rx)
-                .map_err(|e| anyhow::anyhow!("Failed to spawn TX/RX task: {}", e))?,
+                .map_err(|e| anyhow::anyhow!("Failed to spawn TX/RX task: {e}"))?,
         );
 
         let maindevice = Arc::new(MainDevice::new(
@@ -167,7 +161,7 @@ fn test_interface(interface: &str) -> Result<(), anyhow::Error> {
             )
             .await
             .map(|_| ())
-            .map_err(|e| anyhow::anyhow!("Failed to initialize group: {}", e));
+            .map_err(|e| anyhow::anyhow!("Failed to initialize group: {e}"));
 
         tx_rx_handle.cancel().await;
 
@@ -179,9 +173,7 @@ fn test_interface(interface: &str) -> Result<(), anyhow::Error> {
 
     if let Err(e) = result {
         return Err(anyhow::anyhow!(
-            "Failed to initialize EtherCAT on interface {}: {:?}",
-            interface,
-            e
+            "Failed to initialize EtherCAT on interface {interface}: {e:?}"
         ));
     }
 

--- a/control-core/src/ethercat/interface_discovery.rs
+++ b/control-core/src/ethercat/interface_discovery.rs
@@ -88,7 +88,7 @@ pub async fn discover_ethercat_interface() -> Result<String, anyhow::Error> {
     let mut interface: Option<&str> = None;
 
     for i in 0..interfaces.len() {
-        if let Ok(()) = test_interface(&interfaces[i].name) {
+        if matches!(test_interface(&interfaces[i].name), Ok(())) {
             // if interface found with ethercat Exit early, we expect only one interface with ethercat
             interface = Some(&interfaces[i].name);
             break;

--- a/control-core/src/ethernet/mod.rs
+++ b/control-core/src/ethernet/mod.rs
@@ -10,7 +10,7 @@ pub mod modbus_tcp_discovery;
 fn is_ethernet(interface: &str) -> std::io::Result<bool> {
     #[cfg(target_os = "linux")]
     {
-        let base_path = format!("/sys/class/net/{}", interface);
+        let base_path = format!("/sys/class/net/{interface}");
         let type_path = std::path::Path::new(&base_path).join("type");
         let iface_type = std::fs::read_to_string(&type_path)?.trim().to_string();
         // 1 means Ethernet
@@ -28,7 +28,7 @@ fn is_ethernet(interface: &str) -> std::io::Result<bool> {
 
 pub fn get_interfaces() -> Result<Vec<Interface>> {
     let vec = Interface::get_all()
-        .map_err(|e| anyhow::anyhow!("Failed to get network interfaces: {}", e))?
+        .map_err(|e| anyhow::anyhow!("Failed to get network interfaces: {e}"))?
         .into_iter()
         .filter(|iface| {
             iface.is_up()
@@ -45,13 +45,10 @@ pub fn get_interfaces() -> Result<Vec<Interface>> {
     Ok(vec)
 }
 
-/// Sets a network interface to unmanaged by NetworkManager.
+/// Sets a network interface to unmanaged by `NetworkManager`.
 /// Returns true if the command succeeded.
 pub fn set_interface_managed(interface: &str, managed: bool) -> bool {
-    let managed_str = match managed {
-        true => "yes",
-        false => "no",
-    };
+    let managed_str = if managed { "yes" } else { "no" };
     tracing::info!(
         "set_interface_managed for {} managed was set to: {}",
         interface,

--- a/control-core/src/ethernet/modbus_tcp_discovery.rs
+++ b/control-core/src/ethernet/modbus_tcp_discovery.rs
@@ -53,7 +53,7 @@ async fn probe_modbus_tcp_addresses(interface: Interface) -> Vec<ModbusTcpProbe>
         .join_all()
         .await
         .into_iter()
-        .filter_map(|x| x.ok())
+        .filter_map(std::result::Result::ok)
         .collect();
 
     out

--- a/control-core/src/helpers/compare_lists.rs
+++ b/control-core/src/helpers/compare_lists.rs
@@ -7,6 +7,7 @@ where
     pub same: Vec<&'t T>,
 }
 
+#[must_use]
 pub fn compare_lists<'oldlist, 'newlist, 't, T: PartialEq>(
     old_list: &'oldlist Vec<T>,
     new_list: &'newlist Vec<T>,
@@ -20,15 +21,15 @@ where
     let mut removed = Vec::new();
     let mut same = Vec::new();
 
-    for item in new_list.iter() {
-        if !old_list.iter().any(|x| x == item) {
-            added.push(item);
-        } else {
+    for item in new_list {
+        if old_list.iter().any(|x| x == item) {
             same.push(item);
+        } else {
+            added.push(item);
         }
     }
 
-    for item in old_list.iter() {
+    for item in old_list {
         if !new_list.iter().any(|x| x == item) {
             removed.push(item);
         }

--- a/control-core/src/helpers/hasher_serializer.rs
+++ b/control-core/src/helpers/hasher_serializer.rs
@@ -12,7 +12,7 @@ pub struct HashSerializerError {}
 
 impl std::fmt::Display for HashSerializerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&format!("{:?}", self))
+        f.write_str(&format!("{self:?}"))
         // f.debug_struct("HashSerialiyerError")
         // .finish()
     }
@@ -164,7 +164,7 @@ impl<H: Hasher> Serializer for HashSerializer<'_, H> {
     type SerializeStructVariant = Self;
 
     fn serialize_bool(self, v: bool) -> Result<(), Self::Error> {
-        self.0.write_u8(v as u8);
+        self.0.write_u8(u8::from(v));
         Ok(())
     }
 

--- a/control-core/src/helpers/hashing.rs
+++ b/control-core/src/helpers/hashing.rs
@@ -2,11 +2,12 @@
 ///
 /// Takes a slice of bytes and XORs them together in chunks to produce a u128.
 /// If there are fewer than 16 bytes, the remaining bytes are padded with zeros.
+#[must_use]
 pub fn byte_folding_u128(bytes: &[u8]) -> u128 {
     let mut result = 0u128;
     for (i, &byte) in bytes.iter().enumerate() {
         let shift = (i % 16) * 8;
-        result ^= (byte as u128) << shift;
+        result ^= u128::from(byte) << shift;
     }
     result
 }
@@ -15,11 +16,12 @@ pub fn byte_folding_u128(bytes: &[u8]) -> u128 {
 ///
 /// Takes a slice of bytes and XORs them together in chunks to produce a u64.
 /// If there are fewer than 8 bytes, the remaining bytes are padded with zeros.
+#[must_use]
 pub fn byte_folding_u64(bytes: &[u8]) -> u64 {
     let mut result = 0u64;
     for (i, &byte) in bytes.iter().enumerate() {
         let shift = (i % 8) * 8;
-        result ^= (byte as u64) << shift;
+        result ^= u64::from(byte) << shift;
     }
     result
 }
@@ -28,11 +30,12 @@ pub fn byte_folding_u64(bytes: &[u8]) -> u64 {
 ///
 /// Takes a slice of bytes and XORs them together in chunks to produce a u32.
 /// If there are fewer than 4 bytes, the remaining bytes are padded with zeros.
+#[must_use]
 pub fn byte_folding_u32(bytes: &[u8]) -> u32 {
     let mut result = 0u32;
     for (i, &byte) in bytes.iter().enumerate() {
         let shift = (i % 4) * 8;
-        result ^= (byte as u32) << shift;
+        result ^= u32::from(byte) << shift;
     }
     result
 }
@@ -41,11 +44,12 @@ pub fn byte_folding_u32(bytes: &[u8]) -> u32 {
 ///
 /// Takes a slice of bytes and XORs them together in chunks to produce a u16.
 /// If there are fewer than 2 bytes, the remaining bytes are padded with zeros.
+#[must_use]
 pub fn byte_folding_u16(bytes: &[u8]) -> u16 {
     let mut result = 0u16;
     for (i, &byte) in bytes.iter().enumerate() {
         let shift = (i % 2) * 8;
-        result ^= (byte as u16) << shift;
+        result ^= u16::from(byte) << shift;
     }
     result
 }
@@ -53,6 +57,7 @@ pub fn byte_folding_u16(bytes: &[u8]) -> u16 {
 /// Folds bytes using XOR to produce a u8 value.
 ///
 /// Takes a slice of bytes and XORs them all together to produce a u8.
+#[must_use]
 pub fn byte_folding_u8(bytes: &[u8]) -> u8 {
     bytes.iter().fold(0u8, |acc, &byte| acc ^ byte)
 }
@@ -87,11 +92,12 @@ pub fn byte_folding_u8(bytes: &[u8]) -> u8 {
 /// - Initial hash value: 5381 (djb2 magic number)
 /// - For each byte: `hash = hash * 33 + byte`
 /// - Uses wrapping arithmetic to prevent overflow panics
+#[must_use]
 pub fn hash_djb2(bytes: &[u8]) -> u32 {
     let mut hash: u32 = 5381;
 
     for byte in bytes {
-        hash = hash.wrapping_mul(33).wrapping_add(*byte as u32);
+        hash = hash.wrapping_mul(33).wrapping_add(u32::from(*byte));
     }
     hash
 }

--- a/control-core/src/helpers/interpolation.rs
+++ b/control-core/src/helpers/interpolation.rs
@@ -512,15 +512,15 @@ mod tests {
         let normalized_value = 0.5;
         let new_min_f32 = 0.0f32;
         let new_max_f32 = 10.0f32;
-        let expected_f32 = (normalized_value * (new_max_f32 as f64 - new_min_f32 as f64)
-            + new_min_f32 as f64) as f32;
+        let expected_f32 = (normalized_value * (f64::from(new_max_f32) - f64::from(new_min_f32))
+            + f64::from(new_min_f32)) as f32;
         assert_relative_eq!(expected_f32, 5.0f32, epsilon = EPSILON as f32);
 
         // Testing i32 return type with direct calculation
         let new_min_i32 = 0i32;
         let new_max_i32 = 10i32;
-        let expected_i32 = (normalized_value * (new_max_i32 as f64 - new_min_i32 as f64)
-            + new_min_i32 as f64) as i32;
+        let expected_i32 = (normalized_value * (f64::from(new_max_i32) - f64::from(new_min_i32))
+            + f64::from(new_min_i32)) as i32;
         assert_eq!(expected_i32, 5i32);
 
         // Edge cases
@@ -535,7 +535,7 @@ mod tests {
     #[test]
     fn test_interpolate_exponential() {
         // Test boundary points (0,0) and (1,1) for various values of a
-        for a in [-10.0, -5.0, -1.0, -0.1, 0.1, 1.0, 5.0, 10.0].iter() {
+        for a in &[-10.0, -5.0, -1.0, -0.1, 0.1, 1.0, 5.0, 10.0] {
             assert_relative_eq!(interpolate_exponential(0.0, *a), 0.0, epsilon = EPSILON);
             assert_relative_eq!(interpolate_exponential(1.0, *a), 1.0, epsilon = EPSILON);
         }
@@ -546,24 +546,19 @@ mod tests {
         assert_relative_eq!(interpolate_exponential(1.1, a), 1.0, epsilon = EPSILON);
 
         // Test monotonicity - function should be strictly increasing for any a
-        for a in [-10.0, -1.0, 0.0, 1.0, 10.0].iter() {
+        for a in &[-10.0, -1.0, 0.0, 1.0, 10.0] {
             let mut prev = interpolate_exponential(0.0, *a);
             for i in 1..=10 {
-                let x = i as f64 / 10.0;
+                let x = f64::from(i) / 10.0;
                 let current = interpolate_exponential(x, *a);
-                assert!(
-                    current > prev,
-                    "Failed monotonicity test at x={}, a={}",
-                    x,
-                    a
-                );
+                assert!(current > prev, "Failed monotonicity test at x={x}, a={a}");
                 prev = current;
             }
         }
 
         // Test symmetry property: f(x, a) + f(1-x, -a) ≈ 1
-        for x in [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9].iter() {
-            for a in [0.5, 1.0, 2.0, 5.0].iter() {
+        for x in &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9] {
+            for a in &[0.5, 1.0, 2.0, 5.0] {
                 let sum = interpolate_exponential(*x, *a) + interpolate_exponential(1.0 - *x, -*a);
                 assert_relative_eq!(sum, 1.0, epsilon = 1e-8);
             }
@@ -594,7 +589,7 @@ mod tests {
     #[test]
     fn test_interpolate_inflected_exponential() {
         // Test boundary points (0,0), (0.5,0.5), and (1,1) for various steepness values
-        for steepness in [0.0, 0.5, 1.0, 2.0, 5.0].iter() {
+        for steepness in &[0.0, 0.5, 1.0, 2.0, 5.0] {
             assert_relative_eq!(
                 interpolate_inflected_exponential(0.0, *steepness),
                 0.0,
@@ -613,7 +608,7 @@ mod tests {
         }
 
         // Test linear case (steepness = 0)
-        for x in [0.0, 0.25, 0.5, 0.75, 1.0].iter() {
+        for x in &[0.0, 0.25, 0.5, 0.75, 1.0] {
             assert_relative_eq!(
                 interpolate_inflected_exponential(*x, 0.0),
                 *x,
@@ -622,18 +617,14 @@ mod tests {
         }
 
         // Test monotonicity - function should be strictly increasing
-        for steepness in [0.5, 1.0, 2.0, 5.0].iter() {
+        for steepness in &[0.5, 1.0, 2.0, 5.0] {
             let mut prev = interpolate_inflected_exponential(0.0, *steepness);
             for i in 1..=20 {
-                let x = i as f64 / 20.0;
+                let x = f64::from(i) / 20.0;
                 let current = interpolate_inflected_exponential(x, *steepness);
                 assert!(
                     current >= prev,
-                    "Failed monotonicity test at x={}, steepness={}, prev={}, current={}",
-                    x,
-                    steepness,
-                    prev,
-                    current
+                    "Failed monotonicity test at x={x}, steepness={steepness}, prev={prev}, current={current}"
                 );
                 prev = current;
             }
@@ -673,16 +664,13 @@ mod tests {
         );
 
         // Test that output is always in [0, 1] range
-        for steepness in [0.0, 1.0, 5.0, 10.0].iter() {
+        for steepness in &[0.0, 1.0, 5.0, 10.0] {
             for i in 0..=100 {
-                let x = i as f64 / 100.0;
+                let x = f64::from(i) / 100.0;
                 let y = interpolate_inflected_exponential(x, *steepness);
                 assert!(
-                    y >= 0.0 && y <= 1.0,
-                    "Output {} out of range [0,1] for x={}, steepness={}",
-                    y,
-                    x,
-                    steepness
+                    (0.0..=1.0).contains(&y),
+                    "Output {y} out of range [0,1] for x={x}, steepness={steepness}"
                 );
             }
         }
@@ -777,16 +765,11 @@ mod tests {
         let mut prev = interpolate_hinge(0.0, test_x, test_y);
 
         for i in 1..=20 {
-            let value = i as f64 / 20.0;
+            let value = f64::from(i) / 20.0;
             let current = interpolate_hinge(value, test_x, test_y);
             assert!(
                 current >= prev,
-                "Failed monotonicity test at value={}, x={}, y={}, prev={}, current={}",
-                value,
-                test_x,
-                test_y,
-                prev,
-                current
+                "Failed monotonicity test at value={value}, x={test_x}, y={test_y}, prev={prev}, current={current}"
             );
             prev = current;
         }
@@ -801,13 +784,13 @@ mod tests {
         // Test different steepness values (both positive and negative)
         let steepness_values = [-3.0, -1.0, 0.0, 1.0, 3.0];
 
-        for steepness in steepness_values.iter() {
-            println!("\nSteepness = {}", steepness);
+        for steepness in &steepness_values {
+            println!("\nSteepness = {steepness}");
 
             // Generate data points
             let points: Vec<(f32, f32)> = (0..=50)
                 .map(|i| {
-                    let x = i as f64 / 50.0;
+                    let x = f64::from(i) / 50.0;
                     let y = interpolate_exponential(x, *steepness);
                     (x as f32, y as f32)
                 })
@@ -829,13 +812,13 @@ mod tests {
         // Test different hinge points
         let hinges = [(0.3, 0.7), (0.5, 0.5), (0.2, 0.9), (0.8, 0.2)];
 
-        for &(x_hinge, y_hinge) in hinges.iter() {
-            println!("\nHinge at ({}, {})", x_hinge, y_hinge);
+        for &(x_hinge, y_hinge) in &hinges {
+            println!("\nHinge at ({x_hinge}, {y_hinge})");
 
             // Generate data points
             let points: Vec<(f32, f32)> = (0..=50)
                 .map(|i| {
-                    let x = i as f64 / 50.0;
+                    let x = f64::from(i) / 50.0;
                     let y = interpolate_hinge(x, x_hinge, y_hinge);
                     (x as f32, y as f32)
                 })
@@ -855,13 +838,13 @@ mod tests {
         // Test different steepness values
         let steepness_values = [0.5, 1.0, 2.0, 5.0];
 
-        for steepness in steepness_values.iter() {
-            println!("\nSteepness = {}", steepness);
+        for steepness in &steepness_values {
+            println!("\nSteepness = {steepness}");
 
             // Generate data points
             let points: Vec<(f32, f32)> = (0..=50)
                 .map(|i| {
-                    let x = i as f64 / 50.0;
+                    let x = f64::from(i) / 50.0;
                     let y = interpolate_inflected_exponential(x, *steepness);
                     (x as f32, y as f32)
                 })

--- a/control-core/src/helpers/interpolation.rs
+++ b/control-core/src/helpers/interpolation.rs
@@ -29,9 +29,7 @@ where
     let min: f64 = min.into();
     let max: f64 = max.into();
 
-    if min >= max {
-        panic!("min must be less than max");
-    }
+    assert!(min < max, "min must be less than max");
     if value < min {
         return 0.0;
     } else if value > max {
@@ -40,7 +38,7 @@ where
     (value - min) / (max - min)
 }
 
-/// Scales a normalized value from the range [0, 1] to a new range [new_min, new_max].
+/// Scales a normalized value from the range [0, 1] to a new range [`new_min`, `new_max`].
 ///
 /// This function takes a normalized value (typically from 0 to 1) and maps it
 /// to a new target range. It's the inverse operation of normalization.
@@ -51,7 +49,7 @@ where
 /// * `new_max` - The maximum value of the target range
 ///
 /// # Returns
-/// * Scaled value in the range [new_min, new_max]
+/// * Scaled value in the range [`new_min`, `new_max`]
 ///
 /// # Example
 /// ```rust
@@ -267,6 +265,7 @@ where
 /// ⠉⠉⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁ 0.0
 /// 0.0                        1.0
 /// ```
+#[must_use]
 pub fn interpolate_exponential(normalized_value: f64, steepness: f64) -> f64 {
     if steepness.abs() < 1e-10 {
         // When a is very close to zero, the function becomes linear
@@ -390,6 +389,7 @@ pub fn interpolate_exponential(normalized_value: f64, steepness: f64) -> f64 {
 /// ⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁⠈⠀⠁ 0.0
 /// 0.0                        1.0
 /// ```
+#[must_use]
 pub fn interpolate_inflected_exponential(x: f64, steepness: f64) -> f64 {
     debug_assert!((0.0..=1.0).contains(&x), "x must be in range [0.0, 1.0]");
     debug_assert!(steepness >= 0.0, "steepness must be non-negative");
@@ -436,6 +436,7 @@ pub fn interpolate_inflected_exponential(x: f64, steepness: f64) -> f64 {
 /// let boundary = invert(0.0); // Returns 1.0
 /// let clamped = invert(1.5);  // Returns 0.0 (input clamped to 1.0 first)
 /// ```
+#[must_use]
 pub fn invert(value: f64) -> f64 {
     let value = clip(value);
     1.0 - value
@@ -460,6 +461,7 @@ pub fn invert(value: f64) -> f64 {
 /// let low = clip(-0.3);    // Returns 0.0
 /// let high = clip(1.7);    // Returns 1.0
 /// ```
+#[must_use]
 pub fn clip(value: f64) -> f64 {
     if value < 0.0 {
         return 0.0;

--- a/control-core/src/helpers/moving_time_window.rs
+++ b/control-core/src/helpers/moving_time_window.rs
@@ -84,6 +84,7 @@ where
     /// # Returns
     ///
     /// A new `MovingTimeWindow` instance with empty sample collection and initialized cache
+    #[must_use]
     pub fn new(duration: Duration, max_samples: usize) -> Self {
         Self {
             max_samples,
@@ -139,7 +140,7 @@ where
     ///
     /// # Returns
     ///
-    /// The arithmetic mean of all current samples, or T::default() if the window is empty
+    /// The arithmetic mean of all current samples, or `T::default()` if the window is empty
     pub fn average(&mut self) -> T {
         // Return cached value if available
         if let Some(cached) = self.cached_average {
@@ -167,7 +168,7 @@ where
     ///
     /// # Returns
     ///
-    /// The maximum value of all current samples, or T::default() if the window is empty
+    /// The maximum value of all current samples, or `T::default()` if the window is empty
     pub fn max(&mut self) -> T {
         // Return cached value if available
         if let Some(cached) = self.cached_max {
@@ -201,7 +202,7 @@ where
     ///
     /// # Returns
     ///
-    /// The minimum value of all current samples, or T::default() if the window is empty
+    /// The minimum value of all current samples, or `T::default()` if the window is empty
     pub fn min(&mut self) -> T {
         // Return cached value if available
         if let Some(cached) = self.cached_min {

--- a/control-core/src/helpers/retry.rs
+++ b/control-core/src/helpers/retry.rs
@@ -340,7 +340,7 @@ mod tests {
             || {
                 attempt += 1;
                 if attempt < 3 {
-                    Err(format!("failed attempt {}", attempt))
+                    Err(format!("failed attempt {attempt}"))
                 } else {
                     Ok(42)
                 }
@@ -361,7 +361,7 @@ mod tests {
         let result: Result<i32, String> = retry_conditionally(
             || {
                 attempt += 1;
-                Err(format!("failed attempt {}", attempt))
+                Err(format!("failed attempt {attempt}"))
             },
             |_err| {
                 // Stop after first failure

--- a/control-core/src/irq_handling.rs
+++ b/control-core/src/irq_handling.rs
@@ -17,16 +17,15 @@ fn read_proc_interrupts() -> Result<String, io::Error> {
     let mut chunk = [0u8; 8192];
 
     loop {
-        let n = unsafe { libc::read(fd, chunk.as_mut_ptr() as *mut _, chunk.len()) };
+        let n = unsafe { libc::read(fd, chunk.as_mut_ptr().cast(), chunk.len()) };
         if n < 0 {
             let e = io::Error::from_raw_os_error(-n as i32);
             unsafe { libc::close(fd) };
             return Err(e);
         } else if n == 0 {
             break;
-        } else {
-            buf.extend_from_slice(&chunk[..n as usize]);
         }
+        buf.extend_from_slice(&chunk[..n as usize]);
     }
     unsafe { libc::close(fd) };
     Ok(String::from_utf8_lossy(&buf).into_owned())
@@ -48,13 +47,13 @@ fn get_interface_irq(proc_content: &str, interface_name: &str) -> Option<u32> {
     None
 }
 
-/// Since kernel 3.0 it’s possible to use the /proc/irq/<IRQ-NUMBER>/smp_affinity_list
+/// Since kernel 3.0 it’s possible to use the /proc/irq/<IRQ-NUMBER>/`smp_affinity_list`
 /// With comma seperated values
 /// This function takes the irq identifier and writes the cpu string
-/// into /proc/irq/irq_number/smp_affinity_list
+/// into /`proc/irq/irq_number/smp_affinity_list`
 #[cfg(target_os = "linux")]
 fn set_irq_affinity_raw(irq: u32, cpu: &str) -> Result<(), io::Error> {
-    let path: String = format!("/proc/irq/{}/smp_affinity_list", irq);
+    let path: String = format!("/proc/irq/{irq}/smp_affinity_list");
     let cpath = CString::new(path.clone()).unwrap();
     // We want to completely overwrite the smp affinities, so that we guarentee execution on the specified cores
     let file_descriptor = unsafe { libc::open(cpath.as_ptr(), libc::O_WRONLY) };
@@ -73,13 +72,8 @@ fn set_irq_affinity_raw(irq: u32, cpu: &str) -> Result<(), io::Error> {
 
     while bytes_written_total < bytes.len() {
         let to_write = &bytes[bytes_written_total..];
-        let bytes_written = unsafe {
-            libc::write(
-                file_descriptor,
-                to_write.as_ptr() as *const _,
-                to_write.len(),
-            )
-        };
+        let bytes_written =
+            unsafe { libc::write(file_descriptor, to_write.as_ptr().cast(), to_write.len()) };
         if bytes_written < 0 {
             let e = io::Error::from_raw_os_error(-bytes_written as i32);
             unsafe { libc::close(file_descriptor) };
@@ -95,7 +89,7 @@ fn set_irq_affinity_raw(irq: u32, cpu: &str) -> Result<(), io::Error> {
 /// On Realtime systems this is the make or break fix for certain usecases like ethercrab
 /// On our machines the 99.99th percentile of cycle times was very bad ~5-11 ms while ethercat is supposed to be in the microseconds
 /// After pinning the ethernet irq to the core that the ethercat code ran on 99.99th percentile went down to ~200us (microseconds)
-/// Example input: irq_name: "eno1" , cpu: 2
+/// Example input: `irq_name`: "eno1" , cpu: 2
 /// Remember that cpu cores are counted from 0
 #[cfg(target_os = "linux")]
 pub fn set_irq_affinity(irq_name: &str, cpu: u32) -> Result<(), anyhow::Error> {
@@ -106,8 +100,8 @@ pub fn set_irq_affinity(irq_name: &str, cpu: u32) -> Result<(), anyhow::Error> {
     }
     let res = set_irq_affinity_raw(irq.unwrap(), &cpu.to_string());
     if res.is_err() {
-        return Err(anyhow::anyhow!("Couldnt write affinity list!"));
+        Err(anyhow::anyhow!("Couldnt write affinity list!"))
     } else {
-        return Ok(());
+        Ok(())
     }
 }

--- a/control-core/src/modbus/mod.rs
+++ b/control-core/src/modbus/mod.rs
@@ -154,6 +154,7 @@ pub fn receive_data_modbus(port: &mut dyn SerialPort) -> Result<Option<Vec<u8>>,
 }
 
 /// Computes Modbus CRC-16 using `crc` crate.
+#[must_use]
 pub const fn modbus_crc16(data: &[u8]) -> u16 {
     let modbus: Crc<u16> = Crc::<u16>::new(&CRC_16_MODBUS);
     modbus.checksum(data)
@@ -220,13 +221,14 @@ impl TryFrom<Vec<u8>> for ModbusResponse {
     }
 }
 
-/// Modbus RTU has silent time between frames that needs to be adhered to, if you send before silent_time is over between frames, then there will be lost frames
+/// Modbus RTU has silent time between frames that needs to be adhered to, if you send before `silent_time` is over between frames, then there will be lost frames
 /// This silent time is needed to identify the start and end of messages
 /// This function also takes into account the time that the slave we are talking to needs to process our request
 /// bits: amount of bits sent for a 8n1 coding: 8 data bits, 0 parity, 1 stop bit (1 start,1 stop) -> 10 bits
-/// machine_operation_delay_nano: Delay for the given operation in nanoseconds as specified by the slaves datasheet (example: mitsubishi csfr84 has 12ms for read write in RAM)
+/// `machine_operation_delay_nano`: Delay for the given operation in nanoseconds as specified by the slaves datasheet (example: mitsubishi csfr84 has 12ms for read write in RAM)
 /// baudrate: bits per second
-/// message_size: size of original message in bytes
+/// `message_size`: size of original message in bytes
+#[must_use]
 pub const fn calculate_modbus_rtu_timeout(
     bits: u8,
     machine_operation_delay_nano: Duration,

--- a/control-core/src/modbus/mod.rs
+++ b/control-core/src/modbus/mod.rs
@@ -263,7 +263,7 @@ mod tests {
             0x11, 0x03, 0x06, 0x17, 0x70, 0x0b, 0xb8, 0x03, 0xe8, 0x2c, 0xe6,
         ];
 
-        let response = ModbusResponse::try_from(response_raw.clone());
+        let response = ModbusResponse::try_from(response_raw);
 
         // Expected result based on provided test data
         let expected = ModbusResponse {
@@ -312,8 +312,7 @@ mod tests {
 
         assert_eq!(
             result, expected,
-            "ModbusRequest conversion failed. Expected: {:?}, Got: {:?}",
-            expected, result
+            "ModbusRequest conversion failed. Expected: {expected:?}, Got: {result:?}"
         );
     }
 

--- a/control-core/src/modbus/modbus_serial_interface.rs
+++ b/control-core/src/modbus/modbus_serial_interface.rs
@@ -17,16 +17,16 @@ struct RequestMetaData {
 
 #[derive(Debug)]
 pub enum State {
-    /// WaitingForResponse is set after sending a request through the serial_interface
+    /// `WaitingForResponse` is set after sending a request through the `serial_interface`
     WaitingForResponse,
     /// After Sending a Request we need to wait atleast one ethercat cycle
     /// After one Cycle we check if el6021 status has transmit accepted toggled
-    /// Then we can set state = ReadyToSend
+    /// Then we can set state = `ReadyToSend`
     WaitingForRequestAccept,
     /// After Receiving a Response we need to wait atleast one ethercat cycle
     /// After one Cycle we check if el6021 status has received accepted toggled
     WaitingForReceiveAccept,
-    /// ReadyToSend is set after receiving the response from the serial_interface
+    /// `ReadyToSend` is set after receiving the response from the `serial_interface`
     ReadyToSend,
     /// Initial State
     Uninitialized,
@@ -49,6 +49,7 @@ pub struct ModbusSerialInterface {
 }
 
 impl ModbusSerialInterface {
+    #[must_use]
     pub fn new(serial_interface: SerialInterface) -> Self {
         Self {
             serial_interface,
@@ -66,6 +67,7 @@ impl ModbusSerialInterface {
         }
     }
 
+    #[must_use]
     pub const fn is_initialized(&self) -> bool {
         !matches!(self.state, State::Uninitialized)
     }
@@ -103,7 +105,7 @@ impl ModbusSerialInterface {
 
     /// This is used internally to fill the write buffer of the el6021 with the modbus request
     /// Decides what requests to send first by finding the one with the highest priority
-    /// For example Highest Priority requests: ResetInverter StopMotor
+    /// For example Highest Priority requests: `ResetInverter` `StopMotor`
     async fn send_modbus_request(&mut self) {
         if self.request_map.is_empty() {
             return;
@@ -173,13 +175,14 @@ impl ModbusSerialInterface {
         }
     }
 
-    /// Modbus RTU has silent time between frames that needs to be adhered to, if you send before silent_time is over between frames, then there will be lost frames
+    /// Modbus RTU has silent time between frames that needs to be adhered to, if you send before `silent_time` is over between frames, then there will be lost frames
     /// This silent time is needed to identify the start and end of messages
     /// This function also takes into account the time that the slave we are talking to needs to process our request
     /// bits: amount of bits sent per byte -> for a 8n1 coding: 8 data bits, 0 parity, 1 stop bit (1 start,1 stop) -> 10 bits
-    /// machine_operation_delay_nano: Delay for the given operation in nanoseconds as specified by the slaves datasheet (example: mitsubishi csfr84 has 12ms for read write in RAM)
+    /// `machine_operation_delay_nano`: Delay for the given operation in nanoseconds as specified by the slaves datasheet (example: mitsubishi csfr84 has 12ms for read write in RAM)
     /// baudrate: bits per second
-    /// message_size: size of original message in bytes
+    /// `message_size`: size of original message in bytes
+    #[must_use]
     pub fn calculate_modbus_rtu_timeout(
         &self,
         machine_operation_delay: Duration,
@@ -188,8 +191,8 @@ impl ModbusSerialInterface {
         let baudrate = self.baudrate?;
         let encoding = self.encoding?;
 
-        let nanoseconds_per_bit = 1_000_000_000 / baudrate as u64;
-        let nanoseconds_per_byte = encoding.total_bits() as u64 * nanoseconds_per_bit;
+        let nanoseconds_per_bit = 1_000_000_000 / u64::from(baudrate);
+        let nanoseconds_per_byte = u64::from(encoding.total_bits()) * nanoseconds_per_bit;
 
         let transmission_timeout = nanoseconds_per_byte * message_size as u64;
         let silent_time = (nanoseconds_per_byte * 35) / 10; // silent_time is 3.5x of character length
@@ -199,6 +202,7 @@ impl ModbusSerialInterface {
         Some(Duration::from_nanos(total_timeout))
     }
 
+    #[must_use]
     pub const fn get_response(&self) -> Option<&ModbusResponse> {
         self.response.as_ref()
     }
@@ -207,7 +211,7 @@ impl ModbusSerialInterface {
         let elapsed = now_ts.duration_since(self.last_ts);
 
         let timeout = self.calculate_modbus_rtu_timeout(
-            Duration::from_nanos(self.last_message_delay as u64),
+            Duration::from_nanos(u64::from(self.last_message_delay)),
             self.last_message_size,
         );
 
@@ -226,17 +230,16 @@ impl ModbusSerialInterface {
         self.response = None;
 
         match self.state {
-            State::WaitingForResponse => match self.read_modbus_response().await {
-                Ok(response) => {
+            State::WaitingForResponse => {
+                if let Ok(response) = self.read_modbus_response().await {
                     self.response = Some(response);
-                }
-                Err(_) => {
+                } else {
                     self.response = None;
                     if self.no_response_expected {
                         self.state = State::ReadyToSend;
                     }
                 }
-            },
+            }
             State::ReadyToSend => {
                 self.send_modbus_request().await;
 

--- a/control-core/src/modbus/tcp.rs
+++ b/control-core/src/modbus/tcp.rs
@@ -52,7 +52,7 @@ pub struct ModbusTcpDevice {
 impl Debug for ModbusTcpDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.stream.peer_addr() {
-            Ok(addr) => write!(f, "ModbusTcpDevice({:?})", addr),
+            Ok(addr) => write!(f, "ModbusTcpDevice({addr:?})"),
             Err(_) => std::fmt::Result::Err(std::fmt::Error),
         }
     }
@@ -98,9 +98,7 @@ impl ModbusTcpDevice {
         if func_code != func_code_res {
             let error_code = self.read_u8().await?;
             bail!(
-                "Modbus device sent unexpected function code 0x{:x}! It probably encountered an error. Error code: 0x{:x}",
-                func_code_res,
-                error_code
+                "Modbus device sent unexpected function code 0x{func_code_res:x}! It probably encountered an error. Error code: 0x{error_code:x}"
             );
         }
 
@@ -125,7 +123,7 @@ impl ModbusTcpDevice {
         self.read_and_check_responce_header(READ_HOLDING_FUNCTION_CODE)
             .await?;
 
-        let num_data_bytes = self.read_u8().await? as u16;
+        let num_data_bytes = u16::from(self.read_u8().await?);
         if count * 2 != num_data_bytes {
             bail!(
                 "Modbus device wants to send only a portion of the requested range - UNIMPLEMENTED!"
@@ -151,8 +149,7 @@ impl ModbusTcpDevice {
         let num_bytes = count * 2;
         assert!(
             count <= 128,
-            "Cannot send that many bytes to modbus device in one go! Trying to send {} bytes of data.",
-            num_bytes
+            "Cannot send that many bytes to modbus device in one go! Trying to send {num_bytes} bytes of data."
         );
 
         let mut packet = Packet::new();
@@ -190,7 +187,7 @@ impl ModbusTcpDevice {
     }
 
     pub async fn get_string<const N: usize>(&mut self, addr: u16) -> Result<String> {
-        assert!(N % 2 == 0, "Strings are always of even length!");
+        assert!(N.is_multiple_of(2), "Strings are always of even length!");
         assert!(N <= 256, "Cannot read long strings in a single swoop!");
         let count = N / 2;
 

--- a/control-core/src/realtime.rs
+++ b/control-core/src/realtime.rs
@@ -2,11 +2,11 @@ use tracing::debug;
 use tracing::error;
 
 #[cfg(target_os = "linux")]
-/// Makes the current thread a real-time thread using the PREEMPT_RT capabilities of Linux.
+/// Makes the current thread a real-time thread using the `PREEMPT_RT` capabilities of Linux.
 ///
 /// This function configures the current thread with real-time scheduling properties by:
 ///
-/// 1. Setting the scheduling policy to SCHED_FIFO (First-In-First-Out), which is a real-time
+/// 1. Setting the scheduling policy to `SCHED_FIFO` (First-In-First-Out), which is a real-time
 ///    scheduling policy that allows the thread to run until it voluntarily yields, blocks on I/O,
 ///    or is preempted by a higher-priority real-time thread.
 ///
@@ -14,7 +14,7 @@ use tracing::error;
 ///    higher priority). This priority level is chosen to be higher than most IRQ handlers
 ///    (typically priority 50) but lower than critical kernel tasks (priority 99).
 ///
-/// When running on a PREEMPT_RT patched Linux kernel, this combination provides deterministic
+/// When running on a `PREEMPT_RT` patched Linux kernel, this combination provides deterministic
 /// scheduling with minimal latency, which is essential for real-time applications.
 ///
 /// # Requirements
@@ -24,7 +24,7 @@ use tracing::error;
 ///   - Running as root
 ///   - Configuring `/etc/security/limits.conf` to allow the user to set real-time priorities
 ///
-/// - The system should be running a Linux kernel with PREEMPT_RT patch applied for
+/// - The system should be running a Linux kernel with `PREEMPT_RT` patch applied for
 ///   optimal real-time performance.
 ///
 /// # Example
@@ -62,7 +62,7 @@ pub fn set_realtime_priority() -> Result<(), anyhow::Error> {
         param.sched_priority = 95;
 
         // Set the thread to use SCHED_FIFO scheduling policy with our priority
-        let result = pthread_setschedparam(pthread_self, SCHED_FIFO, &param);
+        let result = pthread_setschedparam(pthread_self, SCHED_FIFO, &raw const param);
 
         if result != 0 {
             error!(
@@ -74,12 +74,11 @@ pub fn set_realtime_priority() -> Result<(), anyhow::Error> {
                 "Failed to set real-time priority: {}",
                 std::io::Error::last_os_error()
             ));
-        } else {
-            debug!(
-                "Successfully set real-time priority for the thread \"{:?}\"",
-                std::thread::current().name().unwrap_or("unknown")
-            );
         }
+        debug!(
+            "Successfully set real-time priority for the thread \"{:?}\"",
+            std::thread::current().name().unwrap_or("unknown")
+        );
     }
     Ok(())
 }
@@ -147,9 +146,8 @@ pub fn lock_memory() -> Result<(), Box<dyn std::error::Error>> {
             return Err(
                 format!("Failed to lock memory: {}", std::io::Error::last_os_error()).into(),
             );
-        } else {
-            debug!("Successfully locked memory for the process");
         }
+        debug!("Successfully locked memory for the process");
     }
     Ok(())
 }

--- a/control-core/src/socketio/namespace.rs
+++ b/control-core/src/socketio/namespace.rs
@@ -12,6 +12,7 @@ pub struct Namespace {
 }
 
 impl Namespace {
+    #[must_use]
     pub fn new(socket_queue_tx: Sender<(SocketRef, Arc<GenericEvent>)>) -> Self {
         Self {
             sockets: vec![],
@@ -144,7 +145,7 @@ impl Namespace {
             .socket_queue_tx
             .try_send((socket.clone(), event.clone()))
         {
-            Ok(_) => {
+            Ok(()) => {
                 tracing::trace!(
                     socket_id = ?socket.id,
                     event = %event.name,
@@ -190,6 +191,7 @@ pub trait CacheableEvents<Events> {
 pub type CacheFn = Box<dyn Fn(&mut Vec<Arc<GenericEvent>>, &Arc<GenericEvent>)>;
 
 /// [`BufferFn`] that stores the last n events
+#[must_use]
 pub fn cache_n_events(n: usize) -> CacheFn {
     Box::new(move |events, event| {
         if events.len() >= n {
@@ -200,6 +202,7 @@ pub fn cache_n_events(n: usize) -> CacheFn {
 }
 
 /// [`BufferFn`] that stores only one event
+#[must_use]
 pub fn cache_one_event() -> CacheFn {
     cache_n_events(1)
 }
@@ -208,6 +211,7 @@ pub fn cache_one_event() -> CacheFn {
 ///
 /// The primary use case of this function is to cache both the default state of a machine, which should be emitted first,
 /// and the last event, which is the most recent state of the machine.
+#[must_use]
 pub fn cache_first_and_last_event() -> CacheFn {
     Box::new(move |events, event| {
         // if the events length 0 or 1, we just push the event
@@ -224,16 +228,17 @@ pub fn cache_first_and_last_event() -> CacheFn {
 }
 
 /// [`BufferFn`] that stores events for a certain duration
+#[must_use]
 pub fn cache_duration(duration: Duration, bucket_size: Duration) -> CacheFn {
     Box::new(move |events, event| {
         // Use event.ts instead of system time
-        let current_time = event.ts as u128;
+        let current_time = u128::from(event.ts);
 
         // calculate current bucket & last bucket
         let bucket_size_ms = bucket_size.as_millis().max(1);
         let bucket = current_time / bucket_size_ms; // Avoid division by zero
         let last_bucket = match events.last() {
-            Some(last_event) => last_event.ts as u128 / bucket_size_ms,
+            Some(last_event) => u128::from(last_event.ts) / bucket_size_ms,
             None => 0,
         };
 

--- a/control-core/src/socketio/namespace.rs
+++ b/control-core/src/socketio/namespace.rs
@@ -334,7 +334,7 @@ mod tests {
     }
 
     #[test]
-    /// duration: 10 seconds, bucket_size: 1 second
+    /// duration: 10 seconds, `bucket_size`: 1 second
     /// use a for loop that tries to add an event every 100ms
     fn test_cache_duration() {
         // Create a cache function that stores events for 10 seconds

--- a/control-core/src/transmission/fixed.rs
+++ b/control-core/src/transmission/fixed.rs
@@ -12,7 +12,7 @@ impl Transmission for FixedTransmission {
 }
 
 impl FixedTransmission {
-    /// Creates a new FixedTransmission with the specified ratio.
+    /// Creates a new `FixedTransmission` with the specified ratio.
     ///
     /// # Arguments
     ///
@@ -20,7 +20,8 @@ impl FixedTransmission {
     ///
     /// # Returns
     ///
-    /// A new instance of FixedTransmission.
+    /// A new instance of `FixedTransmission`.
+    #[must_use]
     pub const fn new(ratio: f64) -> Self {
         Self { ratio }
     }

--- a/ethercat-hal-derive/src/lib.rs
+++ b/ethercat-hal-derive/src/lib.rs
@@ -13,12 +13,8 @@ fn extract_metedata_field_attributes(
     let mut field_names = Vec::new();
     let mut pdo_indices = Vec::new();
     if let Data::Struct(s) = &mut ast.data {
-        for field in s.fields.iter_mut() {
-            let field_name = field
-                .ident
-                .as_ref()
-                .cloned()
-                .expect("Field must have a name");
+        for field in &mut s.fields {
+            let field_name = field.ident.clone().expect("Field must have a name");
             let attrs: PdoObjectIndexAttribute = deluxe::extract_attributes(field)?;
             field_names.push(field_name);
             pdo_indices.push(attrs.0);
@@ -182,7 +178,7 @@ pub fn ethercat_device_derive(input: TokenStream) -> TokenStream {
     let mut has_txpdo = false;
 
     if let Data::Struct(data_struct) = input.data {
-        for field in data_struct.fields.iter() {
+        for field in &data_struct.fields {
             if let Some(ident) = &field.ident {
                 if ident == "rxpdo" {
                     has_rxpdo = true;

--- a/ethercat-hal/src/debugging/diagnosis_history.rs
+++ b/ethercat-hal/src/debugging/diagnosis_history.rs
@@ -35,6 +35,7 @@ impl fmt::Display for SubdeviceDiagnosisEntry {
 }
 
 impl SubdeviceDiagnosisEntry {
+    #[must_use]
     pub fn to_pretty_string(&self) -> String {
         // Decode message type
         let msg_type = match self.flags {
@@ -57,7 +58,7 @@ impl SubdeviceDiagnosisEntry {
         };
 
         // Format P2 bytes as hex list
-        let p2_hex: Vec<String> = self.p2.iter().map(|b| format!("0x{:02X}", b)).collect();
+        let p2_hex: Vec<String> = self.p2.iter().map(|b| format!("0x{b:02X}")).collect();
 
         format!(
             "Diagnosis Entry:\n\
@@ -129,8 +130,7 @@ pub fn convert_raw_diagnosis_bytes(
 
     if p1 == 0 {
         return Err(anyhow::anyhow!(
-            "convert_raw_diagnosis_bytes: Datatype_p1 is unknown {:?}",
-            data_type_p1
+            "convert_raw_diagnosis_bytes: Datatype_p1 is unknown {data_type_p1:?}"
         ));
     }
 
@@ -145,7 +145,7 @@ pub fn convert_raw_diagnosis_bytes(
         message[24],
         message[25],
     ];
-    return Ok(SubdeviceDiagnosisEntry {
+    Ok(SubdeviceDiagnosisEntry {
         diag_code,
         flags,
         text_id,
@@ -154,10 +154,10 @@ pub fn convert_raw_diagnosis_bytes(
         p1,
         flags_p2,
         p2,
-    });
+    })
 }
 
-/// Expects the SubdeviceRef to be the Coupler or any other device with a diag history index
+/// Expects the `SubdeviceRef` to be the Coupler or any other device with a diag history index
 pub async fn get_most_recent_diagnosis_message(
     device: &SubDeviceRef<'_, &SubDevice>,
 ) -> Option<String> {
@@ -202,12 +202,11 @@ pub async fn get_most_recent_diagnosis_message(
     let res = device
         .sdo_read::<[u8; DIAG_MESSAGE_LENGTH]>(DIAGNOSIS_HISTORY_INDEX, newest_message_index)
         .await;
-    let message: [u8; DIAG_MESSAGE_LENGTH] = match res {
-        Ok(res) => res,
-        Err(_) => {
-            tracing::error!("get_most_recent_diagnosis_message: Failed to read Diagnosis Message");
-            return None;
-        }
+    let message: [u8; DIAG_MESSAGE_LENGTH] = if let Ok(res) = res {
+        res
+    } else {
+        tracing::error!("get_most_recent_diagnosis_message: Failed to read Diagnosis Message");
+        return None;
     };
     let message = convert_raw_diagnosis_bytes(message);
     let message = match message {
@@ -225,5 +224,5 @@ pub async fn get_most_recent_diagnosis_message(
         "get_most_recent_diagnosis_message: {}",
         message.to_pretty_string()
     );
-    return Some(message.to_pretty_string());
+    Some(message.to_pretty_string())
 }

--- a/ethercat-hal/src/devices/el1002.rs
+++ b/ethercat-hal/src/devices/el1002.rs
@@ -52,6 +52,7 @@ pub enum EL1002Port {
 }
 
 impl EL1002Port {
+    #[must_use]
     pub const fn to_bit_index(&self) -> usize {
         match self {
             Self::DI1 => 0,

--- a/ethercat-hal/src/devices/el1008.rs
+++ b/ethercat-hal/src/devices/el1008.rs
@@ -65,6 +65,7 @@ pub enum EL1008Port {
 }
 
 impl EL1008Port {
+    #[must_use]
     pub const fn to_bit_index(&self) -> usize {
         match self {
             Self::DI1 => 0,

--- a/ethercat-hal/src/devices/el2002.rs
+++ b/ethercat-hal/src/devices/el2002.rs
@@ -35,10 +35,10 @@ impl DigitalOutputDevice<EL2002Port> for EL2002 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2002Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into();
             }
             EL2002Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into();
             }
         }
     }

--- a/ethercat-hal/src/devices/el2004.rs
+++ b/ethercat-hal/src/devices/el2004.rs
@@ -33,16 +33,16 @@ impl DigitalOutputDevice<EL2004Port> for EL2004 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2004Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into();
             }
             EL2004Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into();
             }
             EL2004Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into();
             }
             EL2004Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into();
             }
         }
     }

--- a/ethercat-hal/src/devices/el2008.rs
+++ b/ethercat-hal/src/devices/el2008.rs
@@ -35,28 +35,28 @@ impl DigitalOutputDevice<EL2008Port> for EL2008 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2008Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into();
             }
             EL2008Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into();
             }
             EL2008Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into();
             }
             EL2008Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into();
             }
             EL2008Port::DO5 => {
-                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into();
             }
             EL2008Port::DO6 => {
-                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into();
             }
             EL2008Port::DO7 => {
-                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into();
             }
             EL2008Port::DO8 => {
-                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into();
             }
         }
     }

--- a/ethercat-hal/src/devices/el2024.rs
+++ b/ethercat-hal/src/devices/el2024.rs
@@ -36,16 +36,16 @@ impl DigitalOutputDevice<EL2024Port> for EL2024 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2024Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into();
             }
             EL2024Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into();
             }
             EL2024Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into();
             }
             EL2024Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into();
             }
         }
     }

--- a/ethercat-hal/src/devices/el2521.rs
+++ b/ethercat-hal/src/devices/el2521.rs
@@ -103,7 +103,7 @@ pub enum EL2521Port {
     PTO1,
 }
 
-/// 0x8000 CoE
+/// 0x8000 `CoE`
 #[derive(Debug, Clone)]
 pub struct EL2521Configuration {
     /// # 0x8010:02

--- a/ethercat-hal/src/devices/el2522.rs
+++ b/ethercat-hal/src/devices/el2522.rs
@@ -214,7 +214,7 @@ pub struct EL2522ChannelConfiguration {
 
     /// # 0x8000:0E (Ch.1) / 0x8010:0E (Ch.2)
     /// 0: Frequency mod., 1: Pulse-dir, 2: Incremental enc.
-    /// Default: FrequencyModulation (0x00)
+    /// Default: `FrequencyModulation` (0x00)
     pub operating_mode: EL2522OperatingMode,
 
     /// # 0x8000:10 (Ch.1) / 0x8010:10 (Ch.2)

--- a/ethercat-hal/src/devices/el2809.rs
+++ b/ethercat-hal/src/devices/el2809.rs
@@ -36,52 +36,52 @@ impl DigitalOutputDevice<EL2809Port> for EL2809 {
         let expect_text = "All channels should be Some(_)";
         match port {
             EL2809Port::DO1 => {
-                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel1.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO2 => {
-                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel2.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO3 => {
-                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel3.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO4 => {
-                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel4.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO5 => {
-                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel5.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO6 => {
-                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel6.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO7 => {
-                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel7.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO8 => {
-                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel8.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO9 => {
-                self.rxpdo.channel9.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel9.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO10 => {
-                self.rxpdo.channel10.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel10.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO11 => {
-                self.rxpdo.channel11.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel11.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO12 => {
-                self.rxpdo.channel12.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel12.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO13 => {
-                self.rxpdo.channel13.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel13.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO14 => {
-                self.rxpdo.channel14.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel14.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO15 => {
-                self.rxpdo.channel15.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel15.as_mut().expect(expect_text).value = value.into();
             }
             EL2809Port::DO16 => {
-                self.rxpdo.channel16.as_mut().expect(expect_text).value = value.into()
+                self.rxpdo.channel16.as_mut().expect(expect_text).value = value.into();
             }
         }
     }

--- a/ethercat-hal/src/devices/el3001.rs
+++ b/ethercat-hal/src/devices/el3001.rs
@@ -31,12 +31,6 @@ impl std::fmt::Debug for EL3001 {
     }
 }
 
-impl Default for EL3001PredefinedPdoAssignment {
-    fn default() -> Self {
-        Self::Standard
-    }
-}
-
 impl NewEthercatDevice for EL3001 {
     fn new() -> Self {
         let configuration: EL3001Configuration = EL3001Configuration::default();
@@ -146,8 +140,9 @@ impl Configuration for EL3001Configuration {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EL3001PredefinedPdoAssignment {
+    #[default]
     Standard,
     Compact,
 }

--- a/ethercat-hal/src/devices/el3021.rs
+++ b/ethercat-hal/src/devices/el3021.rs
@@ -43,12 +43,6 @@ impl std::fmt::Debug for EL3021 {
     }
 }
 
-impl Default for EL3021PredefinedPdoAssignment {
-    fn default() -> Self {
-        Self::Standard
-    }
-}
-
 impl Default for EL3021Configuration {
     fn default() -> Self {
         Self {
@@ -166,8 +160,9 @@ impl Configuration for EL3021Configuration {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EL3021PredefinedPdoAssignment {
+    #[default]
     Standard,
     Compact,
 }

--- a/ethercat-hal/src/devices/el3024.rs
+++ b/ethercat-hal/src/devices/el3024.rs
@@ -49,12 +49,6 @@ impl std::fmt::Debug for EL3024 {
     }
 }
 
-impl Default for EL3024PredefinedPdoAssignment {
-    fn default() -> Self {
-        Self::Standard
-    }
-}
-
 impl Default for EL3024Configuration {
     fn default() -> Self {
         Self {
@@ -237,8 +231,9 @@ impl Configuration for EL3024Configuration {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EL3024PredefinedPdoAssignment {
+    #[default]
     Standard,
     Compact,
 }

--- a/ethercat-hal/src/devices/el3062_0030.rs
+++ b/ethercat-hal/src/devices/el3062_0030.rs
@@ -150,26 +150,26 @@ pub struct EL3062_0030TxPdo {
 }
 
 impl crate::coe::Configuration for EL3062_0030TxPdo {
-    ///Implemented by the ethercat_hal_derive::TxPdo derive macro
+    ///Implemented by the `ethercat_hal_derive::TxPdo` derive macro
     async fn write_config<'a>(
         &self,
         device: &EthercrabSubDevicePreoperational<'a>,
     ) -> Result<(), anyhow::Error> {
         device.sdo_write(0x1C13, 0, 0u8).await?;
         let mut len = 0;
-        if let Some(_) = &self.ai_standard_channel1 {
+        if self.ai_standard_channel1.is_some() {
             len += 1;
             device.sdo_write(0x1C13, len, 0x1A00u16).await?;
         }
-        if let Some(_) = &self.ai_compact_channel1 {
+        if self.ai_compact_channel1.is_some() {
             len += 1;
             device.sdo_write(0x1C13, len, 0x1A01u16).await?;
         }
-        if let Some(_) = &self.ai_standard_channel2 {
+        if self.ai_standard_channel2.is_some() {
             len += 1;
             device.sdo_write(0x1C13, len, 0x1A02u16).await?;
         }
-        if let Some(_) = &self.ai_compact_channel2 {
+        if self.ai_compact_channel2.is_some() {
             len += 1;
             device.sdo_write(0x1C13, len, 0x1A03u16).await?;
         }
@@ -178,7 +178,7 @@ impl crate::coe::Configuration for EL3062_0030TxPdo {
     }
 }
 impl crate::pdo::TxPdo for EL3062_0030TxPdo {
-    ///Implemented by the ethercat_hal_derive::TxPdo derive macro
+    ///Implemented by the `ethercat_hal_derive::TxPdo` derive macro
     fn get_objects(&self) -> Box<[Option<&dyn crate::pdo::TxPdoObject>]> {
         Box::new([
             self.ai_standard_channel1
@@ -195,7 +195,7 @@ impl crate::pdo::TxPdo for EL3062_0030TxPdo {
                 .map(|o| o as &dyn crate::pdo::TxPdoObject),
         ])
     }
-    ///Implemented by the ethercat_hal_derive::TxPdo derive macro
+    ///Implemented by the `ethercat_hal_derive::TxPdo` derive macro
     fn get_objects_mut(&mut self) -> Box<[Option<&mut dyn crate::pdo::TxPdoObject>]> {
         Box::new([
             self.ai_standard_channel1
@@ -217,7 +217,7 @@ impl crate::pdo::TxPdo for EL3062_0030TxPdo {
 #[derive(Debug, Clone)]
 pub struct EL3062_0030RxPdo {}
 impl crate::coe::Configuration for EL3062_0030RxPdo {
-    ///Implemented by the ethercat_hal_derive::RxPdo derive macro
+    ///Implemented by the `ethercat_hal_derive::RxPdo` derive macro
     async fn write_config<'a>(
         &self,
         _device: &EthercrabSubDevicePreoperational<'a>,
@@ -226,7 +226,7 @@ impl crate::coe::Configuration for EL3062_0030RxPdo {
     }
 }
 impl crate::pdo::RxPdo for EL3062_0030RxPdo {
-    ///Implemented by the ethercat_hal_derive::RxPdo derive macro
+    ///Implemented by the `ethercat_hal_derive::RxPdo` derive macro
     fn get_objects(&self) -> Box<[Option<&dyn crate::pdo::RxPdoObject>]> {
         Box::new([])
     }

--- a/ethercat-hal/src/devices/el3204.rs
+++ b/ethercat-hal/src/devices/el3204.rs
@@ -65,6 +65,7 @@ pub enum EL3204Port {
 }
 
 impl EL3204Port {
+    #[must_use]
     pub const fn to_byte_offset(&self) -> usize {
         match self {
             Self::T1 => 0,

--- a/ethercat-hal/src/devices/el4002.rs
+++ b/ethercat-hal/src/devices/el4002.rs
@@ -81,12 +81,12 @@ impl AnalogOutputDevice<EL4002Port> for EL4002 {
         match port {
             EL4002Port::AO1 => {
                 if let Some(channel) = self.rxpdo.ao_channel1.as_mut() {
-                    channel.value = value
+                    channel.value = value;
                 }
             }
             EL4002Port::AO2 => {
                 if let Some(channel) = self.rxpdo.ao_channel2.as_mut() {
-                    channel.value = value
+                    channel.value = value;
                 }
             }
         }

--- a/ethercat-hal/src/devices/el6021.rs
+++ b/ethercat-hal/src/devices/el6021.rs
@@ -576,6 +576,26 @@ impl SerialInterfaceDevice<EL6021Port> for EL6021 {
     }
 }
 
+pub const EL6021_VENDOR_ID: u32 = 2;
+pub const EL6021_PRODUCT_ID: u32 = 0x17853052;
+
+pub const EL6021_REVISION_A: u32 = 0x150000;
+pub const EL6021_REVISION_B: u32 = 0x140000;
+pub const EL6021_REVISION_C: u32 = 0x160000;
+pub const EL6021_REVISION_D: u32 = 0x100000;
+
+pub const EL6021_IDENTITY_A: SubDeviceIdentityTuple =
+    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_A);
+
+pub const EL6021_IDENTITY_B: SubDeviceIdentityTuple =
+    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_B);
+
+pub const EL6021_IDENTITY_C: SubDeviceIdentityTuple =
+    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_C);
+
+pub const EL6021_IDENTITY_D: SubDeviceIdentityTuple =
+    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_D);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -594,12 +614,12 @@ mod tests {
         let mut input = Standard22ByteMdp600Input::default();
 
         input.read(bits.as_bitslice());
-        assert_eq!(input.status.transmit_accepted, true);
-        assert_eq!(input.status.receive_request, false);
-        assert_eq!(input.status.init_accepted, true);
-        assert_eq!(input.status.buffer_full, false);
-        assert_eq!(input.status.parity_error, true);
-        assert_eq!(input.status.receive_request, false);
+        assert!(input.status.transmit_accepted);
+        assert!(!input.status.receive_request);
+        assert!(input.status.init_accepted);
+        assert!(!input.status.buffer_full);
+        assert!(input.status.parity_error);
+        assert!(!input.status.receive_request);
         assert_eq!(input.length, 0x16);
         for i in 0..22 {
             assert_eq!(input.data[i], (i + 1) as u8);
@@ -615,7 +635,7 @@ mod tests {
         };
 
         let output = Standard22ByteMdp600Output {
-            control: control,
+            control,
             length: 0x16,
             data: [
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
@@ -636,23 +656,3 @@ mod tests {
         }
     }
 }
-
-pub const EL6021_VENDOR_ID: u32 = 2;
-pub const EL6021_PRODUCT_ID: u32 = 0x17853052;
-
-pub const EL6021_REVISION_A: u32 = 0x150000;
-pub const EL6021_REVISION_B: u32 = 0x140000;
-pub const EL6021_REVISION_C: u32 = 0x160000;
-pub const EL6021_REVISION_D: u32 = 0x100000;
-
-pub const EL6021_IDENTITY_A: SubDeviceIdentityTuple =
-    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_A);
-
-pub const EL6021_IDENTITY_B: SubDeviceIdentityTuple =
-    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_B);
-
-pub const EL6021_IDENTITY_C: SubDeviceIdentityTuple =
-    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_C);
-
-pub const EL6021_IDENTITY_D: SubDeviceIdentityTuple =
-    (EL6021_VENDOR_ID, EL6021_PRODUCT_ID, EL6021_REVISION_D);

--- a/ethercat-hal/src/devices/el6021.rs
+++ b/ethercat-hal/src/devices/el6021.rs
@@ -19,19 +19,19 @@ impl std::fmt::Debug for EL6021 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EL6021Baudrate {
-    /// 2400 baud (CoE Value: 4)
+    /// 2400 baud (`CoE` Value: 4)
     B2400 = 4,
-    /// 4800 baud (CoE Value: 5)
+    /// 4800 baud (`CoE` Value: 5)
     B4800 = 5,
-    /// 9600 baud (CoE Value: 6) DEFAULT
+    /// 9600 baud (`CoE` Value: 6) DEFAULT
     B9600 = 6,
-    /// 19200 baud (CoE Value: 7)
+    /// 19200 baud (`CoE` Value: 7)
     B19200 = 7,
-    /// 38400 baud (CoE Value: 8)
+    /// 38400 baud (`CoE` Value: 8)
     B38400 = 8,
-    /// 57600 baud (CoE Value: 9)
+    /// 57600 baud (`CoE` Value: 9)
     B57600 = 9,
-    /// 115200 baud (CoE Value: 10)
+    /// 115200 baud (`CoE` Value: 10)
     B115200 = 10,
 }
 
@@ -508,8 +508,8 @@ impl SerialInterfaceDevice<EL6021Port> for EL6021 {
     }
 
     /// For el6021 this returns false for as long as the Initialization takes
-    /// When its finished it returns true    
-    /// Every step of the init has to be done in an EtherCatCycle
+    /// When its finished it returns true\\
+    /// Every step of the init has to be done in an `EtherCatCycle`
     fn serial_interface_initialize(&mut self, port: EL6021Port) -> bool {
         match port {
             EL6021Port::SI1 => {

--- a/ethercat-hal/src/devices/el7031/mod.rs
+++ b/ethercat-hal/src/devices/el7031/mod.rs
@@ -79,15 +79,12 @@ impl EthercatDeviceProcessing for EL7031 {
         }
 
         // set counter
-        match self.counter_wrapper.pop_override() {
-            Some(new_counter) => {
-                enc_control_compact.set_counter = true;
-                enc_control_compact.set_counter_value = new_counter;
-            }
-            None => {
-                enc_control_compact.set_counter = false;
-                enc_control_compact.set_counter_value = 0;
-            }
+        if let Some(new_counter) = self.counter_wrapper.pop_override() {
+            enc_control_compact.set_counter = true;
+            enc_control_compact.set_counter_value = new_counter;
+        } else {
+            enc_control_compact.set_counter = false;
+            enc_control_compact.set_counter_value = 0;
         }
 
         Ok(())
@@ -114,12 +111,11 @@ impl StepperVelocityEL70x1Device<EL7031StepperPort> for EL7031 {
         value: StepperVelocityEL70x1Output,
     ) -> Result<(), anyhow::Error> {
         // check if operating mode is velocity
-        if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
-            panic!(
-                "Operation mode is not velocity, but {:?}",
-                self.configuration.stm_features.operation_mode
-            );
-        }
+        assert!(
+            self.configuration.stm_features.operation_mode == EL70x1OperationMode::DirectVelocity,
+            "Operation mode is not velocity, but {:?}",
+            self.configuration.stm_features.operation_mode
+        );
 
         match port {
             EL7031StepperPort::STM1 => {

--- a/ethercat-hal/src/devices/el7031_0030/coe.rs
+++ b/ethercat-hal/src/devices/el7031_0030/coe.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::{EL7031_0030, pdo::EL7031_0030PredefinedPdoAssignment};
 
-/// Configuration for EL7031_0030 Stepper Motor Terminal
+/// Configuration for `EL7031_0030` Stepper Motor Terminal
 #[derive(Debug, Clone)]
 pub struct EL7031_0030Configuration {
     /// Encoder configuration
@@ -110,7 +110,7 @@ impl ConfigurableDevice<EL7031_0030Configuration> for EL7031_0030 {
     }
 }
 
-/// StmFeatures for the EL7031-0030
+/// `StmFeatures` for the EL7031-0030
 ///
 /// Has two extra fields over the [`crate::shared_config::el70x1::StmFeatures`]
 /// for digital input emulation
@@ -313,8 +313,7 @@ impl TryFrom<u8> for EL7031_0030DigitalInputEmulation {
             5 => Ok(Self::Hysteresis1),
             6 => Ok(Self::Hysteresis2),
             _ => Err(anyhow::anyhow!(
-                "Invalid value for EL7031_0030DigitalInputEmulation: {}",
-                value
+                "Invalid value for EL7031_0030DigitalInputEmulation: {value}"
             )),
         }
     }

--- a/ethercat-hal/src/devices/el7031_0030/mod.rs
+++ b/ethercat-hal/src/devices/el7031_0030/mod.rs
@@ -83,15 +83,12 @@ impl EthercatDeviceProcessing for EL7031_0030 {
         }
 
         // set counter
-        match self.counter_wrapper.pop_override() {
-            Some(new_counter) => {
-                enc_control_compact.set_counter = true;
-                enc_control_compact.set_counter_value = new_counter;
-            }
-            None => {
-                enc_control_compact.set_counter = false;
-                enc_control_compact.set_counter_value = 0;
-            }
+        if let Some(new_counter) = self.counter_wrapper.pop_override() {
+            enc_control_compact.set_counter = true;
+            enc_control_compact.set_counter_value = new_counter;
+        } else {
+            enc_control_compact.set_counter = false;
+            enc_control_compact.set_counter_value = 0;
         }
 
         Ok(())
@@ -118,13 +115,12 @@ impl StepperVelocityEL70x1Device<EL7031_0030StepperPort> for EL7031_0030 {
         value: StepperVelocityEL70x1Output,
     ) -> Result<(), anyhow::Error> {
         // check if operating mode is velocity
-        if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
-            panic!(
-                "[{}::StepperVelocityEL70x1Device::stepper_velocity_write] Operation mode is not velocity, but {:?}",
-                module_path!(),
-                self.configuration.stm_features.operation_mode
-            );
-        }
+        assert!(
+            self.configuration.stm_features.operation_mode == EL70x1OperationMode::DirectVelocity,
+            "[{}::StepperVelocityEL70x1Device::stepper_velocity_write] Operation mode is not velocity, but {:?}",
+            module_path!(),
+            self.configuration.stm_features.operation_mode
+        );
 
         match port {
             EL7031_0030StepperPort::STM1 => {

--- a/ethercat-hal/src/devices/el7041_0052/coe.rs
+++ b/ethercat-hal/src/devices/el7041_0052/coe.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{EL7041_0052, pdo::EL7041_0052PredefinedPdoAssignment};
 
-/// Configuration for EL7041_0052 Stepper Motor Terminal
+/// Configuration for `EL7041_0052` Stepper Motor Terminal
 #[derive(Debug, Clone)]
 pub struct EL7041_0052Configuration {
     /// Encoder configuration

--- a/ethercat-hal/src/devices/el7041_0052/mod.rs
+++ b/ethercat-hal/src/devices/el7041_0052/mod.rs
@@ -92,15 +92,12 @@ impl EthercatDeviceProcessing for EL7041_0052 {
         }
 
         // set counter
-        match self.counter_wrapper.pop_override() {
-            Some(new_counter) => {
-                enc_control_compact.set_counter = true;
-                enc_control_compact.set_counter_value = new_counter;
-            }
-            None => {
-                enc_control_compact.set_counter = false;
-                enc_control_compact.set_counter_value = 0;
-            }
+        if let Some(new_counter) = self.counter_wrapper.pop_override() {
+            enc_control_compact.set_counter = true;
+            enc_control_compact.set_counter_value = new_counter;
+        } else {
+            enc_control_compact.set_counter = false;
+            enc_control_compact.set_counter_value = 0;
         }
 
         Ok(())
@@ -114,12 +111,11 @@ impl StepperVelocityEL70x1Device<EL7041_0052Port> for EL7041_0052 {
         value: StepperVelocityEL70x1Output,
     ) -> Result<(), anyhow::Error> {
         // check if operating mode is velocity
-        if self.configuration.stm_features.operation_mode != EL70x1OperationMode::DirectVelocity {
-            panic!(
-                "Operation mode is not velocity, but {:?}",
-                self.configuration.stm_features.operation_mode
-            );
-        }
+        assert!(
+            self.configuration.stm_features.operation_mode == EL70x1OperationMode::DirectVelocity,
+            "Operation mode is not velocity, but {:?}",
+            self.configuration.stm_features.operation_mode
+        );
 
         match port {
             EL7041_0052Port::STM1 => {
@@ -149,8 +145,7 @@ impl StepperVelocityEL70x1Device<EL7041_0052Port> for EL7041_0052 {
                 Ok(())
             }
             _ => Err(anyhow!(
-                "Port {:?} is not supported for stepper velocity",
-                port
+                "Port {port:?} is not supported for stepper velocity"
             )),
         }
     }
@@ -187,8 +182,7 @@ impl StepperVelocityEL70x1Device<EL7041_0052Port> for EL7041_0052 {
                 })
             }
             _ => Err(anyhow!(
-                "Port {:?} is not supported for stepper velocity",
-                port
+                "Port {port:?} is not supported for stepper velocity"
             )),
         }
     }
@@ -226,8 +220,7 @@ impl StepperVelocityEL70x1Device<EL7041_0052Port> for EL7041_0052 {
                 })
             }
             _ => Err(anyhow!(
-                "Port {:?} is not supported for stepper velocity",
-                port
+                "Port {port:?} is not supported for stepper velocity"
             )),
         }
     }
@@ -261,10 +254,7 @@ impl DigitalInputDevice<EL7041_0052Port> for EL7041_0052 {
                         .digital_input_2
                 }
                 _ => {
-                    return Err(anyhow!(
-                        "Port {:?} is not supported for digital input",
-                        port
-                    ));
+                    return Err(anyhow!("Port {port:?} is not supported for digital input"));
                 }
             },
         })

--- a/ethercat-hal/src/devices/mod.rs
+++ b/ethercat-hal/src/devices/mod.rs
@@ -199,7 +199,7 @@ pub async fn downcast_device<T: EthercatDevice>(
         // Transmute the Arc to the desired type
         unsafe {
             Ok(Arc::from_raw(
-                Arc::into_raw(cloned_device) as *const RwLock<T>
+                Arc::into_raw(cloned_device).cast::<RwLock<T>>(),
             ))
         }
     } else {
@@ -291,7 +291,8 @@ pub type SubDeviceIdentityTuple = (u32, u32, u32);
 // Is vendor id at 0, and prodid at 1
 pub type SubDeviceProductTuple = (u32, u32);
 
-/// function that converts SubDeviceIdentity to tuple
+/// function that converts `SubDeviceIdentity` to tuple
+#[must_use]
 pub const fn subdevice_identity_to_tuple(identity: &SubDeviceIdentity) -> SubDeviceIdentityTuple {
     (identity.vendor_id, identity.product_id, identity.revision)
 }

--- a/ethercat-hal/src/devices/wago_750_354.rs
+++ b/ethercat-hal/src/devices/wago_750_354.rs
@@ -2,7 +2,10 @@ use super::{
     EthercatDevice, EthercatDeviceProcessing, EthercatDeviceUsed, NewEthercatDevice,
     SubDeviceIdentityTuple,
 };
-use crate::devices::wago_modules::*;
+use crate::devices::wago_modules::{
+    wago_750_402, wago_750_430, wago_750_455, wago_750_460, wago_750_501, wago_750_530,
+    wago_750_553, wago_750_652, wago_750_671, wago_750_672, wago_750_1506,
+};
 use crate::{
     devices::{
         DynamicEthercatDevice, Module,
@@ -110,7 +113,7 @@ impl EthercatDevice for Wago750_354 {
     }
 
     fn set_module(&mut self, module: Module) {
-        self.slots[self.module_count] = Some(module.clone());
+        self.slots[self.module_count] = Some(module);
         self.module_count += 1;
     }
 }
@@ -150,11 +153,9 @@ impl std::fmt::Debug for Wago750_354 {
 }
 
 impl Wago750_354 {
-    pub fn calculate_module_index(pdo_mapping: u32, is_tx: bool) -> u32 {
-        let start_index = match is_tx {
-            true => 0x6000,
-            false => 0x7000,
-        };
+    #[must_use]
+    pub const fn calculate_module_index(pdo_mapping: u32, is_tx: bool) -> u32 {
+        let start_index = if is_tx { 0x6000 } else { 0x7000 };
         let pdo_index = (pdo_mapping & 0xFFFF0000) >> 16;
 
         if pdo_index < start_index {
@@ -180,9 +181,10 @@ impl Wago750_354 {
         let mut bit_offset = 0;
         let start_subindex = 0x2;
 
-        let index = match get_tx {
-            true => (TX_MAPPING_INDEX.0, TX_MAPPING_INDEX.1),
-            false => (RX_MAPPING_INDEX.0, RX_MAPPING_INDEX.1),
+        let index = if get_tx {
+            (TX_MAPPING_INDEX.0, TX_MAPPING_INDEX.1)
+        } else {
+            (RX_MAPPING_INDEX.0, RX_MAPPING_INDEX.1)
         };
 
         let count_mappings = device.sdo_read::<u8>(index.0, index.1).await?;
@@ -207,7 +209,7 @@ impl Wago750_354 {
                 // entries still consume bits, but must not be assigned to a module.
                 let start_index = if get_tx { 0x6000 } else { 0x7000 };
                 if pdo_index_hi >= start_index {
-                    let module_i = Wago750_354::calculate_module_index(pdo_mapping, get_tx);
+                    let module_i = Self::calculate_module_index(pdo_mapping, get_tx);
                     if module_i < 64 && !vec.iter().any(|map| map.module_i == module_i) {
                         vec.push(ModulePdoMapping {
                             offset: bit_offset,
@@ -239,8 +241,7 @@ impl Wago750_354 {
         {
             Ok(value) => Ok(value as usize),
             Err(e) => Err(anyhow::anyhow!(
-                "Failed to read Module Count for Wago750_354: {:?}",
-                e
+                "Failed to read Module Count for Wago750_354: {e:?}"
             )),
         }
     }
@@ -268,7 +269,7 @@ impl Wago750_354 {
                 has_rx: false,
                 tx_offset: 0,
                 rx_offset: 0,
-                name: "".to_string(),
+                name: String::new(),
             };
 
             match ident_iom {
@@ -328,10 +329,7 @@ impl Wago750_354 {
                     module.has_rx = true;
                     module.name = "750-553".to_string();
                 }
-                _ => println!(
-                    "Wago-750-354 found Unknown/Unimplemented Module: {}",
-                    ident_iom
-                ),
+                _ => println!("Wago-750-354 found Unknown/Unimplemented Module: {ident_iom}"),
             }
             modules.push(module);
         }
@@ -339,7 +337,7 @@ impl Wago750_354 {
     }
 
     /// Call after all modules have been added
-    pub fn init_slot_modules<'a>(&mut self, device: &EthercrabSubDevicePreoperational<'a>) {
+    pub fn init_slot_modules(&mut self, device: &EthercrabSubDevicePreoperational<'_>) {
         // Already initialized
         if self.dev_count != 0 {
             return;
@@ -457,14 +455,14 @@ impl Wago750_354 {
     pub async fn initialize_modules<'a>(
         device: &EthercrabSubDevicePreoperational<'a>,
     ) -> Result<Vec<Module>, Error> {
-        let count = match Wago750_354::get_module_count(device).await {
+        let count = match Self::get_module_count(device).await {
             Ok(count) => count,
             Err(e) => return Err(e),
         };
         if count == 0 {
             return Ok(vec![]);
         }
-        let modules = Wago750_354::get_modules(device, count).await?;
+        let modules = Self::get_modules(device, count).await?;
         Ok(modules)
     }
 }

--- a/ethercat-hal/src/devices/wago_modules/ip20_ec_di8_do8.rs
+++ b/ethercat-hal/src/devices/wago_modules/ip20_ec_di8_do8.rs
@@ -452,11 +452,11 @@ impl IP20EcDi8Do8 {
 
                     let mut dev_guard = dev.write_blocking();
                     if let Some(offset) = tx_pdo_offset {
-                        dev_guard.set_tx_offset(*offset)
+                        dev_guard.set_tx_offset(*offset);
                     }
 
                     if let Some(offset) = rx_pdo_offset {
-                        dev_guard.set_rx_offset(*offset)
+                        dev_guard.set_rx_offset(*offset);
                     }
                     drop(dev_guard);
                     self.slot_devices[self.dev_count] = Some(dev);

--- a/ethercat-hal/src/devices/wago_modules/ip20_ec_di8_do8.rs
+++ b/ethercat-hal/src/devices/wago_modules/ip20_ec_di8_do8.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{wago_750_402, wago_750_501, wago_750_652, wago_750_1506};
 use crate::devices::{
     EthercatDevice, EthercatDeviceProcessing, EthercatDeviceUsed, NewEthercatDevice,
     SubDeviceIdentityTuple,
@@ -313,9 +313,10 @@ impl IP20EcDi8Do8 {
         let mut vec: Vec<usize> = vec![];
         let mut bit_offset = 0;
         let start_subindex = 0x1;
-        let index = match get_tx {
-            true => (TX_MAPPING_INDEX.0, TX_MAPPING_INDEX.1),
-            false => (RX_MAPPING_INDEX.0, RX_MAPPING_INDEX.1),
+        let index = if get_tx {
+            (TX_MAPPING_INDEX.0, TX_MAPPING_INDEX.1)
+        } else {
+            (RX_MAPPING_INDEX.0, RX_MAPPING_INDEX.1)
         };
         let count = device.sdo_read::<u8>(index.0, index.1).await?;
 
@@ -378,7 +379,7 @@ impl IP20EcDi8Do8 {
                 has_rx: false,
                 tx_offset: 0,
                 rx_offset: 0,
-                name: "".to_string(),
+                name: String::new(),
             };
 
             match ident_iom {
@@ -403,7 +404,7 @@ impl IP20EcDi8Do8 {
     }
 
     /// Call after all modules have been added
-    pub fn init_slot_modules<'a>(&mut self, device: &EthercrabSubDevicePreoperational<'a>) {
+    pub fn init_slot_modules(&mut self, device: &EthercrabSubDevicePreoperational<'_>) {
         // Already initialized
         if self.dev_count != 0 {
             return;
@@ -450,14 +451,12 @@ impl IP20EcDi8Do8 {
                     }
 
                     let mut dev_guard = dev.write_blocking();
-                    match tx_pdo_offset {
-                        Some(offset) => dev_guard.set_tx_offset(*offset),
-                        None => (),
+                    if let Some(offset) = tx_pdo_offset {
+                        dev_guard.set_tx_offset(*offset)
                     }
 
-                    match rx_pdo_offset {
-                        Some(offset) => dev_guard.set_rx_offset(*offset),
-                        None => (),
+                    if let Some(offset) = rx_pdo_offset {
+                        dev_guard.set_rx_offset(*offset)
                     }
                     drop(dev_guard);
                     self.slot_devices[self.dev_count] = Some(dev);
@@ -471,14 +470,14 @@ impl IP20EcDi8Do8 {
     pub async fn initialize_modules<'a>(
         device: &EthercrabSubDevicePreoperational<'a>,
     ) -> Result<Vec<Module>, Error> {
-        let count = match IP20EcDi8Do8::get_module_count(device).await {
+        let count = match Self::get_module_count(device).await {
             Ok(count) => count,
             Err(e) => return Err(e),
         };
         if count == 0 {
             return Ok(vec![]);
         }
-        let modules = IP20EcDi8Do8::get_modules(device, count).await?;
+        let modules = Self::get_modules(device, count).await?;
         Ok(modules)
     }
 }

--- a/ethercat-hal/src/devices/wago_modules/wago_750_1506.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_1506.rs
@@ -161,11 +161,11 @@ impl EthercatDynamicPDO for Wago750_1506 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_402.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_402.rs
@@ -67,7 +67,7 @@ impl EthercatDynamicPDO for Wago750_402 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, _offset: usize) {

--- a/ethercat-hal/src/devices/wago_modules/wago_750_430.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_430.rs
@@ -109,11 +109,11 @@ impl EthercatDynamicPDO for Wago750_430 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 
@@ -122,7 +122,7 @@ impl EthercatDevice for Wago750_430 {
         &mut self,
         input: &bitvec::prelude::BitSlice<u8, bitvec::prelude::Lsb0>,
     ) -> Result<(), anyhow::Error> {
-        self.txpdo.port1 = input[self.tx_bit_offset + 0];
+        self.txpdo.port1 = input[self.tx_bit_offset];
         self.txpdo.port2 = input[self.tx_bit_offset + 1];
         self.txpdo.port3 = input[self.tx_bit_offset + 2];
         self.txpdo.port4 = input[self.tx_bit_offset + 3];
@@ -181,7 +181,7 @@ impl EthercatDevice for Wago750_430 {
     fn set_module(&mut self, module: crate::devices::Module) {
         self.tx_bit_offset = module.tx_offset;
         self.rx_bit_offset = module.rx_offset;
-        self.module = Some(module)
+        self.module = Some(module);
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_455.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_455.rs
@@ -94,11 +94,11 @@ impl EthercatDynamicPDO for Wago750_455 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 
@@ -168,7 +168,7 @@ impl EthercatDevice for Wago750_455 {
     fn set_module(&mut self, module: Module) {
         self.tx_bit_offset = module.tx_offset;
         self.rx_bit_offset = module.rx_offset;
-        self.module = Some(module)
+        self.module = Some(module);
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_460.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_460.rs
@@ -51,7 +51,7 @@ impl TemperatureInputDevice<Wago750_460Port> for Wago750_460 {
         };
         // Full 16-bit signed value, 0.1 °C per LSB — no status bits in the word.
         let temp_raw = raw as i16;
-        let temperature = temp_raw as f32 / 10.0;
+        let temperature = f32::from(temp_raw) / 10.0;
         let overrange = temp_raw >= 8500;
         let underrange = temp_raw <= -2000;
         TemperatureInputInput {
@@ -88,11 +88,11 @@ impl EthercatDynamicPDO for Wago750_460 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_501.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_501.rs
@@ -86,11 +86,11 @@ impl EthercatDynamicPDO for Wago750_501 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 
@@ -158,7 +158,7 @@ impl EthercatDevice for Wago750_501 {
     fn set_module(&mut self, module: crate::devices::Module) {
         self.tx_bit_offset = module.tx_offset;
         self.rx_bit_offset = module.rx_offset;
-        self.module = Some(module)
+        self.module = Some(module);
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_530.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_530.rs
@@ -134,11 +134,11 @@ impl EthercatDynamicPDO for Wago750_530 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 
@@ -230,7 +230,7 @@ impl EthercatDevice for Wago750_530 {
     fn set_module(&mut self, module: crate::devices::Module) {
         self.tx_bit_offset = module.tx_offset;
         self.rx_bit_offset = module.rx_offset;
-        self.module = Some(module)
+        self.module = Some(module);
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_553.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_553.rs
@@ -60,7 +60,7 @@ impl AnalogOutputDevice<Wago750_553Port> for Wago750_553 {
             Wago750_553Port::AO3 => self.rx_pdo.ao3,
             Wago750_553Port::AO4 => self.rx_pdo.ao4,
         };
-        AnalogOutputOutput(raw as f32 / 0x7FFF as f32)
+        AnalogOutputOutput(f32::from(raw) / 0x7FFF as f32)
     }
 }
 
@@ -76,11 +76,11 @@ impl EthercatDynamicPDO for Wago750_553 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_652.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_652.rs
@@ -93,11 +93,11 @@ impl EthercatDynamicPDO for Wago750_652 {
     }
 
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
 
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 
@@ -112,7 +112,7 @@ impl EthercatDevice for Wago750_652 {
         self.tx_pdo.in_buffer.fill(0u8);
         let base = self.tx_bit_offset;
 
-        self.tx_pdo.status.transmit_ack = *input.get(base + 0).expect("Missing buf_empty bit");
+        self.tx_pdo.status.transmit_ack = *input.get(base).expect("Missing buf_empty bit");
         self.tx_pdo.status.receive_request = *input.get(base + 1).expect("Missing buf_empty bit");
         self.tx_pdo.status.init_ack = *input.get(base + 2).expect("Missing buf_empty bit");
         self.tx_pdo.status.buf_full = *input.get(base + 6).expect("Missing buf_empty bit");
@@ -121,14 +121,14 @@ impl EthercatDevice for Wago750_652 {
         self.tx_pdo.status.error_framing = *input.get(base + 14).expect("Missing buf_empty bit");
         self.tx_pdo.status.error_overrun = *input.get(base + 15).expect("Missing buf_empty bit");
         // Im sorry but this is what you get by splitting the len across different bytes ...
-        self.tx_pdo.status.input_length = ((*input.get(base + 3).expect("Missing buf_empty bit")
-            as u8)
-            ^ ((*input.get(base + 4).expect("Missing buf_empty bit") as u8) << 1)
-            ^ ((*input.get(base + 5).expect("Missing buf_empty bit") as u8) << 2)
-            ^ ((*input.get(base + 8).expect("Missing buf_empty bit") as u8) << 3)
-            ^ ((*input.get(base + 9).expect("Missing buf_empty bit") as u8) << 4)
-            ^ ((*input.get(base + 10).expect("Missing buf_empty bit") as u8) << 5))
-            as usize;
+        self.tx_pdo.status.input_length =
+            (u8::from(*input.get(base + 3).expect("Missing buf_empty bit"))
+                ^ (u8::from(*input.get(base + 4).expect("Missing buf_empty bit")) << 1)
+                ^ (u8::from(*input.get(base + 5).expect("Missing buf_empty bit")) << 2)
+                ^ (u8::from(*input.get(base + 8).expect("Missing buf_empty bit")) << 3)
+                ^ (u8::from(*input.get(base + 9).expect("Missing buf_empty bit")) << 4)
+                ^ (u8::from(*input.get(base + 10).expect("Missing buf_empty bit")) << 5))
+                as usize;
 
         // the serial bytes start at bit 16,
         // then we calculate the offset of when the serial bytes buffer is over, which for the 24byte pdo is 22bytes
@@ -152,7 +152,7 @@ impl EthercatDevice for Wago750_652 {
         let mut ol0_i = 5; // Ol0 starts at bit 5 and goes to bit 7 (inclusive) 
         let mut ol1_i = 8;
 
-        output.set(base + 0, self.rx_pdo.control.transmit_request);
+        output.set(base, self.rx_pdo.control.transmit_request);
         output.set(base + 1, self.rx_pdo.control.receive_ack);
         output.set(base + 2, self.rx_pdo.control.init_request);
         output.set(base + 3, self.rx_pdo.control.send_continuous);
@@ -252,9 +252,7 @@ pub enum Wago750_652Port {
 
 impl SerialInterfaceDevice<Wago750_652Port> for Wago750_652 {
     fn serial_interface_read_message(&mut self, port: Wago750_652Port) -> Option<Vec<u8>> {
-        if !self.serial_interface_has_messages(port) {
-            return None;
-        } else {
+        if self.serial_interface_has_messages(port) {
             let in_len = self.tx_pdo.status.input_length;
             let received_data = self.tx_pdo.in_buffer[0..in_len].to_vec();
 
@@ -266,6 +264,8 @@ impl SerialInterfaceDevice<Wago750_652Port> for Wago750_652 {
             self.rx_pdo.control.receive_ack = !self.rx_pdo.control.receive_ack;
 
             Some(received_data)
+        } else {
+            None
         }
     }
 
@@ -293,7 +293,7 @@ impl SerialInterfaceDevice<Wago750_652Port> for Wago750_652 {
     }
 
     fn serial_interface_has_messages(&mut self, _port: Wago750_652Port) -> bool {
-        return self.tx_pdo.status.receive_request != self.has_messages_last_toggle;
+        self.tx_pdo.status.receive_request != self.has_messages_last_toggle
     }
 
     fn get_serial_encoding(

--- a/ethercat-hal/src/devices/wago_modules/wago_750_671.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_671.rs
@@ -93,10 +93,10 @@ impl EthercatDynamicPDO for Wago750_671 {
         self.rx_bit_offset
     }
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 
@@ -324,7 +324,7 @@ impl EthercatDevice for Wago750_671 {
     fn set_module(&mut self, module: crate::devices::Module) {
         self.tx_bit_offset = module.tx_offset;
         self.rx_bit_offset = module.rx_offset;
-        self.module = Some(module)
+        self.module = Some(module);
     }
 }
 

--- a/ethercat-hal/src/devices/wago_modules/wago_750_672.rs
+++ b/ethercat-hal/src/devices/wago_modules/wago_750_672.rs
@@ -129,10 +129,10 @@ impl EthercatDynamicPDO for Wago750_672 {
         self.rx_bit_offset
     }
     fn set_tx_offset(&mut self, offset: usize) {
-        self.tx_bit_offset = offset
+        self.tx_bit_offset = offset;
     }
     fn set_rx_offset(&mut self, offset: usize) {
-        self.rx_bit_offset = offset
+        self.rx_bit_offset = offset;
     }
 }
 
@@ -356,7 +356,7 @@ impl EthercatDevice for Wago750_672 {
     fn set_module(&mut self, module: crate::devices::Module) {
         self.tx_bit_offset = module.tx_offset;
         self.rx_bit_offset = module.rx_offset;
-        self.module = Some(module)
+        self.module = Some(module);
     }
 }
 

--- a/ethercat-hal/src/helpers/counter_wrapper_u16_i128.rs
+++ b/ethercat-hal/src/helpers/counter_wrapper_u16_i128.rs
@@ -244,25 +244,25 @@ mod tests {
 
         // Increment to 65530
         raw_counter = 65530;
-        position += counter_change(0, raw_counter, false, false) as i128;
+        position += i128::from(counter_change(0, raw_counter, false, false));
         assert_eq!(position, 65530);
 
         // Increment to 65535
         let mut prev = raw_counter;
         raw_counter = 65535;
-        position += counter_change(prev, raw_counter, false, false) as i128;
+        position += i128::from(counter_change(prev, raw_counter, false, false));
         assert_eq!(position, 65535);
 
         // Overflow to 5
         prev = raw_counter;
         raw_counter = 5;
-        position += counter_change(prev, raw_counter, false, true) as i128;
+        position += i128::from(counter_change(prev, raw_counter, false, true));
         assert_eq!(position, 65541); // 65535 + 6
 
         // Normal decrement to 65530 (no underflow)
         prev = raw_counter;
         raw_counter = 65530;
-        position += counter_change(prev, raw_counter, false, false) as i128;
+        position += i128::from(counter_change(prev, raw_counter, false, false));
         assert_eq!(position, 131066); // 65541 + (65530 - 5) = 65541 + 65525 = 131066
 
         // Now test a true underflow: position 5 -> 65535
@@ -270,7 +270,7 @@ mod tests {
         raw_counter = 5; // Set raw counter to match
         prev = raw_counter;
         raw_counter = 65535;
-        position += counter_change(prev, raw_counter, true, false) as i128;
+        position += i128::from(counter_change(prev, raw_counter, true, false));
         assert_eq!(position, -1); // 5 + (65535 - 5 - 65536) = 5 - 6 = -1
     }
 }

--- a/ethercat-hal/src/helpers/counter_wrapper_u16_i128.rs
+++ b/ethercat-hal/src/helpers/counter_wrapper_u16_i128.rs
@@ -4,7 +4,7 @@ const U16_MAX: i128 = std::u16::MAX as i128;
 ///
 /// We convert the overflows and underflows to an i128 value for easier calculations.
 ///
-/// When overriding the counter we don't set the valeu direclty but schedula it wiht the [`push_override`] so it can be synced with [`pop_override`] to an EtherCAT device.
+/// When overriding the counter we don't set the valeu direclty but schedula it wiht the [`push_override`] so it can be synced with [`pop_override`] to an `EtherCAT` device.
 #[derive(Clone, Debug)]
 pub struct CounterWrapperU16U128 {
     counter: i128,
@@ -21,6 +21,7 @@ impl Default for CounterWrapperU16U128 {
 }
 
 impl CounterWrapperU16U128 {
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             counter: 0,
@@ -48,6 +49,7 @@ impl CounterWrapperU16U128 {
         self.last_counter_overflow = counter_overflow;
     }
 
+    #[must_use]
     pub const fn current(&self) -> i128 {
         self.counter
     }
@@ -79,6 +81,7 @@ impl CounterWrapperU16U128 {
     }
 
     /// Returns the override value as an i128
+    #[must_use]
     pub const fn get_override(&self) -> Option<i128> {
         self.set_counter
     }

--- a/ethercat-hal/src/helpers/el70xx_velocity_converter.rs
+++ b/ethercat-hal/src/helpers/el70xx_velocity_converter.rs
@@ -6,6 +6,7 @@ pub struct EL70x1VelocityConverter {
 }
 
 impl EL70x1VelocityConverter {
+    #[must_use]
     pub const fn new(speed_range: &EL70x1SpeedRange) -> Self {
         let speed_range_value = match speed_range {
             EL70x1SpeedRange::Steps1000 => 1000,
@@ -21,26 +22,30 @@ impl EL70x1VelocityConverter {
     }
 
     /// Convert steps per second to the i16 velocity value used by the EL7031
+    #[must_use]
     pub fn steps_to_velocity(&self, steps_per_second: f64, propability_rounding: bool) -> i16 {
         // Calculate the velocity value (10000 = 100% of max speed)
         let velocity_f64 =
-            (steps_per_second / self.max_steps_per_seconds as f64) * std::i16::MAX as f64;
+            (steps_per_second / f64::from(self.max_steps_per_seconds)) * f64::from(std::i16::MAX);
 
-        match propability_rounding {
-            true => round_propabilistic(velocity_f64),
-            false => velocity_f64.round() as i16,
+        if propability_rounding {
+            round_propabilistic(velocity_f64)
+        } else {
+            velocity_f64.round() as i16
         }
     }
 
     /// Convert i16 velocity value back to steps per second
+    #[must_use]
     pub fn velocity_to_steps(&self, velocity: i16, propability_rounding: bool) -> i16 {
         // Calculate steps per second from velocity value
-        let steps_per_second =
-            (velocity as f64 / std::i16::MAX as f64) * self.max_steps_per_seconds as f64;
+        let steps_per_second = (f64::from(velocity) / f64::from(std::i16::MAX))
+            * f64::from(self.max_steps_per_seconds);
 
-        match propability_rounding {
-            true => round_propabilistic(steps_per_second),
-            false => steps_per_second.round() as i16,
+        if propability_rounding {
+            round_propabilistic(steps_per_second)
+        } else {
+            steps_per_second.round() as i16
         }
     }
 }
@@ -59,9 +64,10 @@ impl EL70x1VelocityConverter {
 fn round_propabilistic(value: f64) -> i16 {
     let propability = value - value.floor();
     // make a random decision to add 1 based on the propability
-    match rand::random_bool(propability) {
-        true => value.ceil() as i16,
-        false => value.floor() as i16,
+    if rand::random_bool(propability) {
+        value.ceil() as i16
+    } else {
+        value.floor() as i16
     }
 }
 

--- a/ethercat-hal/src/helpers/el70xx_velocity_converter.rs
+++ b/ethercat-hal/src/helpers/el70xx_velocity_converter.rs
@@ -85,16 +85,16 @@ mod tests {
         assert_eq!(calc.steps_to_velocity(0.0, false), 0);
         // 1000 sps = 25% velocity = 8192 (25% of 32767)
         let v1 = calc.steps_to_velocity(1000.0, false);
-        assert!((v1 - 8192i16).abs() <= 1, "Expected 8192±1, got {}", v1);
+        assert!((v1 - 8192i16).abs() <= 1, "Expected 8192±1, got {v1}");
         // 2000 sps = 50% velocity = 16384 (50% of 32767)
         let v2 = calc.steps_to_velocity(2000.0, false);
-        assert!((v2 - 16384i16).abs() <= 1, "Expected 16384±1, got {}", v2);
+        assert!((v2 - 16384i16).abs() <= 1, "Expected 16384±1, got {v2}");
         // 3000 sps = 75% velocity = 24575 (75% of 32767)
         let v3 = calc.steps_to_velocity(3000.0, false);
-        assert!((v3 - 24575i16).abs() <= 1, "Expected 24575±1, got {}", v3);
+        assert!((v3 - 24575i16).abs() <= 1, "Expected 24575±1, got {v3}");
         // 4000 sps = 100% velocity = 32767 (100% of 32767)
         let v4 = calc.steps_to_velocity(4000.0, false);
-        assert!((v4 - 32767i16).abs() <= 1, "Expected 32767±1, got {}", v4);
+        assert!((v4 - 32767i16).abs() <= 1, "Expected 32767±1, got {v4}");
     }
 
     #[test]
@@ -105,16 +105,16 @@ mod tests {
         assert_eq!(calc.velocity_to_steps(0, false), 0);
         // 25% velocity = 8192i16 = 1000 sps
         let s1 = calc.velocity_to_steps(8192, false);
-        assert_eq!((s1 - 1000i16).abs(), 0, "Expected 1000±0, got {}", s1);
+        assert_eq!((s1 - 1000i16).abs(), 0, "Expected 1000±0, got {s1}");
         // 50% velocity = 16384i16 = 2000 sps
         let s2 = calc.velocity_to_steps(16384, false);
-        assert_eq!((s2 - 2000i16).abs(), 0, "Expected 2000±0, got {}", s2);
+        assert_eq!((s2 - 2000i16).abs(), 0, "Expected 2000±0, got {s2}");
         // 75% velocity = 24575i16 = 3000 sps
         let s3 = calc.velocity_to_steps(24575, false);
-        assert_eq!((s3 - 3000i16).abs(), 0, "Expected 3000±0, got {}", s3);
+        assert_eq!((s3 - 3000i16).abs(), 0, "Expected 3000±0, got {s3}");
         // 100% velocity = 32767i16 = 4000 sps
         let s4 = calc.velocity_to_steps(32767, false);
-        assert_eq!((s4 - 4000i16).abs(), 0, "Expected 4000±0, got {}", s4);
+        assert_eq!((s4 - 4000i16).abs(), 0, "Expected 4000±0, got {s4}");
     }
 
     #[test]
@@ -123,7 +123,7 @@ mod tests {
         let mut sum = 0.0;
         for _ in 0..100000 {
             let rounded = round_propabilistic(0.5);
-            sum += rounded as f64;
+            sum += f64::from(rounded);
         }
         // Check that the average is close to 0.5
         let average = sum / 100000.0;

--- a/ethercat-hal/src/helpers/signing_converter_u16.rs
+++ b/ethercat-hal/src/helpers/signing_converter_u16.rs
@@ -17,18 +17,21 @@ impl U16SigningConverter {
     /// assert_eq!(value.into_unsigned(), 42);
     /// ```
     #[inline]
+    #[must_use]
     pub const fn load_raw(value: u16) -> Self {
         Self { raw: value }
     }
 
     /// Converts the value to an unsigned 16-bit integer.
     #[inline]
+    #[must_use]
     pub const fn as_unsigned(self) -> u16 {
         self.raw
     }
 
     /// Converts the value to a signed 16-bit integer using two's complement.
     #[inline]
+    #[must_use]
     pub const fn as_signed(self) -> i16 {
         self.raw as i16
     }
@@ -38,6 +41,7 @@ impl U16SigningConverter {
     /// In sign-magnitude representation, the most significant bit represents the sign
     /// (0 for positive, 1 for negative) and the remaining bits represent the magnitude.
     #[inline]
+    #[must_use]
     pub const fn as_signed_magnitude(self) -> i16 {
         if self.raw & 0x8000 != 0 {
             -((self.raw & 0x7FFF) as i16)
@@ -47,6 +51,7 @@ impl U16SigningConverter {
     }
 
     #[inline]
+    #[must_use]
     pub const fn as_absolute(self) -> i16 {
         self.as_signed().abs()
     }

--- a/ethercat-hal/src/io/analog_input/mod.rs
+++ b/ethercat-hal/src/io/analog_input/mod.rs
@@ -49,16 +49,19 @@ impl AnalogInput {
     }
 
     /// Value from -1.0 to 1.0
+    #[must_use]
     pub fn get_normalized(&self) -> f32 {
         let input = (self.get_input)();
         input.normalized
     }
 
+    #[must_use]
     pub fn get_physical(&self) -> AnalogInputValue {
         let normalized = self.get_normalized();
         self.range.normalized_to_physical(normalized)
     }
 
+    #[must_use]
     pub fn get_wiring_error(&self) -> bool {
         let input = (self.get_input)();
         input.wiring_error
@@ -74,6 +77,7 @@ pub struct AnalogInputInput {
 
 impl AnalogInputInput {
     /// Convert to physical value
+    #[must_use]
     pub fn get_physical(&self, range: &AnalogInputRange) -> AnalogInputValue {
         range.normalized_to_physical(self.normalized)
     }

--- a/ethercat-hal/src/io/analog_input/physical.rs
+++ b/ethercat-hal/src/io/analog_input/physical.rs
@@ -23,6 +23,7 @@ pub enum AnalogInputRange {
 }
 
 impl AnalogInputRange {
+    #[must_use]
     pub const fn get_min_raw(&self) -> i16 {
         match self {
             Self::Potential { min_raw, .. } => *min_raw,
@@ -30,6 +31,7 @@ impl AnalogInputRange {
         }
     }
 
+    #[must_use]
     pub const fn get_max_raw(&self) -> i16 {
         match self {
             Self::Potential { max_raw, .. } => *max_raw,
@@ -37,11 +39,13 @@ impl AnalogInputRange {
         }
     }
 
+    #[must_use]
     pub fn raw_to_normalized(&self, raw_value: i16) -> f64 {
-        let range = (self.get_max_raw() as i32 - self.get_min_raw() as i32) as f64;
-        (raw_value as i32 - self.get_min_raw() as i32) as f64 / range
+        let range = f64::from(i32::from(self.get_max_raw()) - i32::from(self.get_min_raw()));
+        f64::from(i32::from(raw_value) - i32::from(self.get_min_raw())) / range
     }
 
+    #[must_use]
     pub fn raw_to_physical(&self, raw_value: i16) -> AnalogInputValue {
         let normalized = self.raw_to_normalized(raw_value);
         match self {
@@ -57,14 +61,15 @@ impl AnalogInputRange {
     }
 
     /// Convert a normalized value (0 to 1.0) to a physical value
+    #[must_use]
     pub fn normalized_to_physical(&self, normalized: f32) -> AnalogInputValue {
         match self {
             Self::Potential { min, max, .. } => {
-                let value = *min + (*max - *min).abs() * normalized as f64;
+                let value = *min + (*max - *min).abs() * f64::from(normalized);
                 AnalogInputValue::Potential(value)
             }
             Self::Current { min, max, .. } => {
-                let value = *min + (*max - *min).abs() * normalized as f64;
+                let value = *min + (*max - *min).abs() * f64::from(normalized);
                 AnalogInputValue::Current(value)
             }
         }

--- a/ethercat-hal/src/io/analog_input_dummy.rs
+++ b/ethercat-hal/src/io/analog_input_dummy.rs
@@ -25,6 +25,7 @@ impl AnalogInputDevice<AnalogInputDummyPort> for AnalogInputDummy {
 }
 
 impl AnalogInputDummy {
+    #[must_use]
     pub fn new(range: AnalogInputRange) -> Self {
         let state = Arc::new(Mutex::new(AnalogInputInput {
             normalized: 0.0,
@@ -33,6 +34,7 @@ impl AnalogInputDummy {
         Self { state, range }
     }
 
+    #[must_use]
     pub fn analog_input(&self) -> AnalogInput {
         let device: Arc<RwLock<dyn AnalogInputDevice<AnalogInputDummyPort>>> =
             Arc::new(RwLock::new(Self {
@@ -49,6 +51,7 @@ impl AnalogInputDummy {
         }
     }
 
+    #[must_use]
     pub fn get_input(&self) -> AnalogInputInput {
         let input_guard = self.state.lock().unwrap();
         input_guard.clone()

--- a/ethercat-hal/src/io/analog_input_dummy.rs
+++ b/ethercat-hal/src/io/analog_input_dummy.rs
@@ -76,7 +76,7 @@ mod tests {
             normalized: 0.5,
             wiring_error: false,
         };
-        dummy.set_input(input.clone());
+        dummy.set_input(input);
 
         let analog_input = dummy.analog_input();
         let normalized = analog_input.get_normalized();

--- a/ethercat-hal/src/io/analog_output.rs
+++ b/ethercat-hal/src/io/analog_output.rs
@@ -55,6 +55,7 @@ impl AnalogOutput {
     }
 
     /// Get the current output value
+    #[must_use]
     pub fn get(&self) -> f32 {
         let output = (self.get_output)();
         output.into()

--- a/ethercat-hal/src/io/digital_output.rs
+++ b/ethercat-hal/src/io/digital_output.rs
@@ -52,6 +52,7 @@ impl DigitalOutput {
     }
 
     /// Get the current output value
+    #[must_use]
     pub fn get(&self) -> bool {
         let output = (self.get_output)();
         output.into()

--- a/ethercat-hal/src/io/pulse_train_output.rs
+++ b/ethercat-hal/src/io/pulse_train_output.rs
@@ -61,12 +61,14 @@ impl<'device> PulseTrainOutput {
     }
 
     /// Get the current frequency value
+    #[must_use]
     pub fn get_frequency(&self) -> i32 {
         let output = (self.get_output)();
         output.frequency_value
     }
 
     /// Get the current encoder position (counter value)
+    #[must_use]
     pub fn get_position(&self) -> u32 {
         let input = (self.get_input)();
         input.counter_value

--- a/ethercat-hal/src/io/serial_interface.rs
+++ b/ethercat-hal/src/io/serial_interface.rs
@@ -170,6 +170,7 @@ pub enum SerialEncoding {
 
 impl SerialEncoding {
     /// Get the number of data bits
+    #[must_use]
     pub const fn data_bits(&self) -> u8 {
         match self {
             Self::Coding7E1 | Self::Coding7O1 | Self::Coding7E2 | Self::Coding7O2 => 7,
@@ -178,6 +179,7 @@ impl SerialEncoding {
     }
 
     /// Get the number of parity bits (0 or 1)
+    #[must_use]
     pub const fn parity_bits(&self) -> u8 {
         match self {
             Self::Coding8N1 | Self::Coding8N2 => 0,
@@ -186,6 +188,7 @@ impl SerialEncoding {
     }
 
     /// Get the parity type
+    #[must_use]
     pub const fn parity_type(&self) -> Option<ParityType> {
         match self {
             Self::Coding7E1 | Self::Coding7E2 | Self::Coding8E1 | Self::Coding8E2 => {
@@ -201,6 +204,7 @@ impl SerialEncoding {
     }
 
     /// Get the number of stop bits
+    #[must_use]
     pub const fn stop_bits(&self) -> u8 {
         match self {
             Self::Coding7E1
@@ -218,8 +222,9 @@ impl SerialEncoding {
         }
     }
 
-    /// Get the total number of bits sent per byte according to the SerialEncoding (including start bit)
+    /// Get the total number of bits sent per byte according to the `SerialEncoding` (including start bit)
     /// For Example: With 8n1 transferring 1 byte over Serial actually transfers 10 bits -> 8 data bits, 0 parity, 1 start bit and 1 stop bit
+    #[must_use]
     pub const fn total_bits(&self) -> u8 {
         // We always have 1 start bit
         1 + self.data_bits() + self.parity_bits() + self.stop_bits()

--- a/ethercat-hal/src/io/stepper_velocity_el70x1.rs
+++ b/ethercat-hal/src/io/stepper_velocity_el70x1.rs
@@ -73,8 +73,8 @@ impl<'device> StepperVelocityEL70x1 {
 
         Self {
             set_output,
-            get_input,
             get_output,
+            get_input,
             get_speed_range,
         }
     }
@@ -96,12 +96,13 @@ impl<'device> StepperVelocityEL70x1 {
     }
 
     /// Get the speed in steps per second
+    #[must_use]
     pub fn get_speed(&self) -> i32 {
         let output = (self.get_output)().unwrap();
 
         let speed_range = (self.get_speed_range)();
         let converter = EL70x1VelocityConverter::new(&speed_range.unwrap());
-        converter.velocity_to_steps(output.velocity, true) as i32
+        i32::from(converter.velocity_to_steps(output.velocity, true))
     }
 
     /// Enable or disable the stepper
@@ -116,12 +117,14 @@ impl<'device> StepperVelocityEL70x1 {
     }
 
     /// Get the enabled state of the stepper
+    #[must_use]
     pub fn is_enabled(&self) -> bool {
         let output = (self.get_output)().unwrap();
         output.enable
     }
 
     /// Get the current position of the stepper
+    #[must_use]
     pub fn get_position(&self) -> i128 {
         let input = (self.get_input)().unwrap();
         input.counter_value

--- a/ethercat-hal/src/io/stepper_velocity_wago_750_671.rs
+++ b/ethercat-hal/src/io/stepper_velocity_wago_750_671.rs
@@ -20,7 +20,7 @@ pub struct StepperVelocityWago750671 {
 }
 
 impl StepperVelocityWago750671 {
-    pub fn new(device: Arc<RwLock<Wago750_671>>) -> Self {
+    pub const fn new(device: Arc<RwLock<Wago750_671>>) -> Self {
         Self {
             device,
             state: InitState::Off,
@@ -154,20 +154,24 @@ pub enum C1Mode {
 }
 
 impl ControlByteC1 {
+    #[must_use]
     pub const fn new() -> Self {
         Self(0)
     }
 
+    #[must_use]
     pub const fn with_flag(mut self, flag: C1Flag) -> Self {
         self.0 |= flag as u8;
         self
     }
 
+    #[must_use]
     pub const fn with_mode(mut self, cmd: C1Mode) -> Self {
         self.0 = (self.0 & 0b0000_0111) | (cmd as u8);
         self
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -189,29 +193,35 @@ pub enum C2Flag {
 }
 
 impl ControlByteC2 {
+    #[must_use]
     pub const fn new() -> Self {
         Self(0)
     }
 
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn with_freq_range(mut self, sel: u8) -> Self {
         self.0 = (self.0 & 0b1111_1100) | (sel & 0b0000_0011);
         self
     }
 
+    #[must_use]
     pub const fn with_acc_range(mut self, sel: u8) -> Self {
         self.0 = (self.0 & 0b1111_0011) | ((sel & 0b0000_0011) << 2);
         self
     }
 
+    #[must_use]
     pub const fn with_flag(mut self, flag: C2Flag) -> Self {
         self.0 |= flag as u8;
         self
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -231,15 +241,18 @@ pub enum C3Flag {
 }
 
 impl ControlByteC3 {
+    #[must_use]
     pub const fn new() -> Self {
         Self(0)
     }
 
+    #[must_use]
     pub const fn with_flag(mut self, flag: C3Flag) -> Self {
         self.0 |= flag as u8;
         self
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -277,14 +290,17 @@ pub enum S1CommandAck {
 }
 
 impl StatusByteS1 {
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn has_flag(self, flag: S1Flag) -> bool {
         (self.0 & flag as u8) != 0
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -308,10 +324,12 @@ pub enum S2Flag {
 }
 
 impl StatusByteS2 {
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn has_flag(self, flag: S2Flag) -> bool {
         (self.0 & flag as u8) != 0
     }
@@ -335,10 +353,12 @@ pub enum S3Flag {
 }
 
 impl StatusByteS3 {
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn has_flag(self, flag: S3Flag) -> bool {
         (self.0 & flag as u8) != 0
     }

--- a/ethercat-hal/src/io/stepper_velocity_wago_750_672.rs
+++ b/ethercat-hal/src/io/stepper_velocity_wago_750_672.rs
@@ -20,7 +20,7 @@ pub struct StepperVelocityWago750672 {
 }
 
 impl StepperVelocityWago750672 {
-    pub fn new(device: Arc<RwLock<Wago750_672>>) -> Self {
+    pub const fn new(device: Arc<RwLock<Wago750_672>>) -> Self {
         Self {
             device,
             state: InitState::Off,
@@ -169,20 +169,24 @@ pub enum C1Command {
 }
 
 impl ControlByteC1 {
+    #[must_use]
     pub const fn new() -> Self {
         Self(0)
     }
 
+    #[must_use]
     pub const fn with_flag(mut self, flag: C1Flag) -> Self {
         self.0 |= flag as u8;
         self
     }
 
+    #[must_use]
     pub const fn with_command(mut self, cmd: C1Command) -> Self {
         self.0 = (self.0 & 0b0000_0111) | (cmd as u8);
         self
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -204,29 +208,35 @@ pub enum C2Flag {
 }
 
 impl ControlByteC2 {
+    #[must_use]
     pub const fn new() -> Self {
         Self(0)
     }
 
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn with_freq_range(mut self, sel: u8) -> Self {
         self.0 = (self.0 & 0b1111_1100) | (sel & 0b0000_0011);
         self
     }
 
+    #[must_use]
     pub const fn with_acc_range(mut self, sel: u8) -> Self {
         self.0 = (self.0 & 0b1111_0011) | ((sel & 0b0000_0011) << 2);
         self
     }
 
+    #[must_use]
     pub const fn with_flag(mut self, flag: C2Flag) -> Self {
         self.0 |= flag as u8;
         self
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -246,15 +256,18 @@ pub enum C3Flag {
 }
 
 impl ControlByteC3 {
+    #[must_use]
     pub const fn new() -> Self {
         Self(0)
     }
 
+    #[must_use]
     pub const fn with_flag(mut self, flag: C3Flag) -> Self {
         self.0 |= flag as u8;
         self
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -292,14 +305,17 @@ pub enum S1CommandAck {
 }
 
 impl StatusByteS1 {
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn has_flag(self, flag: S1Flag) -> bool {
         (self.0 & flag as u8) != 0
     }
 
+    #[must_use]
     pub const fn bits(self) -> u8 {
         self.0
     }
@@ -323,10 +339,12 @@ pub enum S2Flag {
 }
 
 impl StatusByteS2 {
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn has_flag(self, flag: S2Flag) -> bool {
         (self.0 & flag as u8) != 0
     }
@@ -350,10 +368,12 @@ pub enum S3Flag {
 }
 
 impl StatusByteS3 {
+    #[must_use]
     pub const fn from_bits(bits: u8) -> Self {
         Self(bits)
     }
 
+    #[must_use]
     pub const fn has_flag(self, flag: S3Flag) -> bool {
         (self.0 & flag as u8) != 0
     }

--- a/ethercat-hal/src/io/temperature_input.rs
+++ b/ethercat-hal/src/io/temperature_input.rs
@@ -43,7 +43,7 @@ impl TemperatureInput {
         } else if input.undervoltage {
             Err(TemperatureInputError::UnderVoltage)
         } else {
-            Ok(input.temperature as f64)
+            Ok(f64::from(input.temperature))
         }
     }
 }
@@ -84,10 +84,10 @@ pub struct TemperatureInputInput {
     /// Error flag
     pub error: bool,
 
-    /// if the TxPdo state is valid
+    /// if the `TxPdo` state is valid
     pub txpdo_state: bool,
 
-    /// if the TxPdo is toggled
+    /// if the `TxPdo` is toggled
     pub txpdo_toggle: bool,
 }
 

--- a/ethercat-hal/src/pdo/analog_input.rs
+++ b/ethercat-hal/src/pdo/analog_input.rs
@@ -3,7 +3,7 @@ use ethercat_hal_derive::PdoObject;
 
 use super::{TxPdoObject, basic::Limit};
 
-/// PDO Object for EL30xx devices
+/// PDO Object for `EL30xx` devices
 ///
 /// The value is accompanied by some metadata.
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
@@ -51,7 +51,7 @@ impl TxPdoObject for AiStandard {
     }
 }
 
-/// PDO Object for EL30xx devices
+/// PDO Object for `EL30xx` devices
 ///
 /// The value without metadata.
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]

--- a/ethercat-hal/src/pdo/basic.rs
+++ b/ethercat-hal/src/pdo/basic.rs
@@ -83,7 +83,7 @@ mod tests {
         object.value = true;
 
         let mut bits = BitSlice::<_, Lsb0>::from_slice_mut(&mut buffer);
-        object.write(&mut bits);
+        object.write(bits);
 
         assert_eq!(buffer[0], 1);
     }

--- a/ethercat-hal/src/pdo/basic.rs
+++ b/ethercat-hal/src/pdo/basic.rs
@@ -5,7 +5,7 @@ use super::{RxPdoObject, TxPdoObject};
 
 /// PDO Object that is just a bool
 ///
-/// Commonly sued in EL20xx devices
+/// Commonly sued in `EL20xx` devices
 #[derive(Debug, Clone, Default, PdoObject)]
 #[pdo_object(bits = 1)]
 pub struct BoolPdoObject {
@@ -26,7 +26,7 @@ impl RxPdoObject for BoolPdoObject {
 
 /// PDO Object that is just a f32
 ///
-/// Commonly used in EL30xx devices
+/// Commonly used in `EL30xx` devices
 #[derive(Debug, Clone, Default, PdoObject)]
 #[pdo_object(bits = 32)]
 pub struct F32PdoObject {
@@ -49,7 +49,7 @@ impl RxPdoObject for F32PdoObject {
 ///
 /// A u8 is used to map represent 4 states of a configured limit.
 /// The type of limit depends on the device.
-/// The threshhold value is configured via CoE and is commonly deactivated in the base configuration.
+/// The threshhold value is configured via `CoE` and is commonly deactivated in the base configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Default)]
 pub enum Limit {
     #[default]

--- a/ethercat-hal/src/pdo/el252x.rs
+++ b/ethercat-hal/src/pdo/el252x.rs
@@ -158,10 +158,10 @@ mod tests {
     #[test]
     fn test_pto_status() {
         // set all flags
-        let buffer = vec![0b0111_0011u8, 0b1010_0000u8];
+        let buffer = [0b0111_0011u8, 0b1010_0000u8];
         let bits = buffer.view_bits::<Lsb0>();
         let mut pdo_status = PtoStatus::default();
-        pdo_status.read(&bits);
+        pdo_status.read(bits);
         assert_eq!(
             pdo_status,
             PtoStatus {
@@ -173,17 +173,17 @@ mod tests {
                 sync_error: true,
                 txpdo_toggle: true
             }
-        )
+        );
     }
 
     #[test]
     fn test_enc_status() {
         // set all flags
         // set counter value to 0x12345678
-        let buffer = vec![0b0001_1100u8, 0b1010_0000u8, 0x78u8, 0x56u8, 0x34u8, 0x12u8];
+        let buffer = [0b0001_1100u8, 0b1010_0000u8, 0x78u8, 0x56u8, 0x34u8, 0x12u8];
         let bits = buffer.view_bits::<Lsb0>();
         let mut enc_status = EncStatus::default();
-        enc_status.read(&bits);
+        enc_status.read(bits);
 
         assert_eq!(
             enc_status,
@@ -195,7 +195,7 @@ mod tests {
                 txpdo_toggle: true,
                 counter_value: 0x12345678
             }
-        )
+        );
     }
 
     #[test]
@@ -210,8 +210,8 @@ mod tests {
             go_counter: true,
             frequency_value: 0x1234,
         };
-        pto_control.write(&mut bits);
-        assert_eq!(buffer, vec![0b0000_0111u8, 0u8, 0x34u8, 0x12u8])
+        pto_control.write(bits);
+        assert_eq!(buffer, vec![0b0000_0111u8, 0u8, 0x34u8, 0x12u8]);
     }
 
     #[test]
@@ -222,8 +222,8 @@ mod tests {
         let pto_target = PtoTarget {
             target_counter_value: 0x12345678,
         };
-        pto_target.write(&mut bits);
-        assert_eq!(buffer, vec![0x78u8, 0x56u8, 0x34u8, 0x12u8])
+        pto_target.write(bits);
+        assert_eq!(buffer, vec![0x78u8, 0x56u8, 0x34u8, 0x12u8]);
     }
 
     #[test]
@@ -236,10 +236,10 @@ mod tests {
             set_counter: true,
             set_counter_value: 0x12345678,
         };
-        enc_control.write(&mut bits);
+        enc_control.write(bits);
         assert_eq!(
             buffer,
             vec![0b0000_0100u8, 0u8, 0x78u8, 0x56u8, 0x34u8, 0x12u8]
-        )
+        );
     }
 }

--- a/ethercat-hal/src/pdo/el252x.rs
+++ b/ethercat-hal/src/pdo/el252x.rs
@@ -2,7 +2,7 @@ use super::{RxPdoObject, TxPdoObject};
 use bitvec::{field::BitField, order::Lsb0, slice::BitSlice};
 use ethercat_hal_derive::PdoObject;
 
-/// PDO Object for EL252x devices
+/// PDO Object for `EL252x` devices
 ///
 /// "PTO Status" contains status information about the pulse train output.
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
@@ -45,7 +45,7 @@ impl TxPdoObject for PtoStatus {
     }
 }
 
-/// PDO Object for EL252x devices
+/// PDO Object for `EL252x` devices
 ///
 /// "Encoder Status" contains the encoder status information.
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
@@ -85,7 +85,7 @@ impl TxPdoObject for EncStatus {
     }
 }
 
-/// PDO Object for EL252x devices
+/// PDO Object for `EL252x` devices
 ///
 /// "PTO Control" is used to control the pulse train output.
 #[derive(Debug, Clone, Default, PdoObject)]
@@ -112,7 +112,7 @@ impl RxPdoObject for PtoControl {
     }
 }
 
-/// PDO Object for EL252x devices
+/// PDO Object for `EL252x` devices
 ///
 /// "PTO Target" is used to set the target position of the pulse train output.
 #[derive(Debug, Clone, Default, PdoObject)]
@@ -130,7 +130,7 @@ impl RxPdoObject for PtoTarget {
     }
 }
 
-/// PDO Object for EL252x devices
+/// PDO Object for `EL252x` devices
 ///
 /// "Encoder Control" is used to control the encoder.
 #[derive(Debug, Clone, Default, PdoObject)]

--- a/ethercat-hal/src/pdo/el32xx.rs
+++ b/ethercat-hal/src/pdo/el32xx.rs
@@ -3,7 +3,7 @@ use ethercat_hal_derive::PdoObject;
 
 use super::{TxPdoObject, basic::Limit};
 
-/// PDO Object for EL32xx (temperature sensing) devices
+/// PDO Object for `EL32xx` (temperature sensing) devices
 ///
 /// The "RTD Input" holds the value of a temperature sensor accompanied by some metadata.
 #[derive(Debug, Clone, Default, PdoObject, PartialEq)]
@@ -42,7 +42,7 @@ impl TxPdoObject for RtdInput {
             return;
         }
 
-        self.temperature = (bits[16..16 + 16].load_le::<i16>() as f32) / 10.0;
+        self.temperature = f32::from(bits[16..16 + 16].load_le::<i16>()) / 10.0;
         self.undervoltage = bits[0];
         self.overvoltage = bits[1];
         self.limit1 = bits[2..4].load_le::<u8>().into();

--- a/ethercat-hal/src/pdo/el40xx.rs
+++ b/ethercat-hal/src/pdo/el40xx.rs
@@ -167,8 +167,7 @@ mod tests {
             let read_value: i16 = bits[0..16].load_le();
             assert_eq!(
                 read_value, test_value,
-                "Failed round-trip for value: {}",
-                test_value
+                "Failed round-trip for value: {test_value}"
             );
         }
     }
@@ -226,7 +225,7 @@ mod tests {
     #[test]
     fn test_analog_output_debug() {
         let analog_output = AnalogOutput { value: 42 };
-        let debug_string = format!("{:?}", analog_output);
+        let debug_string = format!("{analog_output:?}");
 
         // Should contain the struct name and value
         assert!(debug_string.contains("AnalogOutput"));

--- a/ethercat-hal/src/pdo/el40xx.rs
+++ b/ethercat-hal/src/pdo/el40xx.rs
@@ -2,7 +2,7 @@ use super::RxPdoObject;
 use bitvec::prelude::*;
 use ethercat_hal_derive::PdoObject;
 
-/// PDO Object for EL40xx (analog output) devices
+/// PDO Object for `EL40xx` (analog output) devices
 ///
 /// The "Analog Output" holds the output value and status information.
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]

--- a/ethercat-hal/src/pdo/el5152.rs
+++ b/ethercat-hal/src/pdo/el5152.rs
@@ -2,7 +2,7 @@ use super::{RxPdoObject, TxPdoObject};
 use bitvec::prelude::*;
 use ethercat_hal_derive::PdoObject;
 
-/// PDO Object for EL5152 encoder control (RxPDO)
+/// PDO Object for EL5152 encoder control (`RxPDO`)
 /// Based on 1600/1602 mapping: Set counter (1 bit) + alignment + Set counter value (32/16 bit)
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 48)] // Total 48 bits for full mapping
@@ -22,7 +22,7 @@ impl RxPdoObject for El5152EncoderControl {
     }
 }
 
-/// PDO Object for EL5152 encoder status (TxPDO)
+/// PDO Object for EL5152 encoder status (`TxPDO`)
 /// Based on 1A00/1A04 mapping: Status bits + Counter value (32-bit)
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 48)] // 16 bits status + 32 bits counter
@@ -37,7 +37,7 @@ pub struct El5152EncoderStatus {
     pub status_input_b: bool,
     /// Sync Error - synchronization error occurred (1 bit) - 0x1C32:20
     pub sync_error: bool,
-    /// TxPDO Toggle - toggled when TxPDO data is updated (1 bit) - 0x1800:09
+    /// `TxPDO` Toggle - toggled when `TxPDO` data is updated (1 bit) - 0x1800:09
     pub txpdo_toggle: bool,
     /// Counter value (32-bit) - 0x6000:11
     pub counter_value: u32,
@@ -63,7 +63,7 @@ impl TxPdoObject for El5152EncoderStatus {
     }
 }
 
-/// PDO Object for EL5152 encoder frequency measurement (TxPDO)
+/// PDO Object for EL5152 encoder frequency measurement (`TxPDO`)
 /// Based on 1A03/1A07 mapping: 32-bit frequency value only
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]
@@ -79,7 +79,7 @@ impl TxPdoObject for El5152EncoderFrequency {
     }
 }
 
-/// PDO Object for EL5152 encoder period measurement (TxPDO)
+/// PDO Object for EL5152 encoder period measurement (`TxPDO`)
 /// Based on 1A02/1A06 mapping: 32-bit period value only
 #[derive(Debug, Clone, Default, PdoObject, PartialEq, Eq)]
 #[pdo_object(bits = 32)]

--- a/ethercat-hal/src/pdo/el70x1.rs
+++ b/ethercat-hal/src/pdo/el70x1.rs
@@ -36,7 +36,7 @@ pub struct EncStatusCompact {
     pub sync_error: bool,
 
     /// # 6000:10
-    /// The TxPDO toggle is toggled by the slave when the data of the associated TxPDO is updated.
+    /// The `TxPDO` toggle is toggled by the slave when the data of the associated `TxPDO` is updated.
     pub txpdo_toggle: bool,
 
     /// # 6000:11
@@ -110,7 +110,7 @@ pub struct EncStatus {
     pub sync_error: bool,
 
     /// # 6000:10
-    /// The TxPDO toggle is toggled by the slave when the data of the associated TxPDO is updated.
+    /// The `TxPDO` toggle is toggled by the slave when the data of the associated `TxPDO` is updated.
     pub txpdo_toggle: bool,
 
     /// # 6000:11
@@ -212,7 +212,7 @@ pub struct StmStatus {
     pub sync_error: bool,
 
     /// # 6010:10
-    /// The TxPDO toggle is toggled by the slave when the data of the associated TxPDO is updated.
+    /// The `TxPDO` toggle is toggled by the slave when the data of the associated `TxPDO` is updated.
     pub txpdo_toggle: bool,
 }
 

--- a/ethercat-hal/src/pdo/mod.rs
+++ b/ethercat-hal/src/pdo/mod.rs
@@ -222,7 +222,7 @@ pub trait TxPdo: Configuration {
     /// Will give the PDU bit array to the PDO objects to decode the data
     fn read(&mut self, buffer: &BitSlice<u8, Lsb0>) -> Result<(), anyhow::Error> {
         let mut bit_offset = 0;
-        for object in self.get_objects_mut().iter_mut() {
+        for object in &mut self.get_objects_mut() {
             if let Some(object) = object {
                 let end_bit_index = bit_offset + object.size();
 

--- a/ethercat-hal/src/shared_config/el40xx.rs
+++ b/ethercat-hal/src/shared_config/el40xx.rs
@@ -8,7 +8,7 @@ pub struct EL40XXChannelConfiguration {
     /// Presentation mode (0x80n0:02) - Default: Signed (0x00)
     pub presentation: EL40XXPresentation,
 
-    /// Watchdog behavior (0x80n0:05) - Default: DefaultValue (0x00)
+    /// Watchdog behavior (0x80n0:05) - Default: `DefaultValue` (0x00)
     pub watchdog: EL40XXWatchdog,
 
     /// Enable user calibration (0x80n0:07) - Default: false (0x00)
@@ -117,7 +117,7 @@ impl EL40XXChannelConfiguration {
 
         // Write all configuration parameters according to the documentation table
         device
-            .sdo_write(base_index, 0x01, self.enable_user_scale as u8)
+            .sdo_write(base_index, 0x01, u8::from(self.enable_user_scale))
             .await?;
         device
             .sdo_write(base_index, 0x02, self.presentation.clone() as u8)
@@ -126,10 +126,10 @@ impl EL40XXChannelConfiguration {
             .sdo_write(base_index, 0x05, self.watchdog.clone() as u8)
             .await?;
         device
-            .sdo_write(base_index, 0x07, self.enable_user_calibration as u8)
+            .sdo_write(base_index, 0x07, u8::from(self.enable_user_calibration))
             .await?;
         device
-            .sdo_write(base_index, 0x08, self.enable_vendor_calibration as u8)
+            .sdo_write(base_index, 0x08, u8::from(self.enable_vendor_calibration))
             .await?;
         device.sdo_write(base_index, 0x11, self.offset).await?;
         device.sdo_write(base_index, 0x12, self.gain).await?;

--- a/ethercat-hal/src/shared_config/el70x1.rs
+++ b/ethercat-hal/src/shared_config/el70x1.rs
@@ -578,7 +578,7 @@ impl TryFrom<u16> for StartType {
             28416 => Ok(Self::CalibrationClearManual),
             28160 => Ok(Self::CalibrationSetManual),
             28161 => Ok(Self::CalibrationSetManualAuto),
-            _ => Err(anyhow::anyhow!("Invalid value for StartType: {}", value)),
+            _ => Err(anyhow::anyhow!("Invalid value for StartType: {value}")),
         }
     }
 }
@@ -714,8 +714,7 @@ impl TryFrom<u8> for EL70x1OperationMode {
             2 => Ok(Self::VelocityController),
             3 => Ok(Self::PositionController),
             _ => Err(anyhow::anyhow!(
-                "Invalid value for EL7031OperationMode: {}",
-                value
+                "Invalid value for EL7031OperationMode: {value}"
             )),
         }
     }
@@ -769,8 +768,7 @@ impl TryFrom<u8> for EL70x1SpeedRange {
             4 => Ok(Self::Steps16000),
             5 => Ok(Self::Steps32000),
             _ => Err(anyhow::anyhow!(
-                "Invalid value for EL7031SpeedRange: {}",
-                value
+                "Invalid value for EL7031SpeedRange: {value}"
             )),
         }
     }
@@ -859,10 +857,7 @@ impl TryFrom<u8> for EL70x1InfoData {
             151 => Ok(Self::DriveState),
             152 => Ok(Self::DrivePositionLagLow),
             153 => Ok(Self::DrivePositionLagHigh),
-            _ => Err(anyhow::anyhow!(
-                "Invalid value for EL7031InfoData: {}",
-                value
-            )),
+            _ => Err(anyhow::anyhow!("Invalid value for EL7031InfoData: {value}")),
         }
     }
 }
@@ -907,8 +902,7 @@ impl TryFrom<u8> for EL70x1InputFunction {
             2 => Ok(Self::PlcCam),
             3 => Ok(Self::AutoStart),
             _ => Err(anyhow::anyhow!(
-                "Invalid value for EL7031InputFunction: {}",
-                value
+                "Invalid value for EL7031InputFunction: {value}"
             )),
         }
     }

--- a/machines/src/aquapath1/act.rs
+++ b/machines/src/aquapath1/act.rs
@@ -5,11 +5,8 @@ use std::time::{Duration, Instant};
 impl MachineAct for AquaPathV1 {
     fn act(&mut self, now_ts: Instant) {
         let msg = self.api_receiver.try_recv();
-        match msg {
-            Ok(msg) => {
-                let _res = self.act_machine_message(msg);
-            }
-            Err(_) => (),
+        if let Ok(msg) = msg {
+            self.act_machine_message(msg);
         };
 
         match self.mode {

--- a/machines/src/aquapath1/api.rs
+++ b/machines/src/aquapath1/api.rs
@@ -216,9 +216,8 @@ impl NamespaceCacheingLogic<AquaPathV1Events> for AquaPathV1Namespace {
     fn emit(&mut self, events: AquaPathV1Events) {
         let event = Arc::new(events.event_value());
         let buffer_fn = events.event_cache_fn();
-        match &mut self.namespace {
-            Some(ns) => ns.emit(event, &buffer_fn),
-            None => (),
+        if let Some(ns) = &mut self.namespace {
+            ns.emit(event, &buffer_fn)
         }
     }
 }

--- a/machines/src/aquapath1/controller.rs
+++ b/machines/src/aquapath1/controller.rs
@@ -211,17 +211,17 @@ impl Controller {
             max_temperature: ThermodynamicTemperature::new::<degree_celsius>(80.0),
 
             temperature: temp,
-            cooling_controller: cooling_controller,
+            cooling_controller,
 
             cooling_tolerance: config.cooling.tolerance,
             heating_tolerance: config.heating_tolerance,
 
             current_revolutions: AngularVelocity::new::<revolution_per_minute>(0.0),
-            max_revolutions: max_revolutions,
+            max_revolutions,
             cooling_mode: None,
 
-            cooling_relais: cooling_relais,
-            heating_relais: heating_relais,
+            cooling_relais,
+            heating_relais,
 
             cooling_allowed: false,
             heating_allowed: false,
@@ -231,9 +231,9 @@ impl Controller {
             power: 0.0,
             total_energy: 0.0,
 
-            flow: flow,
-            pump_relais: pump_relais,
-            flow_sensor: flow_sensor,
+            flow,
+            pump_relais,
+            flow_sensor,
             should_pump: false,
             pump_started_at: None,
             flow_became_valid_at: None,
@@ -386,9 +386,7 @@ impl Controller {
                 let actual_flow = ((val / 100) as f32 + 3.0) / 8.1;
                 VolumeRate::new::<liter_per_minute>(actual_flow.into())
             }
-            None => {
-                return VolumeRate::new::<liter_per_minute>(0.0);
-            }
+            None => VolumeRate::new::<liter_per_minute>(0.0),
         }
     }
 
@@ -588,7 +586,7 @@ impl Controller {
         self.last_cooling_switch = now;
     }
 
-    pub fn update(&mut self, now: Instant) -> () {
+    pub fn update(&mut self, now: Instant) {
         let dt = now.duration_since(self.last_update).as_secs_f64();
         self.last_update = now;
 

--- a/machines/src/aquapath1/mod.rs
+++ b/machines/src/aquapath1/mod.rs
@@ -49,7 +49,7 @@ pub struct Temperature {
 
 impl Machine for AquaPathV1 {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/aquapath1/new.rs
+++ b/machines/src/aquapath1/new.rs
@@ -36,11 +36,7 @@ use units::{
 impl MachineNewTrait for AquaPathV1 {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -102,7 +98,7 @@ impl MachineNewTrait for AquaPathV1 {
             el5152
                 .write()
                 .await
-                .write_config(&subdevice, &config)
+                .write_config(subdevice, &config)
                 .await?;
 
             let enc1 = EncoderInput::new(el5152.clone(), EL5152Port::ENC1);

--- a/machines/src/buffer1/act.rs
+++ b/machines/src/buffer1/act.rs
@@ -5,11 +5,8 @@ use std::time::{Duration, Instant};
 impl MachineAct for BufferV1 {
     fn act(&mut self, now: Instant) {
         let msg = self.api_receiver.try_recv();
-        match msg {
-            Ok(msg) => {
-                let _res = self.act_machine_message(msg);
-            }
-            Err(_) => (),
+        if let Ok(msg) = msg {
+            self.act_machine_message(msg);
         };
         // if last measurement is older than 1 second, emit a new measurement
         if now.duration_since(self.last_measurement_emit) > Duration::from_secs_f64(1.0 / 30.0) {

--- a/machines/src/buffer1/api.rs
+++ b/machines/src/buffer1/api.rs
@@ -78,9 +78,8 @@ impl NamespaceCacheingLogic<BufferV1Events> for Buffer1Namespace {
         let event = Arc::new(events.event_value());
         let buffer_fn = events.event_cache_fn();
 
-        match &mut self.namespace {
-            Some(ns) => ns.emit(event, &buffer_fn),
-            None => (),
+        if let Some(ns) = &mut self.namespace {
+            ns.emit(event, &buffer_fn)
         }
     }
 }

--- a/machines/src/buffer1/mod.rs
+++ b/machines/src/buffer1/mod.rs
@@ -29,7 +29,7 @@ pub struct BufferV1 {
 
 impl Machine for BufferV1 {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/buffer1/new.rs
+++ b/machines/src/buffer1/new.rs
@@ -75,7 +75,7 @@ impl MachineNewTrait for BufferV1 {
             el7041
                 .write()
                 .await
-                .write_config(&subdevice, &el7041_config)
+                .write_config(subdevice, &el7041_config)
                 .await?;
             {
                 let mut device_guard = el7041.write().await;
@@ -110,7 +110,7 @@ impl MachineNewTrait for BufferV1 {
             el7031
                 .write()
                 .await
-                .write_config(&subdevice, &el7031_config)
+                .write_config(subdevice, &el7031_config)
                 .await?;
             {
                 let mut device_guard = el7031.write().await;
@@ -137,7 +137,7 @@ impl MachineNewTrait for BufferV1 {
                 last_measurement_emit: Instant::now(),
                 mode: BufferV1Mode::Standby,
                 buffer_tower_controller,
-                machine_identification_unique: machine_identification_unique.clone(),
+                machine_identification_unique,
             };
             buffer.emit_state();
             Ok(buffer)

--- a/machines/src/extruder1/act.rs
+++ b/machines/src/extruder1/act.rs
@@ -9,11 +9,8 @@ use std::time::{Duration, Instant};
 impl MachineAct for ExtruderV2 {
     fn act(&mut self, now: Instant) {
         let msg = self.api_receiver.try_recv();
-        match msg {
-            Ok(msg) => {
-                let _res = self.act_machine_message(msg);
-            }
-            Err(_) => (),
+        if let Ok(msg) = msg {
+            self.act_machine_message(msg);
         };
 
         self.temperature_controller_back.update(now);

--- a/machines/src/extruder1/api.rs
+++ b/machines/src/extruder1/api.rs
@@ -296,9 +296,8 @@ impl NamespaceCacheingLogic<ExtruderV2Events> for ExtruderV2Namespace {
         let event = Arc::new(events.event_value());
         let buffer_fn = events.event_cache_fn();
 
-        match &mut self.namespace {
-            Some(ns) => ns.emit(event, &buffer_fn),
-            None => (),
+        if let Some(ns) = &mut self.namespace {
+            ns.emit(event, &buffer_fn)
         }
     }
 }

--- a/machines/src/extruder1/mod.rs
+++ b/machines/src/extruder1/mod.rs
@@ -106,7 +106,7 @@ pub use mock::ExtruderV2;
 #[cfg(not(feature = "mock-machine"))]
 impl Machine for ExtruderV2 {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/extruder1/new.rs
+++ b/machines/src/extruder1/new.rs
@@ -107,7 +107,7 @@ impl MachineNewTrait for ExtruderV2 {
                     .0
                     .write()
                     .await
-                    .write_config(&device.1, &EL6021Configuration::default())
+                    .write_config(device.1, &EL6021Configuration::default())
                     .await?;
                 {
                     let mut device_guard = device.0.write().await;

--- a/machines/src/extruder1/screw_speed_controller.rs
+++ b/machines/src/extruder1/screw_speed_controller.rs
@@ -71,7 +71,7 @@ impl ScrewSpeedController {
             pressure_sensor,
             uses_rpm: true,
             forward_rotation: true,
-            transmission: transmission,
+            transmission,
             //FixedTransmission::new(1.0 / 34.0),
             motor_on: false,
             nozzle_pressure_limit: Pressure::new::<bar>(100.0),
@@ -144,7 +144,7 @@ impl ScrewSpeedController {
         self.target_rpm = target_rpm;
 
         let target_frequency: Frequency = Frequency::new::<hertz>(
-            target_motor_rpm.get::<revolution_per_minute>() as f64 / 120.0 * motor_poles as f64,
+            target_motor_rpm.get::<revolution_per_minute>() / 120.0 * motor_poles as f64,
         );
 
         self.inverter.set_frequency_target(target_frequency);
@@ -263,33 +263,33 @@ impl ScrewSpeedController {
 
         if !self.uses_rpm && is_extruding {
             // ── Auto-tuning (bang-bang relay control) ──────────────────────────
-            if let Some(ref mut tuner) = self.pid_autotuner {
-                if tuner.is_running() {
-                    let duty_cycle = tuner.update(measured_pressure.get::<bar>(), now);
+            if let Some(ref mut tuner) = self.pid_autotuner
+                && tuner.is_running()
+            {
+                let duty_cycle = tuner.update(measured_pressure.get::<bar>(), now);
 
-                    if tuner.is_completed() {
-                        // Automatically apply the tuned PID parameters
-                        if let Ok(result) = tuner.result() {
-                            self.pid.configure(result.ki, result.kp, result.kd);
-                            tracing::info!(
-                                "Pressure PID auto-tune completed: Kp={:.4}, Ki={:.4}, Kd={:.4}",
-                                result.kp,
-                                result.ki,
-                                result.kd
-                            );
-                        }
+                if tuner.is_completed() {
+                    // Automatically apply the tuned PID parameters
+                    if let Ok(result) = tuner.result() {
+                        self.pid.configure(result.ki, result.kp, result.kd);
+                        tracing::info!(
+                            "Pressure PID auto-tune completed: Kp={:.4}, Ki={:.4}, Kd={:.4}",
+                            result.kp,
+                            result.ki,
+                            result.kd
+                        );
                     }
-
-                    let target_freq = if duty_cycle > 0.0 {
-                        self.autotune_high_frequency
-                    } else {
-                        self.autotune_low_frequency
-                    };
-                    self.frequency = target_freq;
-                    self.inverter.set_frequency_target(target_freq);
-                    self.last_update = now;
-                    return;
                 }
+
+                let target_freq = if duty_cycle > 0.0 {
+                    self.autotune_high_frequency
+                } else {
+                    self.autotune_low_frequency
+                };
+                self.frequency = target_freq;
+                self.inverter.set_frequency_target(target_freq);
+                self.last_update = now;
+                return;
             }
 
             // ── Normal PID pressure control ────────────────────────────────────

--- a/machines/src/extruder2/act.rs
+++ b/machines/src/extruder2/act.rs
@@ -13,11 +13,8 @@ impl MachineAct for ExtruderV3 {
         use std::time::Duration;
 
         let msg = self.api_receiver.try_recv();
-        match msg {
-            Ok(msg) => {
-                let _res = self.act_machine_message(msg);
-            }
-            Err(_) => (),
+        if let Ok(msg) = msg {
+            self.act_machine_message(msg);
         };
 
         self.temperature_controller_back.update(now);

--- a/machines/src/extruder2/api.rs
+++ b/machines/src/extruder2/api.rs
@@ -173,9 +173,8 @@ impl NamespaceCacheingLogic<ExtruderV3Events> for ExtruderV3Namespace {
         let event = Arc::new(events.event_value());
         let buffer_fn = events.event_cache_fn();
 
-        match &mut self.namespace {
-            Some(ns) => ns.emit(event, &buffer_fn),
-            None => (),
+        if let Some(ns) = &mut self.namespace {
+            ns.emit(event, &buffer_fn)
         }
     }
 }

--- a/machines/src/extruder2/mod.rs
+++ b/machines/src/extruder2/mod.rs
@@ -84,7 +84,7 @@ pub struct ExtruderV3 {
 #[cfg(not(feature = "mock-machine"))]
 impl Machine for ExtruderV3 {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/extruder2/new.rs
+++ b/machines/src/extruder2/new.rs
@@ -106,7 +106,7 @@ impl MachineNewTrait for ExtruderV3 {
                     .0
                     .write()
                     .await
-                    .write_config(&device.1, &EL6021Configuration::default())
+                    .write_config(device.1, &EL6021Configuration::default())
                     .await?;
                 {
                     let mut device_guard = device.0.write().await;

--- a/machines/src/laser/act.rs
+++ b/machines/src/laser/act.rs
@@ -22,11 +22,8 @@ use std::time::{Duration, Instant};
 impl MachineAct for LaserMachine {
     fn act(&mut self, now: Instant) {
         let msg = self.api_receiver.try_recv();
-        match msg {
-            Ok(msg) => {
-                let _res = self.act_machine_message(msg);
-            }
-            Err(_) => (),
+        if let Ok(msg) = msg {
+            self.act_machine_message(msg);
         };
         self.update();
 
@@ -70,8 +67,6 @@ impl MachineAct for LaserMachine {
                     })
                     .expect("Failed to send values");
                 sender.close();
-
-                ()
             }
         }
     }

--- a/machines/src/laser/api.rs
+++ b/machines/src/laser/api.rs
@@ -100,9 +100,8 @@ impl NamespaceCacheingLogic<LaserEvents> for LaserMachineNamespace {
         let event = Arc::new(events.event_value());
         let buffer_fn = events.event_cache_fn();
 
-        match &mut self.namespace {
-            Some(ns) => ns.emit(event, &buffer_fn),
-            None => (),
+        if let Some(ns) = &mut self.namespace {
+            ns.emit(event, &buffer_fn)
         }
     }
 }

--- a/machines/src/laser/mod.rs
+++ b/machines/src/laser/mod.rs
@@ -61,7 +61,7 @@ pub struct LaserMachine {
 
 impl Machine for LaserMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {
@@ -108,8 +108,8 @@ impl LaserMachineNamespace {
         if self.namespace.is_none() {
             return vec![];
         }
-        let sockets = self.namespace.clone().unwrap().sockets.clone();
-        sockets
+
+        self.namespace.clone().unwrap().sockets.clone()
     }
 }
 
@@ -247,11 +247,7 @@ impl LaserMachine {
         let top = self.target_diameter + self.higher_tolerance;
         let bottom = self.target_diameter - self.lower_tolerance;
 
-        if self.diameter > top || self.diameter < bottom {
-            self.in_tolerance = false;
-        } else {
-            self.in_tolerance = true;
-        }
+        self.in_tolerance = !(self.diameter > top || self.diameter < bottom);
 
         self.in_tolerance
     }

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -105,7 +105,6 @@ impl MachineNewParams<'_, '_, '_, '_, '_, '_, '_> {
             .expect("device group must have at least one device")
             .device_machine_identification
             .machine_identification_unique
-            .clone()
     }
 }
 
@@ -384,7 +383,7 @@ async fn get_device_ident<
                 ));
             }
         };
-    return Ok(device_hardware_identification_ethercat.clone());
+    Ok(device_hardware_identification_ethercat.clone())
 }
 
 async fn get_ethercat_device<
@@ -451,8 +450,7 @@ where
         ));
     }
 
-    let ethercat_device =
-        get_ethercat_device_by_index(&hardware.ethercat_devices, subdevice_index)?;
+    let ethercat_device = get_ethercat_device_by_index(hardware.ethercat_devices, subdevice_index)?;
     let device = downcast_device::<T>(ethercat_device).await?;
 
     {
@@ -589,9 +587,7 @@ where
     C: MachineWithChannel + 'static,
 {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.get_machine_channel()
-            .machine_identification_unique
-            .clone()
+        self.get_machine_channel().machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/machine_identification.rs
+++ b/machines/src/machine_identification.rs
@@ -432,6 +432,4 @@ pub fn get_identification_addresses(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-}
+mod tests {}

--- a/machines/src/minimal_machines/analog_input_test_machine/mod.rs
+++ b/machines/src/minimal_machines/analog_input_test_machine/mod.rs
@@ -30,7 +30,7 @@ pub struct AnalogInputTestMachine {
 
 impl Machine for AnalogInputTestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/analog_input_test_machine/new.rs
+++ b/machines/src/minimal_machines/analog_input_test_machine/new.rs
@@ -16,11 +16,7 @@ use crate::{
 impl MachineNewTrait for AnalogInputTestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 

--- a/machines/src/minimal_machines/digital_input_test_machine/mod.rs
+++ b/machines/src/minimal_machines/digital_input_test_machine/mod.rs
@@ -28,7 +28,7 @@ pub struct DigitalInputTestMachine {
 
 impl Machine for DigitalInputTestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/digital_input_test_machine/new.rs
+++ b/machines/src/minimal_machines/digital_input_test_machine/new.rs
@@ -20,11 +20,7 @@ use crate::{
 impl MachineNewTrait for DigitalInputTestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -57,7 +53,7 @@ impl MachineNewTrait for DigitalInputTestMachine {
             }
 
             coupler.init_slot_modules(_wago_750_354.1);
-            let dev = coupler.slot_devices.get(0).unwrap().clone().unwrap();
+            let dev = coupler.slot_devices.first().unwrap().clone().unwrap();
             let wago750_402: Arc<RwLock<Wago750_402>> = downcast_device::<Wago750_402>(dev).await?;
 
             let di1 = DigitalInput::new(wago750_402.clone(), Wago750_402InputPort::DI1);

--- a/machines/src/minimal_machines/ip20_test_machine/mod.rs
+++ b/machines/src/minimal_machines/ip20_test_machine/mod.rs
@@ -31,7 +31,7 @@ pub struct IP20TestMachine {
 
 impl Machine for IP20TestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/ip20_test_machine/new.rs
+++ b/machines/src/minimal_machines/ip20_test_machine/new.rs
@@ -18,11 +18,7 @@ use ethercat_hal::io::digital_output::DigitalOutput;
 impl MachineNewTrait for IP20TestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 

--- a/machines/src/minimal_machines/mock/act.rs
+++ b/machines/src/minimal_machines/mock/act.rs
@@ -21,11 +21,8 @@ use std::time::{Duration, Instant};
 impl MachineAct for MockMachine {
     fn act(&mut self, now: Instant) {
         let msg = self.api_receiver.try_recv();
-        match msg {
-            Ok(msg) => {
-                let _res = self.act_machine_message(msg);
-            }
-            Err(_) => (),
+        if let Ok(msg) = msg {
+            self.act_machine_message(msg);
         };
         // Only emit live values if machine is in Running mode
         // The live values are updated approximately 30 times per second

--- a/machines/src/minimal_machines/mock/api.rs
+++ b/machines/src/minimal_machines/mock/api.rs
@@ -95,9 +95,8 @@ impl NamespaceCacheingLogic<MockEvents> for MockMachineNamespace {
         let event = Arc::new(events.event_value());
         let buffer_fn = events.event_cache_fn();
 
-        match &mut self.namespace {
-            Some(ns) => ns.emit(event, &buffer_fn),
-            None => (),
+        if let Some(ns) = &mut self.namespace {
+            ns.emit(event, &buffer_fn)
         }
     }
 }

--- a/machines/src/minimal_machines/mock/mod.rs
+++ b/machines/src/minimal_machines/mock/mod.rs
@@ -44,7 +44,7 @@ pub struct MockMachine {
 
 impl Machine for MockMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/motor_test_machine/mod.rs
+++ b/machines/src/minimal_machines/motor_test_machine/mod.rs
@@ -29,7 +29,7 @@ pub struct MotorTestMachine {
 
 impl Machine for MotorTestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/motor_test_machine/new.rs
+++ b/machines/src/minimal_machines/motor_test_machine/new.rs
@@ -19,7 +19,7 @@ use ethercat_hal::shared_config::el70x1::{EL70x1OperationMode, StmMotorConfigura
 impl MachineNewTrait for MotorTestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         println!("[{}::new] Creating new MotorTestMachine", module_path!());
-        let device_identification = params.device_group.iter().cloned().collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -61,7 +61,7 @@ impl MachineNewTrait for MotorTestMachine {
                     .0
                     .write()
                     .await
-                    .write_config(&device.1, &el7031_config)
+                    .write_config(device.1, &el7031_config)
                     .await?;
 
                 device.0

--- a/machines/src/minimal_machines/test_machine/mod.rs
+++ b/machines/src/minimal_machines/test_machine/mod.rs
@@ -25,7 +25,7 @@ pub struct TestMachine {
 
 impl Machine for TestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/test_machine/new.rs
+++ b/machines/src/minimal_machines/test_machine/new.rs
@@ -23,11 +23,7 @@ use std::sync::Arc;
 impl MachineNewTrait for TestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 

--- a/machines/src/minimal_machines/test_machine_stepper/mod.rs
+++ b/machines/src/minimal_machines/test_machine_stepper/mod.rs
@@ -25,7 +25,7 @@ pub struct TestMachineStepper {
 
 impl Machine for TestMachineStepper {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/test_machine_stepper/new.rs
+++ b/machines/src/minimal_machines/test_machine_stepper/new.rs
@@ -22,11 +22,7 @@ use anyhow::Error;
 impl MachineNewTrait for TestMachineStepper {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 

--- a/machines/src/minimal_machines/wago_750_430_di_machine/mod.rs
+++ b/machines/src/minimal_machines/wago_750_430_di_machine/mod.rs
@@ -28,7 +28,7 @@ pub struct Wago750_430DiMachine {
 
 impl Machine for Wago750_430DiMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/wago_750_430_di_machine/new.rs
+++ b/machines/src/minimal_machines/wago_750_430_di_machine/new.rs
@@ -19,11 +19,7 @@ use crate::{
 
 impl MachineNewTrait for Wago750_430DiMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -58,7 +54,7 @@ impl MachineNewTrait for Wago750_430DiMachine {
             coupler.init_slot_modules(_wago_750_354.1);
 
             // Get the WAGO 750-430 8CH DI module at slot 0
-            let dev = coupler.slot_devices.get(0).unwrap().clone().unwrap();
+            let dev = coupler.slot_devices.first().unwrap().clone().unwrap();
             let wago750_430: Arc<RwLock<Wago750_430>> = downcast_device::<Wago750_430>(dev).await?;
 
             let di1 = DigitalInput::new(wago750_430.clone(), Wago750_430Port::Port1);

--- a/machines/src/minimal_machines/wago_750_460_machine/mod.rs
+++ b/machines/src/minimal_machines/wago_750_460_machine/mod.rs
@@ -30,7 +30,7 @@ pub struct Wago750_460Machine {
 
 impl Machine for Wago750_460Machine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/wago_750_460_machine/new.rs
+++ b/machines/src/minimal_machines/wago_750_460_machine/new.rs
@@ -20,11 +20,7 @@ use crate::{
 
 impl MachineNewTrait for Wago750_460Machine {
     fn new(params: &MachineNewParams) -> Result<Self, Error> {
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|d| d.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -59,7 +55,7 @@ impl MachineNewTrait for Wago750_460Machine {
             // Retrieve the 750-460 module from slot 0.
             let dev = coupler
                 .slot_devices
-                .get(0)
+                .first()
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "[{}::Wago750_460Machine::new] No device in slot 0",

--- a/machines/src/minimal_machines/wago_750_501_test_machine/mod.rs
+++ b/machines/src/minimal_machines/wago_750_501_test_machine/mod.rs
@@ -28,7 +28,7 @@ pub struct Wago750_501TestMachine {
 
 impl Machine for Wago750_501TestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/wago_750_501_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_750_501_test_machine/new.rs
@@ -18,11 +18,7 @@ use std::sync::Arc;
 
 impl MachineNewTrait for Wago750_501TestMachine {
     fn new(params: &MachineNewParams) -> Result<Self, Error> {
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -54,8 +50,7 @@ impl MachineNewTrait for Wago750_501TestMachine {
 
             coupler.init_slot_modules(_wago_750_354.1);
             let dev = coupler
-                .slot_devices
-                .get(0)
+                .slot_devices.first()
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "[{}::MachineNewTrait/Wago750_501TestMachine::new] Expected Wago 750-501 module in slot 0, but slot 0 is not configured",

--- a/machines/src/minimal_machines/wago_750_553_machine/mod.rs
+++ b/machines/src/minimal_machines/wago_750_553_machine/mod.rs
@@ -29,7 +29,7 @@ pub struct Wago750_553Machine {
 
 impl Machine for Wago750_553Machine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/wago_750_553_machine/new.rs
+++ b/machines/src/minimal_machines/wago_750_553_machine/new.rs
@@ -20,11 +20,7 @@ use crate::{
 
 impl MachineNewTrait for Wago750_553Machine {
     fn new(params: &MachineNewParams) -> Result<Self, Error> {
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|d| d.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -55,8 +51,7 @@ impl MachineNewTrait for Wago750_553Machine {
             coupler.init_slot_modules(coupler_subdev);
 
             let dev = coupler
-                .slot_devices
-                .get(0)
+                .slot_devices.first()
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "[{}::Wago750_553Machine::new] Expected Wago 750-553 module in slot 0, but slot 0 is not configured",

--- a/machines/src/minimal_machines/wago_8ch_dio_test_machine/mod.rs
+++ b/machines/src/minimal_machines/wago_8ch_dio_test_machine/mod.rs
@@ -30,7 +30,7 @@ pub struct Wago8chDigitalIOTestMachine {
 
 impl Machine for Wago8chDigitalIOTestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/wago_8ch_dio_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_8ch_dio_test_machine/new.rs
@@ -22,11 +22,7 @@ use crate::{
 impl MachineNewTrait for Wago8chDigitalIOTestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -59,7 +55,7 @@ impl MachineNewTrait for Wago8chDigitalIOTestMachine {
             }
 
             coupler.init_slot_modules(_wago_750_354.1);
-            let dev = coupler.slot_devices.get(0).unwrap().clone().unwrap();
+            let dev = coupler.slot_devices.first().unwrap().clone().unwrap();
             let wago750_1506: Arc<RwLock<Wago750_1506>> =
                 downcast_device::<Wago750_1506>(dev).await?;
 

--- a/machines/src/minimal_machines/wago_ai_test_machine/mod.rs
+++ b/machines/src/minimal_machines/wago_ai_test_machine/mod.rs
@@ -30,7 +30,7 @@ pub struct WagoAiTestMachine {
 
 impl Machine for WagoAiTestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/wago_ai_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_ai_test_machine/new.rs
@@ -21,11 +21,7 @@ use crate::{
 impl MachineNewTrait for WagoAiTestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
         // validate general stuff
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -63,7 +59,7 @@ impl MachineNewTrait for WagoAiTestMachine {
             // Get the 750-455 analog input module from slot 0 (first module)
             let dev = coupler
                 .slot_devices
-                .get(0)
+                .first()
                 .ok_or_else(|| anyhow::anyhow!("No device in slot 0"))?
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("Slot 0 is empty"))?;

--- a/machines/src/minimal_machines/wago_do_test_machine/mod.rs
+++ b/machines/src/minimal_machines/wago_do_test_machine/mod.rs
@@ -28,7 +28,7 @@ pub struct WagoDOTestMachine {
 
 impl Machine for WagoDOTestMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/minimal_machines/wago_do_test_machine/new.rs
+++ b/machines/src/minimal_machines/wago_do_test_machine/new.rs
@@ -18,11 +18,7 @@ use std::sync::Arc;
 
 impl MachineNewTrait for WagoDOTestMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -54,8 +50,7 @@ impl MachineNewTrait for WagoDOTestMachine {
 
             coupler.init_slot_modules(_wago_750_354.1);
             let dev = coupler
-                .slot_devices
-                .get(0)
+                .slot_devices.first()
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "[{}::MachineNewTrait/WagoDOTestMachine::new] Expected Wago 750-530 module in slot 0, but slot 0 is not configured",

--- a/machines/src/registry.rs
+++ b/machines/src/registry.rs
@@ -64,7 +64,7 @@ impl MachineRegistry {
         self.type_map.insert(
             TypeId::of::<T>(),
             (
-                machine_identification.clone(),
+                machine_identification,
                 // create a machine construction closure
                 Box::new(|machine_new_params| Ok(Box::new(T::new(machine_new_params)?))),
             ),

--- a/machines/src/serial/init.rs
+++ b/machines/src/serial/init.rs
@@ -40,25 +40,26 @@ impl SerialDetection {
     /// Returns a clone of the map for quick access.
     pub fn detect_devices() -> HashMap<String, UsbPortInfo> {
         let ports = Self::get_ports();
-        let usb_devices = Self::extract_usb_serial_devices(ports);
-        usb_devices
+
+        Self::extract_usb_serial_devices(ports)
     }
 
     pub fn device_port_exists(device_path: &str) -> bool {
         let ports = Self::get_ports();
-        return ports.iter().any(|p| p.port_name == device_path);
+        ports.iter().any(|p| p.port_name == device_path)
     }
 
     pub fn device_id_exists(sdevid: SerialDeviceIdentification) -> bool {
         let ports = Self::get_ports();
         for port in ports {
-            if let SerialPortType::UsbPort(usb_info) = port.port_type {
-                if usb_info.vid == sdevid.vendor_id && usb_info.pid == sdevid.product_id {
-                    return true;
-                }
+            if let SerialPortType::UsbPort(usb_info) = port.port_type
+                && usb_info.vid == sdevid.vendor_id
+                && usb_info.pid == sdevid.product_id
+            {
+                return true;
             }
         }
-        return false;
+        false
     }
 
     pub fn get_path_by_id(
@@ -70,7 +71,7 @@ impl SerialDetection {
                 return Some(port.clone());
             }
         }
-        return None;
+        None
     }
 }
 

--- a/machines/src/wago_serial_machine/mod.rs
+++ b/machines/src/wago_serial_machine/mod.rs
@@ -28,7 +28,7 @@ pub struct WagoSerialMachine {
 
 impl Machine for WagoSerialMachine {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {

--- a/machines/src/wago_serial_machine/new.rs
+++ b/machines/src/wago_serial_machine/new.rs
@@ -18,11 +18,7 @@ use super::api::WagoSerialMachineNamespace;
 
 impl MachineNewTrait for WagoSerialMachine {
     fn new<'maindevice>(params: &MachineNewParams) -> Result<Self, Error> {
-        let device_identification = params
-            .device_group
-            .iter()
-            .map(|device_identification| device_identification.clone())
-            .collect::<Vec<_>>();
+        let device_identification = params.device_group.to_vec();
         validate_same_machine_identification_unique(&device_identification)?;
         validate_no_role_duplicates(&device_identification)?;
 
@@ -54,8 +50,7 @@ impl MachineNewTrait for WagoSerialMachine {
 
             coupler.init_slot_modules(_wago_750_354.1);
             let dev = coupler
-                .slot_devices
-                .get(0)
+                .slot_devices.first()
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "[{}::MachineNewTrait/WagoSerialMachine::new] Expected Wago 750-652 module in slot 0, but slot 0 is not configured",

--- a/machines/src/winder2/api.rs
+++ b/machines/src/winder2/api.rs
@@ -304,9 +304,8 @@ impl NamespaceCacheingLogic<Winder2Events> for Winder2Namespace {
     fn emit(&mut self, events: Winder2Events) {
         let event = Arc::new(events.event_value());
         let buffer_fn = events.event_cache_fn();
-        match &mut self.namespace {
-            Some(ns) => ns.emit(event, &buffer_fn),
-            None => (),
+        if let Some(ns) = &mut self.namespace {
+            ns.emit(event, &buffer_fn)
         }
     }
 }

--- a/machines/src/winder2/mod.rs
+++ b/machines/src/winder2/mod.rs
@@ -76,7 +76,7 @@ impl Default for SpoolAutomaticAction {
 #[cfg(not(feature = "mock-machine"))]
 impl Machine for Winder2 {
     fn get_machine_identification_unique(&self) -> MachineIdentificationUnique {
-        self.machine_identification_unique.clone()
+        self.machine_identification_unique
     }
 
     fn get_main_sender(&self) -> Option<Sender<AsyncThreadMessage>> {
@@ -117,10 +117,10 @@ impl Machine for Winder2 {
     }
 
     fn unsubscribed_from_machine(&mut self, uid: MachineIdentificationUnique) {
-        if let Some(current_uid) = self.puller_reference_machine {
-            if current_uid == uid {
-                self.puller_reference_machine = None;
-            }
+        if let Some(current_uid) = self.puller_reference_machine
+            && current_uid == uid
+        {
+            self.puller_reference_machine = None;
         }
 
         self.emit_state();

--- a/machines/src/winder2/new.rs
+++ b/machines/src/winder2/new.rs
@@ -116,7 +116,7 @@ impl MachineNewTrait for Winder2 {
                     .0
                     .write()
                     .await
-                    .write_config(&device.1, &el7041_config)
+                    .write_config(device.1, &el7041_config)
                     .await?;
                 device.0
             };
@@ -149,7 +149,7 @@ impl MachineNewTrait for Winder2 {
                     .0
                     .write()
                     .await
-                    .write_config(&device.1, &el7031_config)
+                    .write_config(device.1, &el7031_config)
                     .await?;
 
                 device.0
@@ -182,7 +182,7 @@ impl MachineNewTrait for Winder2 {
                     .0
                     .write()
                     .await
-                    .write_config(&device.1, &el7031_0030_config)
+                    .write_config(device.1, &el7031_0030_config)
                     .await?;
                 device.0
             };
@@ -194,8 +194,7 @@ impl MachineNewTrait for Winder2 {
                 .first()
                 .expect("device group must have at least one device")
                 .device_machine_identification
-                .machine_identification_unique
-                .clone();
+                .machine_identification_unique;
             let (sender, receiver) = smol::channel::unbounded();
             let mut new = Self {
                 main_sender: params.main_thread_channel.clone(),

--- a/machines/src/winder2/puller_speed_controller.rs
+++ b/machines/src/winder2/puller_speed_controller.rs
@@ -13,8 +13,9 @@ use units::jerk::meter_per_minute_per_second_squared;
 use units::length::{meter, millimeter};
 use units::velocity::{meter_per_minute, meter_per_second};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Default)]
 pub enum GearRatio {
+    #[default]
     OneToOne,
     OneToFive,
     OneToTen,
@@ -28,12 +29,6 @@ impl GearRatio {
             GearRatio::OneToFive => 5.0,
             GearRatio::OneToTen => 10.0,
         }
-    }
-}
-
-impl Default for GearRatio {
-    fn default() -> Self {
-        GearRatio::OneToOne
     }
 }
 

--- a/server/src/app_state.rs
+++ b/server/src/app_state.rs
@@ -65,6 +65,7 @@ pub struct EtherCatDeviceMetaData {
 }
 
 impl EtherCatDeviceMetaData {
+    #[must_use]
     pub fn from_subdevice(
         subdevice: &SubDeviceRef<'_, &ethercrab::SubDevice>,
         device_identification: DeviceIdentification,
@@ -100,7 +101,7 @@ use control_core::socketio::namespace::NamespaceCacheingLogic;
 pub struct EthercatSetup {
     /// All Ethercat devices
     /// Device-Specific interface for all devices
-    /// Same length and order as SubDevices inside `group` (index = subdevice_index)
+    /// Same length and order as `SubDevices` inside `group` (index = `subdevice_index`)
     pub devices: Vec<(DeviceIdentification, Arc<RwLock<dyn EthercatDevice>>)>,
     /// All Ethercat devices
     /// Generic interface for all devices
@@ -175,7 +176,7 @@ impl SharedState {
         // Track existing machine identifiers for quick lookup
         let existing_ids: HashSet<_> = current_machines
             .iter()
-            .map(|m| m.machine_identification_unique.clone())
+            .map(|m| m.machine_identification_unique)
             .collect();
 
         for machine in machines {
@@ -210,7 +211,7 @@ impl SharedState {
 
     pub async fn add_machines(&self, machines: Vec<Box<dyn Machine>>) {
         let mut api_machines = self.api_machines.lock().await;
-        for machine in machines.iter() {
+        for machine in &machines {
             api_machines.insert(
                 machine.get_machine_identification_unique(),
                 machine.api_get_sender(),
@@ -235,6 +236,7 @@ impl SharedState {
         self.send_machines_event().await;
     }
 
+    #[must_use]
     pub fn new(
         sender: Sender<HotThreadMessage>,
         main_async_channel: Sender<AsyncThreadMessage>,

--- a/server/src/ethercat/config.rs
+++ b/server/src/ethercat/config.rs
@@ -1,10 +1,10 @@
 use ethercrab::PduStorage;
 
-/// Maximum number of SubDevices that can be stored. This must be a power of 2 greater than 1.
+/// Maximum number of `SubDevices` that can be stored. This must be a power of 2 greater than 1.
 pub const MAX_SUBDEVICES: usize = 16;
 /// Maximum PDU data payload size - set this to the max PDI size or higher.
 pub const MAX_PDU_DATA: usize = PduStorage::element_size(512);
-/// Maximum number of EtherCAT frames that can be in flight at any one time.
+/// Maximum number of `EtherCAT` frames that can be in flight at any one time.
 pub const MAX_FRAMES: usize = 16;
 /// Maximum total PDI length.
 pub const PDI_LEN: usize = 512;

--- a/server/src/ethercat/setup.rs
+++ b/server/src/ethercat/setup.rs
@@ -56,6 +56,7 @@ pub struct DeviceGroupingResult {
     pub unidentified_devices: Vec<DeviceIdentification>,
 }
 
+#[must_use]
 pub fn group_devices_by_identification(
     device_identifications: &Vec<DeviceIdentification>,
 ) -> DeviceGroupingResult {
@@ -81,7 +82,7 @@ pub fn group_devices_by_identification(
         // get the first DeviceMachineIdentification
         // compare and append to the group
         let mut found = false;
-        for check_group in device_groups.iter_mut() {
+        for check_group in &mut device_groups {
             // get first device in group
             let first_device = check_group.first().expect("group to not be empty");
             let first_device_machine_identification = &first_device
@@ -135,13 +136,14 @@ pub async fn set_ethercat_devices<const MAX_SUBDEVICES: usize, const MAX_PDI: us
     let mut machines: Vec<Box<dyn Machine>> = vec![];
     let mut machine_objs: Vec<MachineObj> = vec![];
 
-    for device_group in device_grouping_result.device_groups.iter() {
+    for device_group in &device_grouping_result.device_groups {
         let machine_identification_unique: MachineIdentificationUnique = match device_group.first()
         {
-            Some(device_identification) => device_identification
-                .device_machine_identification
-                .machine_identification_unique
-                .clone(),
+            Some(device_identification) => {
+                device_identification
+                    .device_machine_identification
+                    .machine_identification_unique
+            }
             None => continue, // Skip this group if empty
         };
 
@@ -155,10 +157,12 @@ pub async fn set_ethercat_devices<const MAX_SUBDEVICES: usize, const MAX_PDI: us
 
         match new_machine {
             Ok(machine) => {
-                shared_state.clone().api_machines.lock().await.insert(
-                    machine_identification_unique.clone(),
-                    machine.api_get_sender(),
-                );
+                shared_state
+                    .clone()
+                    .api_machines
+                    .lock()
+                    .await
+                    .insert(machine_identification_unique, machine.api_get_sender());
                 machine_objs.push(MachineObj {
                     machine_identification_unique,
                     error: None,
@@ -192,9 +196,9 @@ pub async fn setup_loop(
     {
         let res = stop_dnsmasq();
         match res {
-            Ok(_) => tracing::info!("Stopped dnsmasq"),
+            Ok(()) => tracing::info!("Stopped dnsmasq"),
             Err(e) => tracing::error!("Failed to stop dnsmasq: {:?}", e),
-        };
+        }
         // Small Timeout to ensure interfaces get released
         smol::Timer::after(Duration::from_millis(1500)).await;
     }
@@ -209,7 +213,7 @@ pub async fn setup_loop(
         .spawn(move || {
             #[cfg(all(target_os = "linux", not(feature = "development-build")))]
             match set_irq_affinity(&interface, 3) {
-                Ok(_) => tracing::info!("ethernet interrupt handler now runs on cpu:{}", 3),
+                Ok(()) => tracing::info!("ethernet interrupt handler now runs on cpu:{}", 3),
                 Err(e) => tracing::error!("set_irq_handler_affinity failed: {:?}", e),
             }
 
@@ -402,7 +406,7 @@ pub async fn setup_loop(
         );
 
     // We always need to have atleast one subdevice anyways
-    let coupler = subdevices.get(0).unwrap();
+    let coupler = subdevices.first().unwrap();
     let _resp = get_most_recent_diagnosis_message(coupler).await;
 
     /*
@@ -416,7 +420,7 @@ pub async fn setup_loop(
             let r = Wago750_354::initialize_modules(coupler).await?;
             for module in r {
                 if coupler.configured_address() == module.belongs_to_addr {
-                    match ethercat_meta_devices.get(0) {
+                    match ethercat_meta_devices.first() {
                         Some(meta) => {
                             let meta_data = EtherCatDeviceMetaData {
                                 configured_address: module.slot,
@@ -439,7 +443,7 @@ pub async fn setup_loop(
             let r = IP20EcDi8Do8::initialize_modules(coupler).await?;
             for module in r {
                 if coupler.configured_address() == module.belongs_to_addr {
-                    match ethercat_meta_devices.get(0) {
+                    match ethercat_meta_devices.first() {
                         Some(meta) => {
                             let meta_data = EtherCatDeviceMetaData {
                                 configured_address: module.slot,
@@ -459,7 +463,7 @@ pub async fn setup_loop(
             }
         }
         _ => (),
-    };
+    }
     drop(ethercat_meta_devices);
 
     // remove subdevice from devices tuple
@@ -526,11 +530,11 @@ pub async fn setup_loop(
                     }
                     Err(Error::WorkingCounter { .. }) => 0,
                     Err(e) => {
-                        return Err(anyhow::anyhow!("Failed to read DC system time: {:?}", e));
+                        return Err(anyhow::anyhow!("Failed to read DC system time: {e:?}"));
                     }
                 };
 
-                let ema_next = ema.next(diff as f64);
+                let ema_next = ema.next(f64::from(diff));
                 max_deviation = max_deviation.max(ema_next.abs() as u32);
             }
             if max_deviation < 100 {
@@ -585,9 +589,8 @@ pub async fn setup_loop(
                 if res.all_safe_op() {
                     tracing::info!("SAFE-OP");
                     break group;
-                } else {
-                    group_container = Some(GroupState::SafeOp(group));
                 }
+                group_container = Some(GroupState::SafeOp(group));
                 smol::Timer::at(now + res.extra.next_cycle_wait).await;
             }
         }

--- a/server/src/logging/fmt.rs
+++ b/server/src/logging/fmt.rs
@@ -1,5 +1,6 @@
 use tracing_subscriber::Layer;
 
+#[must_use]
 pub fn init_fmt_tracing<S>() -> Box<dyn Layer<S> + Send + Sync + 'static>
 where
     S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -31,7 +31,8 @@ pub fn start_loop_thread(
     cycle_target: Duration,
 ) -> Result<std::thread::JoinHandle<()>, std::io::Error> {
     // Start control loop
-    let res = std::thread::Builder::new()
+
+    std::thread::Builder::new()
         .name("loop".to_owned())
         .spawn(move || {
             let rt_receiver = rt_receiver.clone();
@@ -152,8 +153,7 @@ pub fn start_loop_thread(
             // Exit the entire program if the Loop fails
             // gets restarted by systemd if running on NixOS, or different distro wtih the same sysd service
             std::process::exit(1);
-        });
-    res
+        })
 }
 
 pub async fn copy_ethercat_inputs(

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -34,7 +34,7 @@ pub fn start_loop_thread(
     let res = std::thread::Builder::new()
         .name("loop".to_owned())
         .spawn(move || {
-            let rt_receiver = rt_receiver.to_owned();
+            let rt_receiver = rt_receiver.clone();
             let sleeper =
                 SpinSleeper::new(3_333_333) // frequency in Hz ~ 1 / 300µs, Basically specifies the accuracy of our sleep
                     .with_spin_strategy(spin_sleep::SpinStrategy::YieldThread);
@@ -82,7 +82,10 @@ pub fn start_loop_thread(
             };
 
             loop {
-                use HotThreadMessage::*;
+                use HotThreadMessage::{
+                    AddEtherCatSetup, AddMachines, DeleteMachine, NoMsg, SubscriptionEstablish,
+                    SubscriptionTerminate, WriteMachineDeviceInfo,
+                };
 
                 let msg = match rt_receiver.try_recv() {
                     Ok(msg) => msg,
@@ -112,7 +115,7 @@ pub fn start_loop_thread(
                     }
                     DeleteMachine(uid) => rt_loop_inputs.machine_manager.remove_machine(uid),
                     AddMachines(new_machines) => {
-                        rt_loop_inputs.machine_manager.add_machines(new_machines)
+                        rt_loop_inputs.machine_manager.add_machines(new_machines);
                     }
                     SubscriptionEstablish(request) => rt_loop_inputs
                         .machine_manager
@@ -150,7 +153,7 @@ pub fn start_loop_thread(
             // gets restarted by systemd if running on NixOS, or different distro wtih the same sysd service
             std::process::exit(1);
         });
-    return res;
+    res
 }
 
 pub async fn copy_ethercat_inputs(
@@ -206,27 +209,25 @@ pub async fn copy_ethercat_inputs(
                 })?;
             }
             return Ok(());
-        } else {
-            loop {
-                let now = Instant::now();
-                let response @ TxRxResponse {
-                    working_counter: _wkc,
-                    extra:
-                        CycleInfo {
-                            next_cycle_wait, ..
-                        },
-                    ..
-                } = ethercat_setup
-                    .group
-                    .tx_rx_dc(&ethercat_setup.maindevice)
-                    .await
-                    .expect("TX/RX");
-                if response.all_op() {
-                    ethercat_setup.all_operational = true;
-                    break;
-                }
-                smol::Timer::at(now + next_cycle_wait).await;
+        }
+        loop {
+            let now = Instant::now();
+            let response @ TxRxResponse {
+                working_counter: _wkc,
+                extra: CycleInfo {
+                    next_cycle_wait, ..
+                },
+                ..
+            } = ethercat_setup
+                .group
+                .tx_rx_dc(&ethercat_setup.maindevice)
+                .await
+                .expect("TX/RX");
+            if response.all_op() {
+                ethercat_setup.all_operational = true;
+                break;
             }
+            smol::Timer::at(now + next_cycle_wait).await;
         }
     }
     Ok(())
@@ -291,11 +292,11 @@ pub fn loop_once<'maindevice>(inputs: &mut RtLoopInputs<'_>) -> Result<(), anyho
 
         let res = smol::block_on(copy_ethercat_inputs(inputs.ethercat_setup.as_deref_mut()));
         match res {
-            Ok(_) => (),
+            Ok(()) => (),
             Err(e) => {
-                return Err(anyhow::anyhow!("copy_ethercat_inputs failed: {:?}", e));
+                return Err(anyhow::anyhow!("copy_ethercat_inputs failed: {e:?}"));
             }
-        };
+        }
     }
 
     inputs.machine_manager.execute_machines();
@@ -303,11 +304,11 @@ pub fn loop_once<'maindevice>(inputs: &mut RtLoopInputs<'_>) -> Result<(), anyho
     if inputs.ethercat_setup.is_some() && inputs.ethercat_perf_metrics.is_some() {
         let res = smol::block_on(copy_ethercat_outputs(inputs.ethercat_setup.as_deref()));
         match res {
-            Ok(_) => (),
+            Ok(()) => (),
             Err(e) => {
-                return Err(anyhow::anyhow!("copy_ethercat_outputs failed: {:?}", e));
+                return Err(anyhow::anyhow!("copy_ethercat_outputs failed: {e:?}"));
             }
-        };
+        }
     }
 
     if inputs.ethercat_setup.is_some() {
@@ -321,7 +322,9 @@ pub fn loop_once<'maindevice>(inputs: &mut RtLoopInputs<'_>) -> Result<(), anyho
         // We do this, so that when no rt relevant code runs the cpu doesnt spin at 100% for no reason
         let loop_duration = loop_once_start.elapsed();
         if inputs.cycle_target > loop_once_start.elapsed() {
-            smol::block_on(smol::Timer::after(inputs.cycle_target - loop_duration));
+            smol::block_on(smol::Timer::after(
+                inputs.cycle_target.checked_sub(loop_duration).unwrap(),
+            ));
         }
     }
 

--- a/server/src/machine_manager.rs
+++ b/server/src/machine_manager.rs
@@ -72,7 +72,7 @@ impl MachineManager {
     pub fn execute_machines(&mut self) {
         let now = Instant::now();
 
-        for entry in self.machine_entries.iter_mut() {
+        for entry in &mut self.machine_entries {
             // Fuck you rust - jsentity
             let (refresh_state, refresh_live_values) = {
                 let data_entry = self

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -94,8 +94,7 @@ pub async fn add_serial_device(
 
     let machine_identification: MachineIdentificationUnique = device_identification_identified
         .device_machine_identification
-        .machine_identification_unique
-        .clone();
+        .machine_identification_unique;
 
     let new_machine = machine_registry.new_machine(&MachineNewParams {
         device_group: &vec![device_identification_identified],
@@ -115,7 +114,7 @@ pub async fn add_serial_device(
 
     shared_state
         .add_machines_if_not_exists(vec![MachineObj {
-            machine_identification_unique: machine_identification.clone(),
+            machine_identification_unique: machine_identification,
             error: None,
         }])
         .await;
@@ -175,7 +174,7 @@ pub async fn start_interface_discovery(
                 match res {
                     Ok(o) => o,
                     Err(e) => tracing::error!("Failed to start dnsmasq: {:?}", e),
-                };
+                }
             }
         }
         Err(e) => {
@@ -210,7 +209,7 @@ pub async fn handle_serial_device_hotplug(
             if machine.machine_identification_unique.machine_identification
                 == LaserMachine::MACHINE_IDENTIFICATION
             {
-                unique_ident = Some(machine.machine_identification_unique.clone());
+                unique_ident = Some(machine.machine_identification_unique);
                 break;
             }
         }
@@ -221,19 +220,16 @@ pub async fn handle_serial_device_hotplug(
         let serial_params = SerialDeviceNewParams {
             path: laser.unwrap(),
         };
-        match Laser::new_serial(&serial_params) {
-            Ok((device_identification, serial_device)) => {
-                add_serial_device(
-                    app_state.clone(),
-                    &device_identification,
-                    serial_device,
-                    &MACHINE_REGISTRY,
-                    app_state.socketio_setup.socket_queue_tx.clone(),
-                )
-                .await;
-            }
-            _ => (),
-        };
+        if let Ok((device_identification, serial_device)) = Laser::new_serial(&serial_params) {
+            add_serial_device(
+                app_state.clone(),
+                &device_identification,
+                serial_device,
+                &MACHINE_REGISTRY,
+                app_state.socketio_setup.socket_queue_tx.clone(),
+            )
+            .await;
+        }
     } else if laser.is_none() && unique_ident.is_some() {
         let unique_ident = unique_ident.unwrap();
         app_state
@@ -255,7 +251,7 @@ pub async fn handle_serial_device_hotplug(
 }
 
 async fn handle_async_requests(recv: Receiver<AsyncThreadMessage>, shared_state: Arc<SharedState>) {
-    use AsyncThreadMessage::*;
+    use AsyncThreadMessage::{NoMsg, SubscribeToMachine, UnsubscribeFromMachine};
 
     while let Ok(message) = recv.recv().await {
         match message {

--- a/server/src/metrics/collector.rs
+++ b/server/src/metrics/collector.rs
@@ -35,18 +35,12 @@ pub fn spawn_runtime_metrics_sampler(cfg: RuntimeMetricsConfig) {
 
             // naively expects values for every second
             let faults_since_last = match last_proc {
-                Some(last) => {
-                    if proc.minor_faults > last.minor_faults {
-                        proc.minor_faults - last.minor_faults
-                    } else {
-                        0
-                    }
-                }
+                Some(last) => proc.minor_faults.saturating_sub(last.minor_faults),
                 None => 0,
             };
 
             let mut sample = RuntimeSample::from_process_metrics(
-                last_proc.unwrap_or(ProcessMetrics::default()),
+                last_proc.unwrap_or_default(),
                 faults_since_last,
                 now_ms,
             );
@@ -64,7 +58,7 @@ pub fn spawn_runtime_metrics_sampler(cfg: RuntimeMetricsConfig) {
                     let j = s.jitter_ns as i64;
                     min = min.min(j);
                     max = max.max(j);
-                    sum += j as i128;
+                    sum += i128::from(j);
                     count += 1;
                 }
 
@@ -79,7 +73,7 @@ pub fn spawn_runtime_metrics_sampler(cfg: RuntimeMetricsConfig) {
             let iface_name = cfg
                 .ethercat_iface
                 .clone()
-                .or_else(|| get_ethercat_iface().map(|s| s.to_string()));
+                .or_else(|| get_ethercat_iface().map(std::string::ToString::to_string));
 
             if let Some(iface) = iface_name.as_deref() {
                 let now_inst = Instant::now();

--- a/server/src/metrics/csv_writer.rs
+++ b/server/src/metrics/csv_writer.rs
@@ -35,7 +35,8 @@ pub struct RuntimeSample {
 }
 
 impl RuntimeSample {
-    pub fn from_process_metrics(
+    #[must_use]
+    pub const fn from_process_metrics(
         m: ProcessMetrics,
         mfaults_per_second: u64,
         timestamp_ms: u128,
@@ -89,7 +90,7 @@ fn opt_u64(v: Option<u64>) -> String {
 }
 
 fn opt_f64(v: Option<f64>) -> String {
-    v.map(|x| format!("{:.6}", x)).unwrap_or_default()
+    v.map(|x| format!("{x:.6}")).unwrap_or_default()
 }
 
 pub fn append_runtime_sample_csv<P: AsRef<Path>>(

--- a/server/src/metrics/io.rs
+++ b/server/src/metrics/io.rs
@@ -12,14 +12,14 @@ pub struct NetDevCounters {
 // Global storage for the discovered EtherCAT interface name.
 static ETHERCAT_IFACE: OnceLock<String> = OnceLock::new();
 
-/// Record the EtherCAT interface name for later I/O metrics.
+/// Record the `EtherCAT` interface name for later I/O metrics.
 pub fn set_ethercat_iface<S: Into<String>>(iface: S) {
     let _ = ETHERCAT_IFACE.set(iface.into());
 }
 
-/// Get the EtherCAT interface name if it has been discovered.
+/// Get the `EtherCAT` interface name if it has been discovered.
 pub fn get_ethercat_iface() -> Option<&'static str> {
-    ETHERCAT_IFACE.get().map(|s| s.as_str())
+    ETHERCAT_IFACE.get().map(std::string::String::as_str)
 }
 
 fn read_u64_from(path: &Path) -> Option<u64> {
@@ -30,6 +30,7 @@ fn read_u64_from(path: &Path) -> Option<u64> {
 /// Read rx/tx byte counters for a network interface from /sys/class/net.
 ///
 /// Returns None if the interface or files do not exist.
+#[must_use]
 pub fn read_netdev_counters(iface: &str) -> Option<NetDevCounters> {
     let base = format!("/sys/class/net/{iface}/statistics");
     let rx_path = Path::new(&base).join("rx_bytes");

--- a/server/src/metrics/jitter.rs
+++ b/server/src/metrics/jitter.rs
@@ -53,12 +53,13 @@ fn machines_ring() -> &'static JitterRing {
     MACHINES_JITTER_RING.get_or_init(JitterRing::new)
 }
 
-/// Record one jitter sample for the main RT loop (machines + EtherCAT).
+/// Record one jitter sample for the main RT loop (machines + `EtherCAT`).
 pub fn record_machines_loop_jitter(jitter_ns: i128) {
     machines_ring().push(JitterSample { jitter_ns });
 }
 
 /// Get a snapshot of recent jitter samples for the machines loop.
+#[must_use]
 pub fn snapshot_machines_jitter() -> Vec<JitterSample> {
     machines_ring().snapshot()
 }

--- a/server/src/metrics/preemption.rs
+++ b/server/src/metrics/preemption.rs
@@ -26,6 +26,7 @@ pub struct ThreadSchedStats {
 /// Read basic scheduling stats for a thread (by TID) from /proc/<tid>/sched.
 ///
 /// Returns None if the file can't be read or parsed.
+#[must_use]
 pub fn read_thread_sched_stats(tid: libc::pid_t) -> Option<ThreadSchedStats> {
     // /proc/<tid>/sched is a shortcut for /proc/self/task/<tid>/sched
     let path = format!("/proc/self/task/{tid}/sched");

--- a/server/src/metrics/process.rs
+++ b/server/src/metrics/process.rs
@@ -29,7 +29,8 @@ impl ProcessMetrics {
     /// Collect current process metrics from /proc.
     ///
     /// Linux-specific; on other platforms returns zeroed metrics.
-    pub fn collect() -> ProcessMetrics {
+    #[must_use]
+    pub fn collect() -> Self {
         #[cfg(target_os = "linux")]
         {
             let mut rss_bytes = 0;
@@ -69,7 +70,7 @@ impl ProcessMetrics {
                 }
             }
 
-            ProcessMetrics {
+            Self {
                 rss_bytes,
                 cpu_time_seconds,
                 minor_faults,

--- a/server/src/metrics/state.rs
+++ b/server/src/metrics/state.rs
@@ -16,13 +16,14 @@ fn latest_slot() -> &'static Mutex<Option<RuntimeSample>> {
 /// Clones `sample` into the global slot.
 pub fn set_latest_runtime_sample(sample: &RuntimeSample) {
     let mut guard = latest_slot().lock().unwrap();
-    *guard = Some(sample.clone());
+    *guard = Some(*sample);
 }
 
 /// Get the latest runtime metrics sample, if any.
 ///
 /// Returns a cloned `RuntimeSample`.
+#[must_use]
 pub fn get_latest_runtime_sample() -> Option<RuntimeSample> {
     let guard = latest_slot().lock().unwrap();
-    guard.clone()
+    *guard
 }

--- a/server/src/modbus_tcp/mod.rs
+++ b/server/src/modbus_tcp/mod.rs
@@ -14,7 +14,7 @@ mod imports {
 }
 
 #[cfg(not(feature = "mock-machine"))]
-use imports::*;
+use imports::{Duration, FutureIteratorExt, Timer, probe_modbus_tcp};
 
 #[cfg(not(feature = "mock-machine"))]
 pub async fn start_modbus_tcp_discovery(shared_state: Arc<SharedState>) {

--- a/server/src/panic.rs
+++ b/server/src/panic.rs
@@ -22,8 +22,8 @@ fn panic_hook(panic_info: &PanicHookInfo) {
         .unwrap_or_else(|| "<unknown>".to_string());
 
     tracing::error!("thread '{}' panicked at {}:", thread, locataion);
-    eprintln!("{}\n", message);
-    eprintln!("Backtrace:\n{}", backtrace);
+    eprintln!("{message}\n");
+    eprintln!("Backtrace:\n{backtrace}");
 
     std::process::exit(1);
 }

--- a/server/src/performance_metrics.rs
+++ b/server/src/performance_metrics.rs
@@ -6,7 +6,7 @@ use tracing::info;
 const METRICS_WINDOW_SIZE: usize = 1000 * 30; // Keep last 30k measurements
 const METRICS_LOG_INTERVAL_SECS: u64 = 30; // Log every 30 seconds
 
-/// Collects and manages EtherCAT performance metrics
+/// Collects and manages `EtherCAT` performance metrics
 pub struct EthercatPerformanceMetrics {
     txrx_times: VecDeque<Duration>,
     loop_times: VecDeque<Duration>,
@@ -22,6 +22,7 @@ impl Default for EthercatPerformanceMetrics {
 
 impl EthercatPerformanceMetrics {
     /// Creates a new metrics collector
+    #[must_use]
     pub fn new() -> Self {
         Self {
             txrx_times: VecDeque::with_capacity(METRICS_WINDOW_SIZE),
@@ -44,7 +45,7 @@ impl EthercatPerformanceMetrics {
         self.last_loop_start = Some(now);
     }
 
-    /// Adds a tx_rx time measurement
+    /// Adds a `tx_rx` time measurement
     pub fn add_txrx_time(&mut self, duration: Duration) {
         if self.txrx_times.len() >= METRICS_WINDOW_SIZE {
             self.txrx_times.pop_front();

--- a/server/src/rest/handlers/machine_mutation.rs
+++ b/server/src/rest/handlers/machine_mutation.rs
@@ -15,7 +15,7 @@ pub async fn post_machine_mutate(
 ) -> Response<Body> {
     let result = _post_machine_mutate(State(app_state), Json(body)).await;
     match result {
-        Ok(_) => ResponseUtil::ok(MutationResponse::success()),
+        Ok(()) => ResponseUtil::ok(MutationResponse::success()),
         Err(e) => ResponseUtilError::Error(e).into(),
     }
 }
@@ -47,14 +47,14 @@ async fn _post_machine_mutate(
                 ))
                 .await;
             match res {
-                Ok(_) => (),
+                Ok(()) => (),
                 Err(e) => tracing::error!(
                     "[{}::_post_machine_mutate] Sending MachineMessage::HttpApiJsonRequest to {} failed {}",
                     module_path!(),
                     body.machine_identification_unique,
                     e
                 ),
-            };
+            }
             Ok(())
         }
 

--- a/server/src/rest/handlers/metrics.rs
+++ b/server/src/rest/handlers/metrics.rs
@@ -20,7 +20,7 @@ pub struct ProcessMetricsResponse {
 
 /// Snapshot of runtime metrics for the frontend.
 ///
-/// This is a thin view over the latest RuntimeSample.
+/// This is a thin view over the latest `RuntimeSample`.
 #[derive(Debug, Serialize)]
 pub struct RuntimeMetricsResponse {
     pub timestamp_ms: u128,

--- a/server/src/rest/handlers/mutation.rs
+++ b/server/src/rest/handlers/mutation.rs
@@ -11,12 +11,14 @@ pub struct MutationResponse {
 }
 
 impl MutationResponse {
+    #[must_use]
     pub const fn success() -> Self {
         Self {
             success: true,
             error: None,
         }
     }
+    #[must_use]
     pub const fn error(error: String) -> Self {
         Self {
             success: false,

--- a/server/src/rest/handlers/write_machine_device_identification.rs
+++ b/server/src/rest/handlers/write_machine_device_identification.rs
@@ -27,7 +27,7 @@ pub async fn post_write_machine_device_identification(
         .await;
 
     match res {
-        Ok(_) => (),
+        Ok(()) => (),
         Err(e) => tracing::error!(
             "Failed to send HotThreadMessage::WriteMachineDeviceInfo {}",
             e

--- a/server/src/rest/init.rs
+++ b/server/src/rest/init.rs
@@ -44,7 +44,7 @@ async fn init_api(app_state: Arc<SharedState>) -> Result<()> {
 
     axum::serve(listener, app)
         .await
-        .map_err(|e| anyhow::anyhow!("Server error: {}", e))
+        .map_err(|e| anyhow::anyhow!("Server error: {e}"))
 }
 
 /// Starts the API server in its own thread with a single-threaded Tokio runtime

--- a/server/src/rest/response.rs
+++ b/server/src/rest/response.rs
@@ -36,7 +36,7 @@ impl axum::response::IntoResponse for ApiError {
 
 pub type Result<T> = axum::response::Result<Json<T>, ApiError>;
 
-pub fn json<T>(t: T) -> Result<T> {
+pub const fn json<T>(t: T) -> Result<T> {
     Result::Ok(Json(t))
 }
 

--- a/server/src/rest/rest_api.rs
+++ b/server/src/rest/rest_api.rs
@@ -17,7 +17,7 @@ use machines::winder2::Winder2;
 use serde::Serialize;
 
 use crate::app_state::SharedState;
-use crate::rest::response::*;
+use crate::rest::response::{Result, internal_error, json, not_found};
 
 #[derive(Serialize, Debug, PartialEq)]
 struct MachineResponce {

--- a/server/src/socketio/init.rs
+++ b/server/src/socketio/init.rs
@@ -91,13 +91,9 @@ fn setup_disconnection(socket: SocketRef, namespace_id: NamespaceId, app_state: 
                 }
             }
             if let NamespaceId::Machine(ident) = namespace_id.clone() {
-                    match app_state.clone().api_machines.lock().await.get(&ident) {
-                        Some(sender) => {
-                            let _ = sender.send(machines::MachineMessage::UnsubscribeNamespace).await;
-                        },
-                        None => tracing::info!("sender doesnt exist for: {}",ident),
-                    };
-                }else{
+                    if let Some(sender) = app_state.clone().api_machines.lock().await.get(&ident) {
+                        let _ = sender.send(machines::MachineMessage::UnsubscribeNamespace).await;
+                    } else { tracing::info!("sender doesnt exist for: {}",ident) }
                 }
         })
         .detach();
@@ -139,13 +135,10 @@ fn setup_connection(socket: SocketRef, namespace_id: NamespaceId, app_state: Arc
                 namespace.reemit(socket_clone);
 
                 if let NamespaceId::Machine(ident) = namespace_id_clone {
-                    match app_state.clone().api_machines.lock().await.get(&ident) {
-                        Some(sender) => {
-                            tracing::info!("subscribing namespace to {}",ident);
-                            let _ = sender.send(machines::MachineMessage::SubscribeNamespace(namespace.clone())).await;
-                        },
-                        None => tracing::info!("sender doesnt exist for: {}",ident),
-                    };
+                    if let Some(sender) = app_state.clone().api_machines.lock().await.get(&ident) {
+                        tracing::info!("subscribing namespace to {}",ident);
+                        let _ = sender.send(machines::MachineMessage::SubscribeNamespace(namespace.clone())).await;
+                    } else { tracing::info!("sender doesnt exist for: {}",ident) }
                 }
 
             }

--- a/server/src/socketio/main_namespace/ethercat_devices_event.rs
+++ b/server/src/socketio/main_namespace/ethercat_devices_event.rs
@@ -29,6 +29,7 @@ impl EthercatDevicesEventBuilder {
         )
     }
 
+    #[must_use]
     pub fn initializing(&self) -> Event<EthercatDevicesEvent> {
         Event::new(Self::NAME, EthercatDevicesEvent::Initializing(true))
     }

--- a/server/src/socketio/main_namespace/ethercat_interface_discovery_event.rs
+++ b/server/src/socketio/main_namespace/ethercat_interface_discovery_event.rs
@@ -8,6 +8,7 @@ pub enum EthercatInterfaceDiscoveryEvent {
 }
 
 impl EthercatInterfaceDiscoveryEvent {
+    #[must_use]
     pub fn build(&self) -> Event<Self> {
         Event::new("EthercatInterfaceDiscoveryEvent", self.clone())
     }

--- a/server/src/socketio/main_namespace/machines_event.rs
+++ b/server/src/socketio/main_namespace/machines_event.rs
@@ -17,6 +17,7 @@ pub struct MachinesEventBuilder();
 impl MachinesEventBuilder {
     const NAME: &'static str = "MachinesEvent";
 
+    #[must_use]
     pub fn build(&self, machine_objs: Vec<MachineObj>) -> Event<MachinesEvent> {
         Event::new(
             Self::NAME,

--- a/server/src/socketio/main_namespace/mod.rs
+++ b/server/src/socketio/main_namespace/mod.rs
@@ -20,6 +20,7 @@ pub struct MainRoom {
 }
 
 impl MainRoom {
+    #[must_use]
     pub fn new(socket_queue_tx: Sender<(SocketRef, Arc<GenericEvent>)>) -> Self {
         Self {
             namespace: Namespace::new(socket_queue_tx),

--- a/server/src/socketio/namespace_id.rs
+++ b/server/src/socketio/namespace_id.rs
@@ -227,7 +227,7 @@ mod tests {
     #[test]
     fn test_display_main() {
         let namespace_id = NamespaceId::Main;
-        assert_eq!(format!("{}", namespace_id), "/main");
+        assert_eq!(format!("{namespace_id}"), "/main");
     }
 
     #[test]
@@ -240,7 +240,7 @@ mod tests {
             serial: 789,
         };
         let namespace_id = NamespaceId::Machine(machine_id);
-        assert_eq!(format!("{}", namespace_id), "/machine/123/456/789");
+        assert_eq!(format!("{namespace_id}"), "/machine/123/456/789");
     }
 
     #[test]
@@ -285,7 +285,7 @@ mod tests {
             serial: 789,
         });
 
-        let string_repr = format!("{}", original);
+        let string_repr = format!("{original}");
         let parsed = NamespaceId::from_str(&string_repr).unwrap();
 
         match parsed {

--- a/server/src/socketio/namespace_id.rs
+++ b/server/src/socketio/namespace_id.rs
@@ -71,7 +71,7 @@ impl<'de> Deserialize<'de> for NamespaceId {
                     }
                 }
 
-                Err(E::custom(format!("Invalid namespace path: {}", value)))
+                Err(E::custom(format!("Invalid namespace path: {value}")))
             }
         }
 
@@ -108,7 +108,7 @@ impl FromStr for NamespaceId {
             }
         }
 
-        Err(format!("Invalid namespace path: {}", s))
+        Err(format!("Invalid namespace path: {s}"))
     }
 }
 

--- a/server/src/socketio/namespaces.rs
+++ b/server/src/socketio/namespaces.rs
@@ -27,6 +27,7 @@ impl Namespaces {
         }
     }
 
+    #[must_use]
     pub fn new(socket_queue_tx: Sender<(SocketRef, Arc<GenericEvent>)>) -> Self {
         Self {
             main_namespace: MainRoom::new(socket_queue_tx),

--- a/server/src/socketio/queue.rs
+++ b/server/src/socketio/queue.rs
@@ -21,7 +21,7 @@ async fn send_event_with_retry(
         }
 
         match socket.emit("event", event.as_ref()) {
-            Ok(_) => {
+            Ok(()) => {
                 trace!(
                     socket_id = ?socket.id,
                     event = %event.name,

--- a/units/src/jerk.rs
+++ b/units/src/jerk.rs
@@ -12,6 +12,6 @@ quantity! {
         Z0>; // luminous intensity
     units {
         @meter_per_second_cubed: 1.0; "m/s³", "meter per second cubed", "meters per second cubed";
-        @meter_per_minute_per_second_squared: 0.016_666_666_666_666_666_67; "m/min/s²", "meters per minute per second squared", "meters per minute per second squared";
+        @meter_per_minute_per_second_squared: 0.016_666_666_666_666_666; "m/min/s²", "meters per minute per second squared", "meters per minute per second squared";
     }
 }


### PR DESCRIPTION
## What does this PR do / add / change?

- Fixes typo in lint setup ("pe**n**dantic" in Cargo.toml)
- Adds githooks for formatting and linting
- Fixes all auto fixable clippy issues

This currently does not add linting to CI checks as there are many more linting issues that clippy could not fix.
Just a proposal towards a path without clippy issues to increase code quality.
I appreciate the fact that this comes with tons of changes from a random guy. Happy for you to apply the clippy fixes yourself to save review time.

I am also happy to adapt the current clippy rules upfront as the non-default categories like pedantic and nursery can be controversial latest when it comes to activating this in CI.
Going forward I would propose to:
- fix all default category issues
- mark the default categories (anything that is warn by default as described here https://doc.rust-lang.org/stable/clippy/) as deny, keep the remaining ones as warnings
- run clippy with warnings as errors in the pre-commit hook to encourage dealing with the warnings (hooks can be skipped)
- run clippy with the above defaults in CI

Consider this PR the start of a conversastion.

*Note that all auto-fixes are applied without `--broken-code`, wanted to leave that and further fixes for follow-up PRs.
Once the repo has no clippy issues we can add clippy to the rust CI steps.