### PR TITLE
Update error message for inverter status in Extruder control pages

### DIFF
--- a/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder2/Extruder2ControlPage.tsx
@@ -132,7 +132,9 @@ export function Extruder2ControlPage() {
             </StatusBadge>
           ) : state?.inverter_status_state.fault_occurence == true ? (
             <StatusBadge variant="error">
-              Inverter encountered an error!! Press the restart button in Config
+              Inverter encountered an error! Press the restart button in Config.
+              If the issue persists, activate the extruder emergency stop to
+              reset the inverter.
             </StatusBadge>
           ) : state?.inverter_status_state.running == true &&
             state.inverter_status_state.fault_occurence == false ? (

--- a/electron/src/machines/extruder/extruder3/Extruder3ControlPage.tsx
+++ b/electron/src/machines/extruder/extruder3/Extruder3ControlPage.tsx
@@ -132,7 +132,9 @@ export function Extruder3ControlPage() {
             </StatusBadge>
           ) : state?.inverter_status_state.fault_occurence == true ? (
             <StatusBadge variant="error">
-              Inverter encountered an error!! Press the restart button in Config
+              Inverter encountered an error! Press the restart button in Config.
+              If the issue persists, activate the extruder emergency stop to
+              reset the inverter.
             </StatusBadge>
           ) : state?.inverter_status_state.running == true &&
             state.inverter_status_state.fault_occurence == false ? (


### PR DESCRIPTION
## What does this PR do / add / change?
Updates the error message for the inverter status to: 
```
"Inverter encountered an error! Press the restart button in Config. 
If the issue persists, activate the extruder emergency stop to reset
the inverter."
```

## Checklist before opening the pr

- [x] Tested locally
- [ ] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
