### PR TITLE
1316 bug laser graph buttons become unresponsive after 1 hour runtime

### DIFF
--- a/electron/src/components/graph/GraphControls.tsx
+++ b/electron/src/components/graph/GraphControls.tsx
@@ -125,20 +125,44 @@ export function GraphControls({
                   Remove Marker
                 </TouchButton>
               )}
-              {onExport && (
-                <TouchButton
-                  onClick={onExport}
-                  variant="outline"
-                  className="h-auto bg-green-600 px-3 py-3 text-base font-medium text-white hover:bg-green-700"
-                >
-                  Export
-                </TouchButton>
-              )}
+              {onExport && <ExportButton onExport={onExport} />}
             </>
           )}
         </div>
       </div>
     </ControlCard>
+  );
+}
+
+function ExportButton({ onExport }: { onExport: () => void | Promise<void> }) {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleClick = async () => {
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      await onExport();
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <TouchButton
+      onClick={handleClick}
+      disabled={isExporting}
+      variant="outline"
+      className="h-auto bg-green-600 px-3 py-3 text-base font-medium text-white hover:bg-green-700 disabled:opacity-70"
+    >
+      {isExporting ? (
+        <>
+          <Icon name="lu:Loader" className="mr-2 size-4 animate-spin" />
+          Exporting...
+        </>
+      ) : (
+        "Export"
+      )}
+    </TouchButton>
   );
 }
 
@@ -263,15 +287,7 @@ export function FloatingControlPanel({
                 Remove Marker
               </TouchButton>
             )}
-            {isExpanded && onExport && (
-              <TouchButton
-                onClick={onExport}
-                variant="outline"
-                className="h-auto bg-green-600 px-3 py-3 text-base font-medium text-white hover:bg-green-700"
-              >
-                Export
-              </TouchButton>
-            )}
+            {isExpanded && onExport && <ExportButton onExport={onExport} />}
           </div>
 
           {isExpanded && <div className="h-8 w-px bg-gray-200"></div>}

--- a/electron/src/components/graph/GraphControls.tsx
+++ b/electron/src/components/graph/GraphControls.tsx
@@ -140,6 +140,9 @@ function ExportButton({ onExport }: { onExport: () => void | Promise<void> }) {
   const handleClick = async () => {
     if (isExporting) return;
     setIsExporting(true);
+    // Yield to the event loop so React can re-render and paint the spinner
+    // before the heavy synchronous XLSX work blocks the thread.
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
     try {
       await onExport();
     } finally {

--- a/electron/src/components/graph/types.ts
+++ b/electron/src/components/graph/types.ts
@@ -109,7 +109,7 @@ export type ControlProps = {
   onTimeWindowChange: (timeWindow: number | "all") => void;
   onSwitchToLive: () => void;
   onSwitchToHistorical: (origin: SwitchOrigin) => void;
-  onExport?: () => void;
+  onExport?: () => void | Promise<void>;
   onAddMarker?: () => void;
   onManageMarkers?: () => void;
   timeWindowOptions?: TimeWindowOption[];

--- a/electron/src/components/graph/useGraphSync.ts
+++ b/electron/src/components/graph/useGraphSync.ts
@@ -71,10 +71,6 @@ export function useGraphSync(exportGroupId?: string) {
       },
       requestId?: number,
     ) => {
-      // Generate request ID if not provided
-      const currentRequestId =
-        requestId ?? ++syncStateRef.current.currentRequestId;
-
       // Prevent circular updates and stale requests
       if (syncStateRef.current.lastChangeSource === graphId) return;
       if (syncStateRef.current.isProcessingChange && !requestId) {
@@ -82,12 +78,17 @@ export function useGraphSync(exportGroupId?: string) {
         return;
       }
 
+      // Generate request ID after guards so blocked calls don't pollute the counter
+      const currentRequestId =
+        requestId ?? ++syncStateRef.current.currentRequestId;
+
       syncStateRef.current.isProcessingChange = true;
       syncStateRef.current.lastChangeSource = graphId;
       // Use requestAnimationFrame to ensure state updates happen in next frame
       requestAnimationFrame(() => {
         // Check if this request is still valid
         if (currentRequestId < syncStateRef.current.currentRequestId - 1) {
+          clearChangeSource(); // Always release the lock, even for stale requests
           return; // Skip stale request
         }
 

--- a/electron/src/components/graph/useGraphSync.ts
+++ b/electron/src/components/graph/useGraphSync.ts
@@ -132,10 +132,10 @@ export function useGraphSync(exportGroupId?: string) {
   const handleExport = useCallback(() => {
     if (graphDataRef.current.size === 0) {
       console.warn("No graphs registered for export");
-      return;
+      return Promise.resolve();
     }
     const logs = useLogsStore.getState().entries;
-    exportGraphsToExcel(
+    return exportGraphsToExcel(
       graphDataRef.current,
       exportGroupId || "synced-graphs",
       logs,


### PR DESCRIPTION
Fix https://github.com/qitechgmbh/control/issues/1316 

And fix https://github.com/qitechgmbh/control/issues/1326

The buttons now stay responsive even after an hour and if you want to export the UI seems more responsive because of an Loading Animation when waiting for the Export Window to appear.