### PR TITLE
nixos: networkmanager shouldn't manage ethernet

### DIFF
--- a/nixos/os/configuration.nix
+++ b/nixos/os/configuration.nix
@@ -104,6 +104,8 @@ in
 
   # Enable networking
   networking.networkmanager.enable = true;
+  # ... but do not interfere with ethercat
+  networking.networkmanager.unmanaged = [ "type:ethernet" ];
 
   # Enable the X11 windowing system.
   services.displayManager.gdm = {


### PR DESCRIPTION
## What does this PR do / add / change?

Silence failed NetworkManager connections by not managing any ethernet devices

## Screenshots

<!-- Include screenshots for any UI changes. Remove this section if not applicable. -->

## Checklist before opening the pr

- [ ] Tested locally
- [ ] Tested on the machine (if hardware interaction is involved)
- [ ] No format errors (`cargo fmt` / `npm run format`)
- [ ] No build errors (`cargo build` / `npm run build`)
