### PR TITLE
Switch to mailbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 dependencies = [
  "anyhow",
  "libc",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal_derive"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 dependencies = [
  "deluxe",
  "proc-macro2",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "machines"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 
 [[package]]
 name = "matchit"
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "modbus"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 dependencies = [
  "anyhow",
  "common",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "qitech_lib"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 dependencies = [
  "bitvec",
  "common",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "serial"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 dependencies = [
  "anyhow",
  "tokio",
@@ -2744,7 +2744,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 [[package]]
 name = "units"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
 dependencies = [
  "uom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 dependencies = [
  "anyhow",
  "libc",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal_derive"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 dependencies = [
  "deluxe",
  "proc-macro2",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "machines"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 
 [[package]]
 name = "matchit"
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "modbus"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 dependencies = [
  "anyhow",
  "common",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "qitech_lib"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 dependencies = [
  "bitvec",
  "common",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "serial"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 dependencies = [
  "anyhow",
  "tokio",
@@ -2744,7 +2744,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 [[package]]
 name = "units"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=8fb39829971ff71f1e211008283801c8765c5197#8fb39829971ff71f1e211008283801c8765c5197"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6aa13a54602577cdcfcb59824b348a61fb4cb3d9#6aa13a54602577cdcfcb59824b348a61fb4cb3d9"
 dependencies = [
  "uom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = []
 resolver = "2"
 
 [workspace.dependencies]
-qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "8fb39829971ff71f1e211008283801c8765c5197" }
+qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "6aa13a54602577cdcfcb59824b348a61fb4cb3d9" }
 
 [workspace.lints.clippy]
 # don't lint poissbilities for let chains because they were introduces after Rust 1.86

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = []
 resolver = "2"
 
 [workspace.dependencies]
-qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "6aa13a54602577cdcfcb59824b348a61fb4cb3d9" }
+qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "1058e40d9d63c234e55510aefe35b54938bf0a41" }
 
 [workspace.lints.clippy]
 # don't lint poissbilities for let chains because they were introduces after Rust 1.86

--- a/qitech_control/src/app_state.rs
+++ b/qitech_control/src/app_state.rs
@@ -82,7 +82,7 @@ impl SharedAppState {
         infos: Vec<MachineDeviceInfo>,
     ) -> Result<(), anyhow::Error> {
         let mut guard = self.ethercat_meta_datas.try_write()?;
-        for i in 0..controller.subdevice_count {
+        for i in 0..controller.get_subdevice_count() {
             let dev = controller.subdevices[i];
             let device_machine_identification = infos
                 .iter()

--- a/qitech_control/src/machine_loop.rs
+++ b/qitech_control/src/machine_loop.rs
@@ -10,7 +10,9 @@ pub fn write_ecat_inputs<C: Consumer, P: Producer>(
     ecat: &mut EtherCATAppHandle<C, P>,
     subdevices: Vec<(MetaSubdevice, Rc<RefCell<dyn EthercatDevice>>)>,
 ) {
-    let inputs = ecat.get_inputs().expect("There should always be an input (latest state)");
+    let inputs = ecat
+        .get_inputs()
+        .expect("There should always be an input (latest state)");
     //println!("{:?}", inputs);
     for i in 0..subdevices.len() {
         let meta_dev = subdevices[i].0;
@@ -43,12 +45,11 @@ pub fn write_ecat_outputs<C: Consumer, P: Producer>(
                 }
             }
             ecat.send_outputs();
-        },
+        }
         None => {
             // Do nothing
-        },
-    }   
-    
+        }
+    }
 }
 
 pub fn run_machines(

--- a/qitech_control/src/machine_loop.rs
+++ b/qitech_control/src/machine_loop.rs
@@ -10,7 +10,8 @@ pub fn write_ecat_inputs<C: Consumer, P: Producer>(
     ecat: &mut EtherCATAppHandle<C, P>,
     subdevices: Vec<(MetaSubdevice, Rc<RefCell<dyn EthercatDevice>>)>,
 ) {
-    let inputs = ecat.get_inputs();
+    let inputs = ecat.get_inputs().expect("There should always be an input (latest state)");
+    //println!("{:?}", inputs);
     for i in 0..subdevices.len() {
         let meta_dev = subdevices[i].0;
         let subdevice = subdevices.get(i).unwrap();
@@ -28,19 +29,26 @@ pub fn write_ecat_outputs<C: Consumer, P: Producer>(
     ecat: &mut EtherCATAppHandle<C, P>,
     subdevices: Vec<(MetaSubdevice, Rc<RefCell<dyn EthercatDevice>>)>,
 ) {
-    let outputs = ecat.write_outputs();
-    for i in 0..subdevices.len() {
-        let meta_dev = subdevices[i].0;
-        let subdevice = subdevices.get(i).unwrap();
-        let output_slice = &mut outputs[meta_dev.start_rx..meta_dev.end_rx];
-        let output_bits = BitSlice::<u8, Lsb0>::from_slice_mut(output_slice);
-        {
-            let mut subdevice = subdevice.1.borrow_mut();
-            let _res = subdevice.output_pre_process();
-            let _res = subdevice.output(output_bits);
-        }
-    }
-    ecat.send_outputs();
+    match ecat.write_outputs() {
+        Some(outputs) => {
+            for i in 0..subdevices.len() {
+                let meta_dev = subdevices[i].0;
+                let subdevice = subdevices.get(i).unwrap();
+                let output_slice = &mut outputs[meta_dev.start_rx..meta_dev.end_rx];
+                let output_bits = BitSlice::<u8, Lsb0>::from_slice_mut(output_slice);
+                {
+                    let mut subdevice = subdevice.1.borrow_mut();
+                    let _res = subdevice.output_pre_process();
+                    let _res = subdevice.output(output_bits);
+                }
+            }
+            ecat.send_outputs();
+        },
+        None => {
+            // Do nothing
+        },
+    }   
+    
 }
 
 pub fn run_machines(

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -5,7 +5,7 @@ use machine_implementations::registry::MACHINE_REGISTRY;
 #[cfg(not(feature = "mock"))]
 use machine_loop::{run_machines, write_ecat_inputs, write_ecat_outputs};
 use qitech_lib::ethercat_hal::{
-    BECKHOFF_VENDOR_ID, EtherCATControl, Mailbox, TripleBufConsumer, TripleBufProducer
+    BECKHOFF_VENDOR_ID, EtherCATControl, Mailbox, TripleBufConsumer, TripleBufProducer,
 };
 #[cfg(not(feature = "mock"))]
 use qitech_lib::ethercat_hal::{
@@ -33,7 +33,7 @@ pub mod persist;
 fn setup_ethercat(
     state: Arc<SharedAppState>,
     main_state: &mut MainState,
-    eth_control: &EtherCATControl<Arc<Mailbox>,TripleBufProducer,TripleBufConsumer,Arc<Mailbox>>,
+    eth_control: &EtherCATControl<Arc<Mailbox>, TripleBufProducer, TripleBufConsumer, Arc<Mailbox>>,
 ) {
     let _res = eth_control
         .channel
@@ -149,7 +149,7 @@ fn send_machines_event(state: Arc<SharedAppState>) {
 
 fn finalize_ethercat(
     main_state: &mut MainState,
-    eth_control:  &EtherCATControl<Arc<Mailbox>,TripleBufProducer,TripleBufConsumer,Arc<Mailbox>>,
+    eth_control: &EtherCATControl<Arc<Mailbox>, TripleBufProducer, TripleBufConsumer, Arc<Mailbox>>,
 ) {
     let _res = eth_control
         .channel
@@ -214,7 +214,7 @@ fn detect_and_build_machines(state: Arc<SharedAppState>, main_state: &mut MainSt
 
 fn optimized_ethercat_init(
     interface: &str,
-) ->  EtherCATControl<Arc<Mailbox>,TripleBufProducer,TripleBufConsumer,Arc<Mailbox>> {
+) -> EtherCATControl<Arc<Mailbox>, TripleBufProducer, TripleBufConsumer, Arc<Mailbox>> {
     let target_cycle_time_us: u64 = 1000;
     let dc_config: DcConfiguration = DcConfiguration {
         start_delay: Duration::from_millis(100),

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -5,7 +5,7 @@ use machine_implementations::registry::MACHINE_REGISTRY;
 #[cfg(not(feature = "mock"))]
 use machine_loop::{run_machines, write_ecat_inputs, write_ecat_outputs};
 use qitech_lib::ethercat_hal::{
-    BECKHOFF_VENDOR_ID, EtherCATControl, TripleBufConsumer, TripleBufProducer,
+    BECKHOFF_VENDOR_ID, EtherCATControl, Mailbox, TripleBufConsumer, TripleBufProducer
 };
 #[cfg(not(feature = "mock"))]
 use qitech_lib::ethercat_hal::{
@@ -33,7 +33,7 @@ pub mod persist;
 fn setup_ethercat(
     state: Arc<SharedAppState>,
     main_state: &mut MainState,
-    eth_control: &EtherCATControl<TripleBufConsumer, TripleBufProducer>,
+    eth_control: &EtherCATControl<Arc<Mailbox>,TripleBufProducer,TripleBufConsumer,Arc<Mailbox>>,
 ) {
     let _res = eth_control
         .channel
@@ -43,7 +43,7 @@ fn setup_ethercat(
     let mut idents = vec![];
     println!(
         "Initialized {} subdevices",
-        eth_control.controller.subdevice_count
+        eth_control.controller.get_subdevice_count()
     );
 
     for meta in eth_control.controller.get_subdevices() {
@@ -149,7 +149,7 @@ fn send_machines_event(state: Arc<SharedAppState>) {
 
 fn finalize_ethercat(
     main_state: &mut MainState,
-    eth_control: &EtherCATControl<TripleBufConsumer, TripleBufProducer>,
+    eth_control:  &EtherCATControl<Arc<Mailbox>,TripleBufProducer,TripleBufConsumer,Arc<Mailbox>>,
 ) {
     let _res = eth_control
         .channel
@@ -214,7 +214,7 @@ fn detect_and_build_machines(state: Arc<SharedAppState>, main_state: &mut MainSt
 
 fn optimized_ethercat_init(
     interface: &str,
-) -> EtherCATControl<TripleBufConsumer, TripleBufProducer> {
+) ->  EtherCATControl<Arc<Mailbox>,TripleBufProducer,TripleBufConsumer,Arc<Mailbox>> {
     let target_cycle_time_us: u64 = 1000;
     let dc_config: DcConfiguration = DcConfiguration {
         start_delay: Duration::from_millis(100),
@@ -320,7 +320,7 @@ fn main_logic() {
     let state = Arc::new(shared_state);
     match &eth_control {
         Some(ecat) => {
-            send_ecat_state(state.clone(), ecat.controller.state.into());
+            send_ecat_state(state.clone(), ecat.controller.get_state().into());
         }
         None => (),
     }
@@ -334,7 +334,7 @@ fn main_logic() {
 
     match &eth_control {
         Some(ecat) => {
-            send_ecat_state(state.clone(), ecat.controller.state.into());
+            send_ecat_state(state.clone(), ecat.controller.get_state().into());
         }
         None => (),
     }
@@ -354,7 +354,7 @@ fn main_logic() {
     match &eth_control {
         Some(ecat) => {
             finalize_ethercat(&mut main_state, ecat);
-            send_ecat_state(state.clone(), ecat.controller.state.into());
+            send_ecat_state(state.clone(), ecat.controller.get_state().into());
         }
         None => (),
     };


### PR DESCRIPTION
## What does this PR do / add / change?

Switched out the default impl of qitech_lib rxpdo to Mailbox for ensuring that events are not treated as state.
Rxpdo -> Event
txpdo -> latest state

### Checklist before opening the pr

- [x] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
