### PR TITLE
fix: memoize namespaceId in useMock1Namespace to prevent infinite render loop

### DIFF
--- a/electron/src/machines/minimal_machines/mock/mock1/mock1Namespace.ts
+++ b/electron/src/machines/minimal_machines/mock/mock1/mock1Namespace.ts
@@ -5,6 +5,7 @@
 
 import { StoreApi } from "zustand";
 import { create } from "zustand";
+import { useMemo } from "react";
 import { z } from "zod";
 import {
   EventHandler,
@@ -179,12 +180,13 @@ const useMock1NamespaceImplementation =
 export function useMock1Namespace(
   machine_identification_unique: MachineIdentificationUnique,
 ): Mock1NamespaceStore {
-  // Generate namespace ID from validated machine ID
-  const namespaceId: NamespaceId = {
-    type: "machine",
-    machine_identification_unique,
-  };
+  const namespaceId = useMemo<NamespaceId>(
+    () => ({
+      type: "machine",
+      machine_identification_unique,
+    }),
+    [machine_identification_unique],
+  );
 
-  // Use the implementation with validated namespace ID
   return useMock1NamespaceImplementation(namespaceId);
 }


### PR DESCRIPTION
useMock1Namespace was creating a new namespaceId object literal on every render. The useEffect in createNamespaceHookImplementation uses [namespaceId] as a dependency — since React uses reference equality, the new object each render caused the effect to re-fire, calling incrementNamespace → zustand set() → re-render → repeat until React's update depth limit was hit.

Fixed by wrapping the namespaceId construction in useMemo, matching the pattern already used in all other namespace implementations (e.g. winder2Namespace.ts).