### PR TITLE
Add target values over time to Excel export

### DIFF
--- a/electron/src/components/graph/excelExport/excelDataSheetBuilder.ts
+++ b/electron/src/components/graph/excelExport/excelDataSheetBuilder.ts
@@ -34,14 +34,31 @@ export class DataSheetBuilder {
     const [timestamps, values] = seriesToUPlotData(this.graphLine.series.long);
     const unitSymbol = renderUnitSymbol(this.unit) || "";
 
+    const targetLine = this.graphLine.targetLines.find(
+      (line): line is Extract<GraphLine, { type: "target" }> =>
+        line.type === "target",
+    );
+
+    const getTargetAt = targetLine
+      ? this.buildTargetLookup(targetLine)
+      : undefined;
+
     const sheetData: any[][] = [];
 
     // Build header
     const col1Header = unitSymbol
       ? `${unitSymbol} ${this.seriesTitle}`
       : this.seriesTitle;
+    const col2Header = targetLine ? "Target" : "";
 
-    sheetData.push(["Timestamp", col1Header, "", "", "Statistic", "Value"]);
+    sheetData.push([
+      "Timestamp",
+      col1Header,
+      col2Header,
+      "",
+      "Statistic",
+      "Value",
+    ]);
 
     // Build stats section
     const statsRows = this.buildStatsRows(timestamps, values, unitSymbol);
@@ -49,7 +66,13 @@ export class DataSheetBuilder {
     // Combine data and stats rows
     const maxRows = Math.max(timestamps.length, statsRows.length);
     for (let i = 0; i < maxRows; i++) {
-      const row = this.buildDataRow(i, timestamps, values, statsRows);
+      const row = this.buildDataRow(
+        i,
+        timestamps,
+        values,
+        statsRows,
+        getTargetAt,
+      );
       sheetData.push(row);
     }
 
@@ -62,7 +85,7 @@ export class DataSheetBuilder {
     worksheet["!cols"] = [
       { wch: 20 }, // Timestamp
       { wch: 15 }, // Value
-      { wch: 5 }, // Empty
+      { wch: targetLine ? 15 : 5 }, // Target (or spacer)
       { wch: 5 }, // Empty
       { wch: 30 }, // Statistic name
       { wch: 20 }, // Statistic value
@@ -143,11 +166,36 @@ export class DataSheetBuilder {
     return statsRows;
   }
 
+  private buildTargetLookup(
+    targetLine: Extract<GraphLine, { type: "target" }>,
+  ): (timestamp: number) => string {
+    if (targetLine.targetSeries) {
+      const [tts, tvs] = seriesToUPlotData(targetLine.targetSeries.long);
+      return (ts: number) => {
+        // Step-interpolation: find last target timestamp <= ts
+        let lo = 0,
+          hi = tts.length - 1,
+          idx = -1;
+        while (lo <= hi) {
+          const mid = (lo + hi) >> 1;
+          if (tts[mid] <= ts) {
+            idx = mid;
+            lo = mid + 1;
+          } else hi = mid - 1;
+        }
+        const v = idx >= 0 ? tvs[idx] : targetLine.value;
+        return Number.isFinite(v) ? this.formatValue(v) : "";
+      };
+    }
+    return () => this.formatValue(targetLine.value);
+  }
+
   private buildDataRow(
     index: number,
     timestamps: number[],
     values: number[],
     statsRows: string[][],
+    getTargetAt?: (timestamp: number) => string,
   ): any[] {
     const row: any[] = ["", "", "", ""];
 
@@ -156,6 +204,7 @@ export class DataSheetBuilder {
       const date = new Date(timestamps[index]);
       row[0] = this.formatter.formatDate(date);
       row[1] = this.formatValue(values[index]);
+      row[2] = getTargetAt ? getTargetAt(timestamps[index]) : "";
     }
 
     // Add stats


### PR DESCRIPTION
## What does this PR do / add / change?
Adds the target values over time to the excel export, for every graph that has an target line.

## Screenshots
<img width="1446" height="1350" alt="grafik" src="https://github.com/user-attachments/assets/7b9578e2-f3c7-409b-ad10-9f4b8624dbfa" />


## Checklist before opening the pr

- [x] Tested locally
- [ ] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
