### PR TITLE
nixos: remove unnecessary big stuff

### DIFF
--- a/nixos/os/configuration.nix
+++ b/nixos/os/configuration.nix
@@ -173,7 +173,6 @@ in
   services.pipewire = {
     enable = true;
     alsa.enable = true;
-    alsa.support32Bit = true;
     pulse.enable = true;
   };
 
@@ -236,7 +235,12 @@ in
 
   documentation.doc.enable = false;
   services.gnome.core-apps.enable = false;
-  environment.gnome.excludePackages = [ pkgs.gnome-tour ];
+  services.gnome.localsearch.enable = false;
+  services.gnome.tinysparql.enable = false;
+  environment.gnome.excludePackages = [
+    pkgs.gnome-tour
+    pkgs.orca
+  ];
   environment.systemPackages = with pkgs; [
     # Bare minimum gnome desktop
     gnome-console


### PR DESCRIPTION
## What does this PR do / add / change?

Fix for #1444

Also closure size reduction

```
qitech-control on  staging via  v22.23.0 via 🦀 v1.96.0 via ❄️  impure (nix-shell-env)
> nix path-info -h --closure-size .#nixosConfigurations.nixos.config.system.build.toplevel
/nix/store/jvcv4vxmmbq4nnlbjxgm0vil6hd1z3jx-nixos-system-nixos-_	  8.1 GiB

qitech-control on  9l/nix-conf-fixes-202606 via  v22.23.0 via 🦀 v1.96.0 via ❄️  impure (nix-shell-env)
> nix path-info -h --closure-size .#nixosConfigurations.nixos.config.system.build.toplevel
/nix/store/slc4vk4gqvslby852mbwdnr6bhcw8gcz-nixos-system-nixos-_	  7.5 GiB
```

## Screenshots

<!-- Include screenshots for any UI changes. Remove this section if not applicable. -->

## Checklist before opening the pr

- [ ] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
