### PR TITLE
Staging Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 dependencies = [
  "anyhow",
  "libc",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal_derive"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 dependencies = [
  "deluxe",
  "proc-macro2",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "machines"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 
 [[package]]
 name = "matchit"
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "modbus"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 dependencies = [
  "anyhow",
  "common",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "qitech_lib"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 dependencies = [
  "bitvec",
  "common",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "serial"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 dependencies = [
  "anyhow",
  "tokio",
@@ -2819,7 +2819,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 [[package]]
 name = "units"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
 dependencies = [
  "uom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 dependencies = [
  "anyhow",
  "libc",
@@ -455,7 +455,7 @@ dependencies = [
  "core_affinity",
  "crc",
  "erased-serde",
- "ethercrab",
+ "ethercrab 0.6.0",
  "interfaces",
  "libc",
  "qitech_lib",
@@ -815,14 +815,14 @@ dependencies = [
 [[package]]
 name = "ethercat_hal"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 dependencies = [
  "anyhow",
  "bitvec",
  "common",
  "core_affinity",
  "ethercat_hal_derive",
- "ethercrab",
+ "ethercrab 0.7.1",
  "libc",
  "rand 0.9.4",
  "smol",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal_derive"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 dependencies = [
  "deluxe",
  "proc-macro2",
@@ -856,7 +856,7 @@ dependencies = [
  "crc",
  "embassy-time",
  "embedded-io-async",
- "ethercrab-wire",
+ "ethercrab-wire 0.2.0",
  "futures-lite",
  "heapless",
  "io-uring",
@@ -874,11 +874,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethercrab"
+version = "0.7.1"
+source = "git+https://github.com/ethercrab-rs/ethercrab?branch=main#4c7d36157fa5caab3194df494e92e08551cd2e43"
+dependencies = [
+ "async-io",
+ "atomic-waker",
+ "atomic_enum",
+ "bitflags 2.11.1",
+ "crc",
+ "embassy-time",
+ "embedded-io-async",
+ "ethercrab-wire 0.3.0",
+ "futures-lite",
+ "heapless",
+ "io-uring",
+ "libc",
+ "lock_api",
+ "log",
+ "nix 0.31.3",
+ "pcap",
+ "pnet_datalink",
+ "sealed",
+ "slab",
+ "smallvec",
+ "smlang",
+ "spin",
+ "timerfd",
+]
+
+[[package]]
 name = "ethercrab-wire"
 version = "0.2.0"
 source = "git+https://github.com/v-morlock/ethercrab?branch=main#d297d13389d85a4edb4e69cc98f9dd7f12626cac"
 dependencies = [
- "ethercrab-wire-derive",
+ "ethercrab-wire-derive 0.2.0",
+ "heapless",
+]
+
+[[package]]
+name = "ethercrab-wire"
+version = "0.3.0"
+source = "git+https://github.com/ethercrab-rs/ethercrab?branch=main#4c7d36157fa5caab3194df494e92e08551cd2e43"
+dependencies = [
+ "ethercrab-wire-derive 0.3.0",
  "heapless",
 ]
 
@@ -886,6 +925,17 @@ dependencies = [
 name = "ethercrab-wire-derive"
 version = "0.2.0"
 source = "git+https://github.com/v-morlock/ethercrab?branch=main#d297d13389d85a4edb4e69cc98f9dd7f12626cac"
+dependencies = [
+ "criterion",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ethercrab-wire-derive"
+version = "0.3.0"
+source = "git+https://github.com/ethercrab-rs/ethercrab?branch=main#4c7d36157fa5caab3194df494e92e08551cd2e43"
 dependencies = [
  "criterion",
  "proc-macro2",
@@ -1420,6 +1470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "machines"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 
 [[package]]
 name = "matchit"
@@ -1522,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "modbus"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 dependencies = [
  "anyhow",
  "common",
@@ -1564,6 +1623,19 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -1833,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "qitech_lib"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 dependencies = [
  "bitvec",
  "common",
@@ -2122,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "serial"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 dependencies = [
  "anyhow",
  "tokio",
@@ -2326,6 +2398,9 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2744,7 +2819,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 [[package]]
 name = "units"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=1058e40d9d63c234e55510aefe35b54938bf0a41#1058e40d9d63c234e55510aefe35b54938bf0a41"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=6110764e02b5ff3769f9e1615946ccd3888cc9a0#6110764e02b5ff3769f9e1615946ccd3888cc9a0"
 dependencies = [
  "uom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 dependencies = [
  "anyhow",
  "libc",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "ethercat_hal_derive"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 dependencies = [
  "deluxe",
  "proc-macro2",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "machines"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 
 [[package]]
 name = "matchit"
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "modbus"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 dependencies = [
  "anyhow",
  "common",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "qitech_lib"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 dependencies = [
  "bitvec",
  "common",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "serial"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 dependencies = [
  "anyhow",
  "tokio",
@@ -2819,7 +2819,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 [[package]]
 name = "units"
 version = "0.1.0"
-source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b41e7601776011e8c83967265e8c08da6754038b#b41e7601776011e8c83967265e8c08da6754038b"
+source = "git+https://github.com/qitechgmbh/qitech_lib.git?rev=b0277b75b525a4e74cc53601b0f02d8a6306b4e5#b0277b75b525a4e74cc53601b0f02d8a6306b4e5"
 dependencies = [
  "uom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = []
 resolver = "2"
 
 [workspace.dependencies]
-qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "1058e40d9d63c234e55510aefe35b54938bf0a41" }
+qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "6110764e02b5ff3769f9e1615946ccd3888cc9a0" }
 
 [workspace.lints.clippy]
 # don't lint poissbilities for let chains because they were introduces after Rust 1.86

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = []
 resolver = "2"
 
 [workspace.dependencies]
-qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "6110764e02b5ff3769f9e1615946ccd3888cc9a0" }
+qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "b41e7601776011e8c83967265e8c08da6754038b" }
 
 [workspace.lints.clippy]
 # don't lint poissbilities for let chains because they were introduces after Rust 1.86

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = []
 resolver = "2"
 
 [workspace.dependencies]
-qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "b41e7601776011e8c83967265e8c08da6754038b" }
+qitech_lib = { git = "https://github.com/qitechgmbh/qitech_lib.git", rev  = "b0277b75b525a4e74cc53601b0f02d8a6306b4e5" }
 
 [workspace.lints.clippy]
 # don't lint poissbilities for let chains because they were introduces after Rust 1.86

--- a/electron/src/client/socketioStore.ts
+++ b/electron/src/client/socketioStore.ts
@@ -319,7 +319,8 @@ export const useSocketioStore = create<SocketioStore>()((set, get) => ({
         );
       }
     });
-    socket.on("disconnect", (_reason) => {
+    socket.on("disconnect", (reason) => {
+      console.debug(`Disconnected from ${namespace_path}: ${reason}`);
       resetStore(set);
       if (namespace_path === "/main") {
         mainNamespaceStore.setState({

--- a/electron/src/client/socketioStore.ts
+++ b/electron/src/client/socketioStore.ts
@@ -312,6 +312,8 @@ export const useSocketioStore = create<SocketioStore>()((set, get) => ({
     socket.on("disconnect", (reason) => {
       socket.disconnect();
       resetStore(set);
+      
+      window.location.reload();
     });
     socket.on("event", (event: unknown) => {
       const event_parsed = eventSchema(z.any()).safeParse(event);

--- a/electron/src/client/socketioStore.ts
+++ b/electron/src/client/socketioStore.ts
@@ -9,6 +9,7 @@ import { toastError, toastZodError } from "@/components/Toast";
 import { MachineIdentificationUnique } from "@/machines/types";
 import { FPS_30 } from "@/lib/constants";
 import { mainNamespaceStore } from "./mainNamespace";
+import { router } from "@/routes/router";
 
 /**
  * Simple buffer-based store updater to limit React re-renders to ~30 FPS
@@ -245,6 +246,7 @@ export function deserializeNamespaceId(namespaceId: string): NamespaceId {
 
 type SocketioStore = {
   baseUrl: string;
+  backendConnected: boolean;
   namespaces: Record<string, Namespace<unknown>>;
   getNamespace: (namespaceId: NamespaceId) => Namespace<unknown> | undefined;
   hasNamespace: (namespaceId: NamespaceId) => boolean;
@@ -265,6 +267,7 @@ type SocketioStore = {
  */
 export const useSocketioStore = create<SocketioStore>()((set, get) => ({
   baseUrl: "http://localhost:3001",
+  backendConnected: false,
   namespaces: {},
   getNamespace: (namespaceId: NamespaceId) => {
     const namespace_path = serializeNamespaceId(namespaceId);
@@ -308,12 +311,45 @@ export const useSocketioStore = create<SocketioStore>()((set, get) => ({
     socket.on("connect", () => {
       console.log(`Connected to ${namespace_path}`);
       resetStore(set);
+      if (namespace_path === "/main") {
+        set(
+          produce((s: SocketioStore) => {
+            s.backendConnected = true;
+          }),
+        );
+      }
     });
-    socket.on("disconnect", (reason) => {
-      socket.disconnect();
+    socket.on("disconnect", (_reason) => {
       resetStore(set);
-      
-      window.location.reload();
+      if (namespace_path === "/main") {
+        mainNamespaceStore.setState({
+          ethercatDevices: null,
+          ethercatState: null,
+          machines: null,
+          ethercatInterfaceDiscovery: null,
+        });
+        set(
+          produce((s: SocketioStore) => {
+            s.backendConnected = false;
+          }),
+        );
+        for (const [path, ns] of Object.entries(get().namespaces)) {
+          if (path !== "/main") ns.socket.disconnect();
+        }
+        router.navigate({ to: "/_sidebar/setup/ethercat" });
+      } else if (namespaceId.type === "machine") {
+        const serial = namespaceId.machine_identification_unique.serial;
+        const repollingInterval = setInterval(() => {
+          const mainState = mainNamespaceStore.getState();
+          const machineExists = mainState.machines?.data?.machines.some(
+            (m) => m.machine_identification_unique.serial === serial,
+          );
+          if (machineExists && !socket.connected) {
+            socket.connect();
+            clearInterval(repollingInterval);
+          }
+        }, 500);
+      }
     });
     socket.on("event", (event: unknown) => {
       const event_parsed = eventSchema(z.any()).safeParse(event);
@@ -471,6 +507,10 @@ export interface NamespaceImplementationConfig<S> {
 }
 
 export type NamespaceImplementationResult<S> = (namespaceId: NamespaceId) => S;
+
+export function useBackendConnected(): boolean {
+  return useSocketioStore((s) => s.backendConnected);
+}
 
 export function createNamespaceHookImplementation<S>({
   createStore,

--- a/electron/src/setup/EthercatPage.tsx
+++ b/electron/src/setup/EthercatPage.tsx
@@ -16,6 +16,7 @@ import {
   EthercatDevicesEventData,
   useMainNamespace,
 } from "@/client/mainNamespace";
+import { useBackendConnected } from "@/client/socketioStore";
 import { restartBackendIntoPreop } from "@/helpers/troubleshoot_helpers";
 import { toast } from "sonner";
 import { TouchButton } from "@/components/touch/TouchButton";
@@ -120,6 +121,7 @@ export function createColumns(
 export function EthercatPage() {
   const { ethercatDevices, ethercatState, ethercatInterfaceDiscovery } =
     useMainNamespace();
+  const backendConnected = useBackendConnected();
   const [isRestartPreopLoading, setIsRestartPreopLoading] = useState(false);
   const etherCatState = ethercatState?.data?.State;
   const data = useMemo(() => {
@@ -178,20 +180,40 @@ export function EthercatPage() {
         <div className="flex w-fit items-center gap-1.5 rounded-full bg-neutral-100 p-0.5 px-3">
           <div
             className={`h-2.5 w-2.5 rounded-full ${
-              etherCatState === "preop"
-                ? "bg-yellow-400"
-                : etherCatState === "op"
-                  ? "bg-green-400"
-                  : "bg-neutral-400"
+              !backendConnected
+                ? "bg-red-400"
+                : etherCatState === "preop"
+                  ? "bg-yellow-400"
+                  : etherCatState === "op"
+                    ? "bg-green-400"
+                    : "bg-neutral-400"
             }`}
           />
-          <span className="text-xs text-neutral-500">{etherCatState}</span>
+          <span className="text-xs text-neutral-500">
+            {!backendConnected ? "disconnected" : etherCatState}
+          </span>
         </div>
       </SectionTitle>
 
       <p style={{ lineHeight: "1.6", margin: "1em 0" }}>
         SubDevices have to be in preop before writing to the EEPROM is allowed
       </p>
+      {!backendConnected && (
+        <span
+          style={{
+            color: "#fff",
+            backgroundColor: "#dc2626",
+            padding: "2px 6px",
+            borderRadius: "4px",
+            fontWeight: "bold",
+            display: "inline-block",
+            width: "max-content",
+            marginLeft: "4px",
+          }}
+        >
+          BACKEND DISCONNECTED — RECONNECTING…
+        </span>
+      )}
       {etherCatState === "preop" && (
         <span
           style={{

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -283,33 +283,40 @@ pub fn remove_machines(
     }
 }
 
-fn find_ethercat_interface() -> Result<String, anyhow::Error> {
-    let interfaces = qitech_lib::ethercat_hal::interface_discovery::list_ethernet_interfaces();
-    match interfaces {
-        Ok(interfaces) => {
-            for interface in interfaces {
-                match interface.link_type {
-                    qitech_lib::ethercat_hal::interface_discovery::LinkType::Link => (),
-                    qitech_lib::ethercat_hal::interface_discovery::LinkType::Unknown => continue,
-                    qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv4 => continue,
-                    qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv6 => continue,
-                };
+fn find_ethercat_interface() -> String {
+    loop {
+        let interfaces = qitech_lib::ethercat_hal::interface_discovery::list_ethernet_interfaces();
+        match interfaces {
+            Ok(interfaces) => {
+                for interface in interfaces {
+                    match interface.link_type {
+                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Link => (),
+                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Unknown => continue,
+                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv4 => continue,
+                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv6 => continue,
+                    };
 
-                let res =
-                    qitech_lib::ethercat_hal::interface_discovery::test_interface(&interface.name);
-                match res {
-                    Ok(_) => {
-                        println!("{} is ethercat", &interface.name);
-                        return Ok(interface.name);
+                    let res = qitech_lib::ethercat_hal::interface_discovery::test_interface(
+                        &interface.name,
+                    );
+                    match res {
+                        Ok(_) => {
+                            println!("{} is ethercat", &interface.name);
+                            return interface.name;
+                        }
+                        Err(_) => println!("{} is not ethercat", &interface.name),
                     }
-                    Err(_) => println!("{} is not ethercat", &interface.name),
                 }
+                println!("No EtherCAT interface found, retrying in 2s...");
             }
-            return Err(anyhow::anyhow!("No EtherCAT Interface Found"));
+            Err(e) => {
+                println!(
+                    "Could not list ethernet interfaces ({:?}), retrying in 2s...",
+                    e
+                );
+            }
         }
-        Err(_) => {
-            return Err(anyhow::anyhow!("No EtherCAT Interface Found"));
-        }
+        std::thread::sleep(Duration::from_secs(2));
     }
 }
 
@@ -319,15 +326,10 @@ fn main_logic() {
         || std::env::args().any(|a| a == "preop");
     let mut shared_state = SharedAppState::new();
     let mut main_state = MainState::new();
-    let res = find_ethercat_interface();
-    let mut eth_control = match res {
-        Ok(interface) => {
-            let eth_control = optimized_ethercat_init(&interface);
-            shared_state.ethercat_thread_channel = Some(eth_control.channel.clone());
-            Some(eth_control)
-        }
-        Err(_) => None,
-    };
+    let interface = find_ethercat_interface();
+    let eth_control = optimized_ethercat_init(&interface);
+    shared_state.ethercat_thread_channel = Some(eth_control.channel.clone());
+    let mut eth_control = Some(eth_control);
 
     let state = Arc::new(shared_state);
     match &eth_control {

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -41,7 +41,33 @@ fn setup_ethercat(
     let _res = eth_control
         .channel
         .request_state_change(qitech_lib::ethercat_hal::EtherCATState::PreOp);
-    std::thread::sleep(Duration::from_millis(5000));
+
+    // Require 2 consecutive stable polls (~100 ms) in PreOp before proceeding.
+    // One poll is not enough: the state machine may still be mid-iteration on first observation,
+    // causing EEPROM reads to contend with its ongoing preop_group tick.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut stable_ticks = 0u32;
+    while stable_ticks < 2 {
+        // State-machine thread died, or timeout — bail for a clean restart.
+        if eth_control
+            .join_handle
+            .as_ref()
+            .map_or(false, |h| h.is_finished())
+            || std::time::Instant::now() >= deadline
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+        // Happy path: bus is in PreOp and subdevices have been enumerated.
+        let preop_ready = eth_control.controller.get_state()
+            == qitech_lib::ethercat_hal::EtherCATState::PreOp
+            && eth_control.controller.get_subdevice_count() > 0;
+        if preop_ready {
+            stable_ticks += 1
+        } else {
+            stable_ticks = 0
+        }
+    }
 
     let mut idents = vec![];
     println!(
@@ -158,6 +184,14 @@ fn finalize_ethercat(
         .channel
         .request_state_change(qitech_lib::ethercat_hal::EtherCATState::Op);
     while !eth_control.controller.is_all_operational() {
+        if eth_control
+            .join_handle
+            .as_ref()
+            .map_or(false, |h| h.is_finished())
+        {
+            // State machine died before reaching OP — bail so main_logic can exit cleanly.
+            return;
+        }
         std::thread::sleep(Duration::from_millis(50));
     }
     for meta in &mut main_state.subdevices {

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -157,7 +157,9 @@ fn finalize_ethercat(
     let _res = eth_control
         .channel
         .request_state_change(qitech_lib::ethercat_hal::EtherCATState::Op);
-    std::thread::sleep(Duration::from_secs(5));
+    while !eth_control.controller.is_all_operational() {
+        std::thread::sleep(Duration::from_millis(50));
+    }
     for meta in &mut main_state.subdevices {
         let m = eth_control
             .controller
@@ -171,6 +173,13 @@ fn finalize_ethercat(
         meta.0.start_rx = m.start_rx;
         meta.0.end_rx = m.end_rx;
     }
+}
+
+fn send_ethercat_devices_event(state: Arc<SharedAppState>) {
+    let rt = get_async_runtime();
+    rt.spawn(async move {
+        let _res = state.send_ethercat_setup_done().await;
+    });
 }
 
 fn send_setup_done_events(state: Arc<SharedAppState>) {
@@ -291,7 +300,9 @@ fn find_ethercat_interface() -> String {
                 for interface in interfaces {
                     match interface.link_type {
                         qitech_lib::ethercat_hal::interface_discovery::LinkType::Link => (),
-                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Unknown => continue,
+                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Unknown => {
+                            continue;
+                        }
                         qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv4 => continue,
                         qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv6 => continue,
                     };
@@ -353,6 +364,9 @@ fn main_logic() {
         None => (),
     }
 
+    // Subdevices are known after PreOp — show them in the frontend now
+    send_ethercat_devices_event(state.clone());
+
     if stay_in_preop && eth_control.is_some() {
         send_setup_done_events(state.clone());
         println!("Staying in PreOp as requested, exiting after setup.");
@@ -361,11 +375,10 @@ fn main_logic() {
         }
     }
 
+    // detect_and_build_machines must run in PreOp (machines initialize assuming PreOp)
     detect_and_build_machines(state.clone(), &mut main_state);
-    send_setup_done_events(state.clone());
 
-    // Order is important here, because when detect_and_build_machines is called
-    // Every machine assumes ethercat devices are in PreOp, finalize moves to OP
+    // finalize_ethercat transitions to OP and waits until all subdevices confirm OP
     match &eth_control {
         Some(ecat) => {
             finalize_ethercat(&mut main_state, ecat);
@@ -373,6 +386,9 @@ fn main_logic() {
         }
         None => (),
     };
+
+    // Only emit machines to frontend after OP state is confirmed
+    send_machines_event(state.clone());
 
     let mut last_check = std::time::Instant::now();
     let hotplug_duration = Duration::from_secs(4);

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -12,6 +12,7 @@ use qitech_lib::{
     ethercat_hal::devices::device_from_subdevice_identity_rc, serial::get_available_ports,
 };
 use qitech_lib::{
+    ethercat_hal::interface_discovery::{LinkType, list_ethernet_interfaces, test_interface},
     ethercat_hal::{
         BECKHOFF_VENDOR_ID, EtherCATControl, Mailbox, TripleBufConsumer, TripleBufProducer,
     },
@@ -46,7 +47,7 @@ fn setup_ethercat(
     // One poll is not enough: the state machine may still be mid-iteration on first observation,
     // causing EEPROM reads to contend with its ongoing preop_group tick.
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    let mut stable_ticks = 0u32;
+    let mut stable_ticks: u32 = 0;
     while stable_ticks < 2 {
         // State-machine thread died, or timeout — bail for a clean restart.
         if eth_control
@@ -328,22 +329,20 @@ pub fn remove_machines(
 
 fn find_ethercat_interface() -> String {
     loop {
-        let interfaces = qitech_lib::ethercat_hal::interface_discovery::list_ethernet_interfaces();
+        let interfaces = list_ethernet_interfaces();
         match interfaces {
             Ok(interfaces) => {
                 for interface in interfaces {
                     match interface.link_type {
-                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Link => (),
-                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Unknown => {
+                        LinkType::Link => (),
+                        LinkType::Unknown => {
                             continue;
                         }
-                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv4 => continue,
-                        qitech_lib::ethercat_hal::interface_discovery::LinkType::Ipv6 => continue,
+                        LinkType::Ipv4 => continue,
+                        LinkType::Ipv6 => continue,
                     };
 
-                    let res = qitech_lib::ethercat_hal::interface_discovery::test_interface(
-                        &interface.name,
-                    );
+                    let res = test_interface(&interface.name);
                     match res {
                         Ok(_) => {
                             println!("{} is ethercat", &interface.name);


### PR DESCRIPTION
## What does this PR do / add / change?
### EtherCat improvements:
- Removes fixed sleep during init with event-driven PreOp wait, making the initialization compared to before about 50% faster (ca. 3,5s now)
- Replaced fixed sleep with event-driven OP whait until is_all_operational() 
- find_ethercat_interface now loops instead of failing
- Thread-death detection
- Machines are emitted to the frontend only after OP is confirmed

### Socket.io:
- Main namespace disconnect redirects to the EtherCAT setup page and clears all main-namespace state (ethercatDevices, ethercatState, machines, ethercatInterfaceDiscovery), then disconnects all other namespaces.
- Machine namespace disconnect auto-reconnects
- backendConnected state is tracked in the socketio store and exposed via useBackendConnected().

### Lib:
Based on: https://github.com/qitechgmbh/qitech_lib/pull/68

## Checklist before opening the pr

- [x] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
