### PR TITLE
nixos: make nix downloads more resillient

### DIFF
--- a/nixos/os/configuration.nix
+++ b/nixos/os/configuration.nix
@@ -70,6 +70,8 @@ in
     settings = {
       experimental-features = "nix-command flakes";
       cores = 2;
+      http-connections = 10;
+      download-attempts = 15;
     };
   };
 


### PR DESCRIPTION
## What does this PR do / add / change?

- Reduce parallel downloads from default 25 to 10
- Increase attempts to 10

## Screenshots

<!-- Include screenshots for any UI changes. Remove this section if not applicable. -->

## Checklist before opening the pr

- [ ] Tested locally
- [ ] Tested on the machine (if hardware interaction is involved)
- [ ] No format errors (`cargo fmt` / `npm run format`)
- [ ] No build errors (`cargo build` / `npm run build`)
