### PR TITLE
show decimal numbers for pressure and rpm in extruder control pages

### DIFF
--- a/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
@@ -183,7 +183,7 @@ export function Extruder2ControlPage() {
             <TimeSeriesValueNumeric
               label="Rpm"
               unit="rpm"
-              renderValue={(value) => roundToDecimals(value, 0)}
+              renderValue={(value) => roundToDecimals(value, 1)}
               timeseries={motorScrewRpm}
             />
 
@@ -195,7 +195,7 @@ export function Extruder2ControlPage() {
             <TimeSeriesValueNumeric
               label="Pressure"
               unit="bar"
-              renderValue={(value) => roundToDecimals(value, 0)}
+              renderValue={(value) => roundToDecimals(value, 1)}
               timeseries={pressure}
             />
           </div>

--- a/electron/src/machines/extruder/extruder3/Extruder3ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder3/Extruder3ControlPage.tsx
@@ -183,7 +183,7 @@ export function Extruder3ControlPage() {
             <TimeSeriesValueNumeric
               label="Rpm"
               unit="rpm"
-              renderValue={(value) => roundToDecimals(value, 0)}
+              renderValue={(value) => roundToDecimals(value, 1)}
               timeseries={motorScrewRpm}
             />
 
@@ -195,7 +195,7 @@ export function Extruder3ControlPage() {
             <TimeSeriesValueNumeric
               label="Pressure"
               unit="bar"
-              renderValue={(value) => roundToDecimals(value, 0)}
+              renderValue={(value) => roundToDecimals(value, 1)}
               timeseries={pressure}
             />
           </div>


### PR DESCRIPTION
## What does this PR do / add / change?
Adds one decimal point to the pressure and rpm data of the extruder.

## Screenshots
<img width="480" height="190" alt="grafik" src="https://github.com/user-attachments/assets/42ef8cbc-32e9-40c3-9156-f84d922fa8e7" />

<!-- Include screenshots for any UI changes. Remove this section if not applicable. -->