### PR TITLE
1439 bug missleading error message when no devices are detected

### DIFF
--- a/electron/src/client/mainNamespace.ts
+++ b/electron/src/client/mainNamespace.ts
@@ -54,7 +54,7 @@ export const ethercatDevicesEventSchema = eventSchema(
 export type EthercatDevicesEvent = z.infer<typeof ethercatDevicesEventSchema>;
 
 export const ethercatStateEventDataSchema = z.object({
-  state: z.string(),
+  State: z.string(),
 });
 
 export type EthercatStateEventData = z.infer<

--- a/electron/src/client/mainNamespace.ts
+++ b/electron/src/client/mainNamespace.ts
@@ -106,6 +106,7 @@ export const mainNamespaceStoreSchema = z.object({
   ethercatState: ethercatStateEventSchema.nullable(),
   machines: machinesEventSchema.nullable(),
   ethercatInterfaceDiscovery: ethercatInterfaceDiscoveryEventSchema.nullable(),
+  isIntentionalPreop: z.boolean(),
 });
 
 export type MainNamespaceStore = z.infer<typeof mainNamespaceStoreSchema>;
@@ -116,6 +117,7 @@ export const createMainNamespaceStore = (): StoreApi<MainNamespaceStore> => {
     ethercatState: null,
     machines: null,
     ethercatInterfaceDiscovery: null,
+    isIntentionalPreop: false,
   }));
 };
 

--- a/electron/src/setup/EthercatPage.tsx
+++ b/electron/src/setup/EthercatPage.tsx
@@ -112,7 +112,7 @@ export function createColumns(
       accessorKey: "eeprom",
       header: "Edit Assignment",
       cell: (row) => (
-        <DeviceEepromDialog device={row.row.original} disabled={!isPreop} />
+        <DeviceEepromDialog device={row.row.original} />
       ),
     },
   ];
