### PR TITLE
Fix machines showing before subdevice initialization

### DIFF
--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -72,8 +72,6 @@ pub enum AsyncThreadMessage {
     NoMsg,
     SubscribeToMachine(MachineSubscriptionRequest),
     UnsubscribeFromMachine(MachineSubscriptionRequest),
-    /// Sent by the RT loop once all EtherCAT subdevices are operational.
-    /// The async handler should then add pending machines to the frontend list.
     MachinesInitialized,
 }
 

--- a/machines/src/lib.rs
+++ b/machines/src/lib.rs
@@ -72,6 +72,9 @@ pub enum AsyncThreadMessage {
     NoMsg,
     SubscribeToMachine(MachineSubscriptionRequest),
     UnsubscribeFromMachine(MachineSubscriptionRequest),
+    /// Sent by the RT loop once all EtherCAT subdevices are operational.
+    /// The async handler should then add pending machines to the frontend list.
+    MachinesInitialized,
 }
 
 pub struct MachineNewParams<

--- a/server/src/app_state.rs
+++ b/server/src/app_state.rs
@@ -84,9 +84,6 @@ pub struct SharedState {
     pub socketio_setup: SocketioSetup,
     pub api_machines: Mutex<HashMap<MachineIdentificationUnique, Sender<MachineMessage>>>,
     pub current_machines_meta: Mutex<Vec<MachineObj>>,
-    /// Machines that have been created but whose EtherCAT subdevices are not yet
-    /// operational. They will be moved to `current_machines_meta` and announced
-    /// to the frontend once the RT loop confirms all subdevices are in OP state.
     pub pending_machine_objs: Mutex<Vec<MachineObj>>,
     pub rt_machine_creation_channel: Sender<HotThreadMessage>,
     pub main_channel: Sender<AsyncThreadMessage>,
@@ -260,17 +257,17 @@ impl SharedState {
         }
     }
 
-    /// Stores machine objects that are pending EtherCAT subdevice initialization.
-    /// These will be announced to the frontend once the RT loop confirms all
-    /// subdevices have reached OP state.
+    // Stores machine objects that are pending EtherCAT subdevice initialization.
+    // These will be announced to the frontend once the RT loop confirms all
+    // subdevices have reached OP state.
     pub async fn store_pending_machine_objs(&self, machine_objs: Vec<MachineObj>) {
         let mut pending = self.pending_machine_objs.lock().await;
         pending.extend(machine_objs);
     }
 
