### PR TITLE
added ability for multiple usb idents for laser

### DIFF
--- a/machines/src/laser/new.rs
+++ b/machines/src/laser/new.rs
@@ -17,9 +17,7 @@ impl MachineNewTrait for LaserMachine {
             MachineNewHardware::Serial(serial) => *serial,
             _ => return Err(Error::msg("Invalid hardware type for LaserMachine")),
         };
-
         // downcast the hardware_serial to Arc<RwLock<Laser>>
-
         let laser = match smol::block_on(
             SERIAL_DEVICE_REGISTRY.downcast_arc_rwlock::<Laser>(hardware_serial.device.clone()),
         ) {

--- a/machines/src/serial/init.rs
+++ b/machines/src/serial/init.rs
@@ -62,12 +62,15 @@ impl SerialDetection {
     }
 
     pub fn get_path_by_id(
-        sdevid: SerialDeviceIdentification,
+        sdevids: Vec<SerialDeviceIdentification>,
         map: HashMap<String, UsbPortInfo>,
     ) -> Option<String> {
         for (port, usbport) in map.iter() {
-            if usbport.vid == sdevid.vendor_id && usbport.pid == sdevid.product_id {
-                return Some(port.clone());
+            let sdevids = sdevids.clone();
+            for device_ident in sdevids {
+                if usbport.vid == device_ident.vendor_id && usbport.pid == device_ident.product_id {
+                    return Some(port.clone());
+                }
             }
         }
         return None;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -200,8 +200,12 @@ pub async fn handle_serial_device_hotplug(
         vendor_id: 0x0403,
         product_id: 0x6001,
     };
+    let alternative_laser_ident = SerialDeviceIdentification {
+        vendor_id: 0x1a86,
+        product_id: 0x7523,
+    };
 
-    let laser = SerialDetection::get_path_by_id(laser_ident, map);
+    let laser = SerialDetection::get_path_by_id(vec![alternative_laser_ident, laser_ident], map);
     let mut unique_ident: Option<MachineIdentificationUnique> = None;
 
     {


### PR DESCRIPTION
## What does this PR do / add / change?
Now Multiple Ids are valid for a laser

## Checklist before opening the pr

- [X] Tested locally
- [X] Tested on the machine (if hardware interaction is involved)
- [X] No format errors (`cargo fmt` / `npm run format`)
- [X] No build errors (`cargo build` / `npm run build`)
