### PR TITLE
update renderValue precision for speed graphs to one decimal place for puller speed

### DIFF
--- a/electron/src/machines/winder/winder2/Winder2Graphs.tsx
+++ b/electron/src/machines/winder/winder2/Winder2Graphs.tsx
@@ -37,7 +37,7 @@ export function Winder2GraphsPage() {
               targetSeries={targetPullerSpeed}
               targetSpeed={state?.puller_state?.target_speed}
               unit="m/min"
-              renderValue={(value) => roundToDecimals(value, 0)}
+              renderValue={(value) => roundToDecimals(value, 1)}
             />
 
             <TensionArmAngleGraph

--- a/electron/src/machines/winder/winder2_7031/Winder2_7031_Graphs.tsx
+++ b/electron/src/machines/winder/winder2_7031/Winder2_7031_Graphs.tsx
@@ -37,7 +37,7 @@ export function Winder2_7031GraphsPage() {
               targetSeries={targetPullerSpeed}
               targetSpeed={state?.puller_state?.target_speed}
               unit="m/min"
-              renderValue={(value) => roundToDecimals(value, 0)}
+              renderValue={(value) => roundToDecimals(value, 1)}
             />
 
             <TensionArmAngleGraph


### PR DESCRIPTION
## What does this PR do / add / change?
Fixes the winder data export rounding the puller speed to an integer. The renderValue function for the PullerSpeedGraph was set to 0 decimal places, which affected both the on-screen tooltip display and the Excel export (both use the same formatter). Changed it to 1 decimal place so a value like 13.5 m/min is exported as 13.5 instead of 13.

Affected components: Winder2GraphsPage and Winder2_7031GraphsPage.

## Checklist before opening the pr

- [x] Tested locally
- [ ] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
