### PR TITLE
Disable touch gestures

### DIFF
--- a/nixos/os/configuration.nix
+++ b/nixos/os/configuration.nix
@@ -181,7 +181,7 @@ in
 
   services.libinput.enable = true;
   services.libinput.touchpad.tapping = true;
-  services.touchegg.enable = true;
+  services.touchegg.enable = false;
 
   # Enable the QiTech Control server
   services.qitech = {


### PR DESCRIPTION
Disables touch gesture weirdness that opened remote desktop for example when using the device with 2 fingers (sometimes also shown up with just one, it was just buggy...)