### PR TITLE
Surface machine error to frontend

### DIFF
--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -262,6 +262,10 @@ fn detect_and_build_machines(state: Arc<SharedAppState>, main_state: &mut MainSt
             }
             Err(e) => {
                 println!("detect_and_build_machines {:?}", e);
+                if !main_state.machine_errors.contains_key(key) {
+                    let _res =
+                        state.add_machine_sync(key.clone().into(), Some(e.to_string()), None);
+                }
                 main_state.machine_errors.insert(*key, e.to_string());
             }
         };


### PR DESCRIPTION
## What does this PR do / add / change?
Fixes an issue where the machine didnt show up at all when there was an issue with the machine (like subdevice missing, etc), now it shows up in the Setup -> Machine list where it used to be and shows the error.