-    /// Moves all pending machine objects to the current machines list and sends
-    /// a machines event to the frontend. Called by the async handler when the RT
-    /// loop reports that all EtherCAT subdevices are operational.
+    // Moves all pending machine objects to the current machines list and sends
+    // a machines event to the frontend. Called by the async handler when the RT
+    // loop reports that all EtherCAT subdevices are operational.
     pub async fn flush_pending_machines(&self) {
         let pending = {
             let mut pending = self.pending_machine_objs.lock().await;

--- a/server/src/app_state.rs
+++ b/server/src/app_state.rs
@@ -84,6 +84,10 @@ pub struct SharedState {
     pub socketio_setup: SocketioSetup,
     pub api_machines: Mutex<HashMap<MachineIdentificationUnique, Sender<MachineMessage>>>,
     pub current_machines_meta: Mutex<Vec<MachineObj>>,
+    /// Machines that have been created but whose EtherCAT subdevices are not yet
+    /// operational. They will be moved to `current_machines_meta` and announced
+    /// to the frontend once the RT loop confirms all subdevices are in OP state.
+    pub pending_machine_objs: Mutex<Vec<MachineObj>>,
     pub rt_machine_creation_channel: Sender<HotThreadMessage>,
     pub main_channel: Sender<AsyncThreadMessage>,
     pub ethercat_meta_data: RwLock<Vec<EtherCatDeviceMetaData>>,
@@ -242,6 +246,7 @@ impl SharedState {
         let (socket_queue_tx, socket_queue_rx) = smol::channel::unbounded();
         Self {
             current_machines_meta: vec![].into(),
+            pending_machine_objs: vec![].into(),
             ethercat_meta_data: vec![].into(),
             socketio_setup: SocketioSetup {
                 socketio: RwLock::new(None),
@@ -253,5 +258,34 @@ impl SharedState {
             rt_machine_creation_channel: sender,
             main_channel: main_async_channel,
         }
+    }
+
+    /// Stores machine objects that are pending EtherCAT subdevice initialization.
+    /// These will be announced to the frontend once the RT loop confirms all
+    /// subdevices have reached OP state.
+    pub async fn store_pending_machine_objs(&self, machine_objs: Vec<MachineObj>) {
+        let mut pending = self.pending_machine_objs.lock().await;
+        pending.extend(machine_objs);
+    }
+
+    /// Moves all pending machine objects to the current machines list and sends
+    /// a machines event to the frontend. Called by the async handler when the RT
+    /// loop reports that all EtherCAT subdevices are operational.
+    pub async fn flush_pending_machines(&self) {
+        let pending = {
+            let mut pending = self.pending_machine_objs.lock().await;
+            std::mem::take(&mut *pending)
+        };
+
+        if pending.is_empty() {
+            return;
+        }
+
+        tracing::info!(
+            "Flushing {} pending machines to frontend (subdevices now operational)",
+            pending.len()
+        );
+
+        self.add_machines_if_not_exists(pending).await;
     }
 }

--- a/server/src/ethercat/setup.rs
+++ b/server/src/ethercat/setup.rs
@@ -176,8 +176,9 @@ pub async fn set_ethercat_devices<const MAX_SUBDEVICES: usize, const MAX_PDI: us
         .send(crate::app_state::HotThreadMessage::AddMachines(machines))
         .await;
 
-    shared_state.add_machines_if_not_exists(machine_objs).await;
-    shared_state.clone().send_machines_event().await;
+    // Store machine metadata in SharedState so the RT loop can
+    // notify the frontend once subdevices become operational.
+    shared_state.store_pending_machine_objs(machine_objs).await;
 
     Ok(())
 }

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -153,9 +153,15 @@ pub fn start_loop_thread(
     return res;
 }
 
+/// Copies EtherCAT inputs from all subdevices.
+///
+/// Returns `Ok(true)` if subdevices just became operational for the first time
+/// (i.e. transitioned from not-all-OP to all-OP in this call).
+/// Returns `Ok(false)` if subdevices were already operational or there is no
+/// EtherCAT setup.
 pub async fn copy_ethercat_inputs(
     ethercat_setup: Option<&mut EthercatSetup>,
-) -> Result<(), anyhow::Error> {
+) -> Result<bool, anyhow::Error> {
     // only if we have an ethercat setup
     // - tx/rx cycle
     // - copy inputs to devices
@@ -205,8 +211,9 @@ pub async fn copy_ethercat_inputs(
                     )
                 })?;
             }
-            return Ok(());
+            return Ok(false);
         } else {
+            // Busy-wait until all subdevices reach OP state
             loop {
                 let now = Instant::now();
                 let response @ TxRxResponse {
@@ -223,13 +230,14 @@ pub async fn copy_ethercat_inputs(
                     .expect("TX/RX");
                 if response.all_op() {
                     ethercat_setup.all_operational = true;
-                    break;
+                    tracing::info!("All EtherCAT subdevices now operational");
+                    return Ok(true);
                 }
                 smol::Timer::at(now + next_cycle_wait).await;
             }
         }
     }
-    Ok(())
+    Ok(false)
 }
 
 pub async fn copy_ethercat_outputs(
@@ -291,7 +299,24 @@ pub fn loop_once<'maindevice>(inputs: &mut RtLoopInputs<'_>) -> Result<(), anyho
 
         let res = smol::block_on(copy_ethercat_inputs(inputs.ethercat_setup.as_deref_mut()));
         match res {
-            Ok(_) => (),
+            Ok(just_became_operational) => {
+                if just_became_operational {
+                    // Subdevices just reached OP state for the first time.
+                    // Notify the async handler to make pending machines visible in the frontend.
+                    if let Some(sender) = inputs
+                        .machine_manager
+                        .machine_entries
+                        .first()
+                        .and_then(|entry| entry.machine.get_main_sender())
+                    {
+                        let _ = sender.try_send(machines::AsyncThreadMessage::MachinesInitialized);
+                        tracing::info!(
+                            "Sent MachinesInitialized to async handler ({} machines pending)",
+                            inputs.machine_manager.machine_entries.len()
+                        );
+                    }
+                }
+            }
             Err(e) => {
                 return Err(anyhow::anyhow!("copy_ethercat_inputs failed: {:?}", e));
             }

--- a/server/src/loop.rs
+++ b/server/src/loop.rs
@@ -153,12 +153,12 @@ pub fn start_loop_thread(
     return res;
 }
 
-/// Copies EtherCAT inputs from all subdevices.
-///
-/// Returns `Ok(true)` if subdevices just became operational for the first time
-/// (i.e. transitioned from not-all-OP to all-OP in this call).
-/// Returns `Ok(false)` if subdevices were already operational or there is no
-/// EtherCAT setup.
+// Copies EtherCAT inputs from all subdevices.
+//
+// Returns `Ok(true)` if subdevices just became operational for the first time
+// (i.e. transitioned from not-all-OP to all-OP in this call).
+// Returns `Ok(false)` if subdevices were already operational or there is no
+// EtherCAT setup.
 pub async fn copy_ethercat_inputs(
     ethercat_setup: Option<&mut EthercatSetup>,
 ) -> Result<bool, anyhow::Error> {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -278,6 +278,11 @@ async fn handle_async_requests(recv: Receiver<AsyncThreadMessage>, shared_state:
                     .await
                     .expect("Could not send to real-time channel");
             }
+            MachinesInitialized => {
+                // The RT loop has confirmed all EtherCAT subdevices are
+                // operational. Flush pending machines to the frontend.
+                shared_state.flush_pending_machines().await;
+            }
         }
     }
 


### PR DESCRIPTION
Fix for: https://github.com/qitechgmbh/control/issues/1349, where an user was able to open the machine, before it was initialized, which lead to being unable to control it and the user having to restart the backendprocess.

## What does this PR do / add / change?
Adds an pending machine obj, where all machines are appended until the subdevices are initialized. And only then the machines can show up in the frontend. Flow after the fix:
```
setup_loop → creates machines → stores as pending (NOT visible)
         → EthercatSetup with all_operational=false → RT loop
RT loop  → copy_ethercat_inputs busy-waits for all_op()
         → returns Ok(true) → sends MachinesInitialized via main channel
async handler → flush_pending_machines() → adds to frontend list → MachinesEvent emitted
frontend → receives MachinesEvent → renders machines
```


## Checklist before opening the pr

- [x] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
