### PR TITLE
FIX: EL1124 and EL9505 device identities missing in machine_identification.rs

### DIFF
--- a/machines/src/machine_identification.rs
+++ b/machines/src/machine_identification.rs
@@ -150,6 +150,7 @@ use anyhow::anyhow;
 use ethercat_hal::devices::ek1100::EK1100_IDENTITY_A;
 use ethercat_hal::devices::el1002::EL1002_IDENTITY_A;
 use ethercat_hal::devices::el1008::EL1008_IDENTITY_A;
+use ethercat_hal::devices::el1124::EL1124_IDENTITY_A;
 use ethercat_hal::devices::el2002::EL2002_IDENTITY_A;
 use ethercat_hal::devices::el2002::EL2002_IDENTITY_B;
 use ethercat_hal::devices::el2004::EL2004_IDENTITY_A;
@@ -173,6 +174,7 @@ use ethercat_hal::devices::el6021::{
 use ethercat_hal::devices::el7031::{EL7031_IDENTITY_A, EL7031_IDENTITY_B};
 use ethercat_hal::devices::el7031_0030::EL7031_0030_IDENTITY_A;
 use ethercat_hal::devices::el7041_0052::EL7041_0052_IDENTITY_A;
+use ethercat_hal::devices::el9505::EL9505_IDENTITY_A;
 use ethercat_hal::devices::subdevice_identity_to_tuple;
 use ethercat_hal::helpers::ethercrab_types::{
     EthercrabSubDeviceOperational, EthercrabSubDevicePreoperational,
@@ -403,6 +405,7 @@ pub fn get_identification_addresses(
         EK1100_IDENTITY_A => MachineIdentificationAddresses::default(),
         EL1002_IDENTITY_A => MachineIdentificationAddresses::default(),
         EL1008_IDENTITY_A => MachineIdentificationAddresses::default(),
+        EL1124_IDENTITY_A => MachineIdentificationAddresses::default(),
         EL2002_IDENTITY_A | EL2002_IDENTITY_B => MachineIdentificationAddresses::default(),
         EL2004_IDENTITY_A => MachineIdentificationAddresses::default(),
         EL2008_IDENTITY_A | EL2008_IDENTITY_B => MachineIdentificationAddresses::default(),
@@ -423,6 +426,7 @@ pub fn get_identification_addresses(
         EL7031_IDENTITY_A | EL7031_IDENTITY_B => MachineIdentificationAddresses::default(),
         EL7031_0030_IDENTITY_A => MachineIdentificationAddresses::default(),
         EL7041_0052_IDENTITY_A => MachineIdentificationAddresses::default(),
+        EL9505_IDENTITY_A => MachineIdentificationAddresses::default(),
 
         _ => {
             // block_on(u16dump(&subdevice, maindevice, 0x00, 0xff))?;


### PR DESCRIPTION
## What does this PR do / add / change?
Adds missing machine identifications to machines/src/machine_identification.rs.

## Checklist before opening the pr

- [x] Tested locally
- [ ] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