@@ -123,6 +123,7 @@ export function EthercatPage() {
     useMainNamespace();
   const backendConnected = useBackendConnected();
   const [isRestartPreopLoading, setIsRestartPreopLoading] = useState(false);
+  const [isIntentionalPreop, setIsIntentionalPreop] = useState(false);
   const etherCatState = ethercatState?.data?.state;
   const data = useMemo(() => {
     return ethercatDevices?.data?.Done?.devices || [];
@@ -144,6 +145,7 @@ export function EthercatPage() {
     try {
       const result = await restartBackendIntoPreop();
       if (result.success) {
+        setIsIntentionalPreop(true);
         toast.success("Backend restarted into Preop mode");
       } else {
         toast.error(`Failed to restart into Preop: ${result.error}`);
@@ -198,23 +200,7 @@ export function EthercatPage() {
       <p style={{ lineHeight: "1.6", margin: "1em 0" }}>
         SubDevices have to be in preop before writing to the EEPROM is allowed
       </p>
-      {!backendConnected && (
-        <span
-          style={{
-            color: "#fff",
-            backgroundColor: "#dc2626",
-            padding: "2px 6px",
-            borderRadius: "4px",
-            fontWeight: "bold",
-            display: "inline-block",
-            width: "max-content",
-            marginLeft: "4px",
-          }}
-        >
-          BACKEND DISCONNECTED — RECONNECTING…
-        </span>
-      )}
-      {etherCatState === "preop" && (
+      {isIntentionalPreop && etherCatState === "preop" && (
         <span
           style={{
             color: "#542603",

--- a/electron/src/setup/EthercatPage.tsx
+++ b/electron/src/setup/EthercatPage.tsx
@@ -14,6 +14,7 @@ import { getMachineProperties } from "@/machines/properties";
 import { DeviceRoleComponent } from "@/components/DeviceRole";
 import {
   EthercatDevicesEventData,
+  mainNamespaceStore,
   useMainNamespace,
 } from "@/client/mainNamespace";
 import { useBackendConnected } from "@/client/socketioStore";
@@ -119,11 +120,11 @@ export function createColumns(
 }
 
 export function EthercatPage() {
-  const { ethercatDevices, ethercatState, ethercatInterfaceDiscovery } =
+  const { ethercatDevices, ethercatState, ethercatInterfaceDiscovery,
+    isIntentionalPreop } =
     useMainNamespace();
   const backendConnected = useBackendConnected();
   const [isRestartPreopLoading, setIsRestartPreopLoading] = useState(false);
-  const [isIntentionalPreop, setIsIntentionalPreop] = useState(false);
   const etherCatState = ethercatState?.data?.State;
   const data = useMemo(() => {
     return ethercatDevices?.data?.Done?.devices || [];
@@ -145,7 +146,7 @@ export function EthercatPage() {
     try {
       const result = await restartBackendIntoPreop();
       if (result.success) {
-        setIsIntentionalPreop(true);
+        mainNamespaceStore.setState({ isIntentionalPreop: true });
         toast.success("Backend restarted into Preop mode");
       } else {
         toast.error(`Failed to restart into Preop: ${result.error}`);

--- a/electron/src/setup/EthercatPage.tsx
+++ b/electron/src/setup/EthercatPage.tsx
@@ -112,17 +112,18 @@ export function createColumns(
     {
       accessorKey: "eeprom",
       header: "Edit Assignment",
-      cell: (row) => (
-        <DeviceEepromDialog device={row.row.original} />
-      ),
+      cell: (row) => <DeviceEepromDialog device={row.row.original} />,
     },
   ];
 }
 
 export function EthercatPage() {
-  const { ethercatDevices, ethercatState, ethercatInterfaceDiscovery,
-    isIntentionalPreop } =
-    useMainNamespace();
+  const {
+    ethercatDevices,
+    ethercatState,
+    ethercatInterfaceDiscovery,
+    isIntentionalPreop,
+  } = useMainNamespace();
   const backendConnected = useBackendConnected();
   const [isRestartPreopLoading, setIsRestartPreopLoading] = useState(false);
   const etherCatState = ethercatState?.data?.State;

--- a/electron/src/setup/EthercatPage.tsx
+++ b/electron/src/setup/EthercatPage.tsx
@@ -124,7 +124,7 @@ export function EthercatPage() {
   const backendConnected = useBackendConnected();
   const [isRestartPreopLoading, setIsRestartPreopLoading] = useState(false);
   const [isIntentionalPreop, setIsIntentionalPreop] = useState(false);
-  const etherCatState = ethercatState?.data?.state;
+  const etherCatState = ethercatState?.data?.State;
   const data = useMemo(() => {
     return ethercatDevices?.data?.Done?.devices || [];
   }, [ethercatDevices]);

--- a/electron/src/setup/Troubleshoot.tsx
+++ b/electron/src/setup/Troubleshoot.tsx
@@ -2,6 +2,7 @@ import { Alert } from "@/components/Alert";
 import { Page } from "@/components/Page";
 import { SectionTitle } from "@/components/SectionTitle";
 import { TouchButton } from "@/components/touch/TouchButton";
+import { mainNamespaceStore } from "@/client/mainNamespace";
 import {
   rebootHmi,
   restartBackend,
@@ -54,6 +55,7 @@ export function TroubleshootPage() {
     try {
       const result = await restartBackendIntoPreop();
       if (result.success) {
+        mainNamespaceStore.setState({ isIntentionalPreop: true });
         toast.success("Backend restarted into Preop mode");
       } else {
         toast.error(`Failed to restart into Preop: ${result.error}`);

--- a/qitech_control/src/app_state.rs
+++ b/qitech_control/src/app_state.rs
@@ -4,6 +4,7 @@ use crate::apis::socketio::{
         ethercat_devices_event::{
             EcatState, EtherCatDeviceMetaData, EthercatDevicesEvent, EthercatSetupDone,
         },
+        ethercat_interface_discovery_event::EthercatInterfaceDiscoveryEvent,
         machines_event::{MachineObj, MachinesEventBuilder},
     },
     namespaces::Namespaces,
@@ -103,6 +104,22 @@ impl SharedAppState {
                     }
             });
         }
+        drop(guard);
+        Ok(())
+    }
+
+    /// Emit an EtherCAT interface discovery event synchronously (non-async).
+    /// Uses `try_write()` so it can be called from a synchronous context during
+    /// startup, before the Tokio runtime and Socket.io server are fully running.
+    /// Events are queued and delivered when the Socket.io queue consumer starts.
+    pub fn emit_ethercat_interface_discovery(
+        &self,
+        event: EthercatInterfaceDiscoveryEvent,
+    ) -> Result<(), anyhow::Error> {
+        let built = event.build();
+        let mut guard = self.socketio_setup.namespaces.try_write()?;
+        let main_namespace = &mut guard.main_namespace;
+        main_namespace.emit(MainNamespaceEvents::EthercatInterfaceDiscoveryEvent(built));
         drop(guard);
         Ok(())
     }

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -24,7 +24,11 @@ use std::{sync::Arc, time::Duration};
 #[cfg(not(feature = "mock"))]
 use crate::app_state::MainState;
 use crate::{
-    apis::socketio::main_namespace::ethercat_devices_event::EcatState, app_state::get_async_runtime,
+    apis::socketio::main_namespace::{
+        ethercat_devices_event::EcatState,
+        ethercat_interface_discovery_event::EthercatInterfaceDiscoveryEvent,
+    },
+    app_state::get_async_runtime,
 };
 
 pub mod apis;
@@ -333,8 +337,11 @@ pub fn remove_machines(
     }
 }
 
-fn find_ethercat_interface() -> String {
+fn find_ethercat_interface(state: &SharedAppState) -> String {
     loop {
+        let _ = state.emit_ethercat_interface_discovery(
+            EthercatInterfaceDiscoveryEvent::Discovering(true),
+        );
         let interfaces = list_ethernet_interfaces();
         match interfaces {
             Ok(interfaces) => {
@@ -352,6 +359,11 @@ fn find_ethercat_interface() -> String {
                     match res {
                         Ok(_) => {
                             println!("{} is ethercat", &interface.name);
+                            let _ = state.emit_ethercat_interface_discovery(
+                                EthercatInterfaceDiscoveryEvent::Done(
+                                    interface.name.clone(),
+                                ),
+                            );
                             return interface.name;
                         }
                         Err(_) => println!("{} is not ethercat", &interface.name),
@@ -376,7 +388,7 @@ fn main_logic() {
         || std::env::args().any(|a| a == "preop");
     let mut shared_state = SharedAppState::new();
     let mut main_state = MainState::new();
-    let interface = find_ethercat_interface();
+    let interface = find_ethercat_interface(&shared_state);
     let eth_control = optimized_ethercat_init(&interface);
     shared_state.ethercat_thread_channel = Some(eth_control.channel.clone());
     let mut eth_control = Some(eth_control);

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -339,9 +339,8 @@ pub fn remove_machines(
 
 fn find_ethercat_interface(state: &SharedAppState) -> String {
     loop {
-        let _ = state.emit_ethercat_interface_discovery(
-            EthercatInterfaceDiscoveryEvent::Discovering(true),
-        );
+        let _ = state
+            .emit_ethercat_interface_discovery(EthercatInterfaceDiscoveryEvent::Discovering(true));
         let interfaces = list_ethernet_interfaces();
         match interfaces {
             Ok(interfaces) => {
@@ -360,9 +359,7 @@ fn find_ethercat_interface(state: &SharedAppState) -> String {
                         Ok(_) => {
                             println!("{} is ethercat", &interface.name);
                             let _ = state.emit_ethercat_interface_discovery(
-                                EthercatInterfaceDiscoveryEvent::Done(
-                                    interface.name.clone(),
-                                ),
+                                EthercatInterfaceDiscoveryEvent::Done(interface.name.clone()),
                             );
                             return interface.name;
                         }


### PR DESCRIPTION
## What does this PR do / add / change?
Fixed:
- Ethernet Interface is now shown (showed Not Discovering all the time)
- The Status information in Prepare SubDevices now shows the status again
- Removed backend disconnected as its not necesarry with the status working and also was confusing.
- PreOp Warning now only shows when restarting in PreOp, when its a normal start then it isnt useful.

## Checklist before opening the pr

- [x] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [ ] ~~No build errors (`cargo build` / `npm run build`)~~ (Not mine)
