### PR TITLE
Interface permanently down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "bitvec",
  "control_core",
  "erased-serde",
+ "libc",
  "machine_implementations",
  "qitech_lib",
  "serde",

--- a/qitech_control/Cargo.toml
+++ b/qitech_control/Cargo.toml
@@ -18,6 +18,7 @@ socketioxide = { version = "0.15.2", features = ["msgpack"] }
 erased-serde = "0.4.10"
 axum = { version = "0.8.8", features = ["macros"] }
 tokio-serial = "5.5.0"
+libc = "0.2.186"
 
 [features]
 default = []

--- a/qitech_control/src/interfaces.rs
+++ b/qitech_control/src/interfaces.rs
@@ -38,13 +38,6 @@ pub fn bring_up_interface(iface: &str) -> std::io::Result<()> {
 
 /// Fails if run by non root user
 pub fn set_all_ethernet_up() -> bool {
-    unsafe {
-        if libc::getuid() != 0 {
-            eprintln!("Must be run as root.");
-            return false;
-        }
-    }
-
     // Scan sysfs directory for ethernet devices
     if let Ok(entries) = fs::read_dir("/sys/class/net/") {
         for entry in entries.flatten() {

--- a/qitech_control/src/interfaces.rs
+++ b/qitech_control/src/interfaces.rs
@@ -1,5 +1,5 @@
-use std::{fs, os::unix::io::AsRawFd};
 use qitech_lib::common::get_async_runtime;
+use std::{fs, os::unix::io::AsRawFd};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_serial::{SerialPortInfo, available_ports};
 
@@ -19,7 +19,10 @@ pub fn bring_up_interface(iface: &str) -> std::io::Result<()> {
     let mut ifr_name = [0u8; libc::IFNAMSIZ];
     let bytes = iface.as_bytes();
     if bytes.len() >= libc::IFNAMSIZ {
-        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Interface name too long"));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Interface name too long",
+        ));
     }
     ifr_name[..bytes.len()].copy_from_slice(bytes);
     let ifr = IfReq {
@@ -52,8 +55,6 @@ pub fn set_all_ethernet_up() -> bool {
     }
     true
 }
-
-
 
 pub fn detect_serial(rx: Receiver<()>, tx_ports: Sender<Vec<SerialPortInfo>>) {
     get_async_runtime().spawn(async move {

--- a/qitech_control/src/interfaces.rs
+++ b/qitech_control/src/interfaces.rs
@@ -1,0 +1,82 @@
+use std::{fs, os::unix::io::AsRawFd};
+use qitech_lib::common::get_async_runtime;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio_serial::{SerialPortInfo, available_ports};
+
+const SIOCSIFFLAGS: libc::c_ulong = 0x8914;
+const IFF_UP: libc::c_short = 0x1;
+// Matching the Linux kernel 'ifreq' structure for ioctl
+#[repr(C)]
+struct IfReq {
+    ifr_name: [u8; libc::IFNAMSIZ],
+    ifr_flags: libc::c_short,
+}
+
+pub fn bring_up_interface(iface: &str) -> std::io::Result<()> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
+    let fd = socket.as_raw_fd();
+    // Prepare the ifr_name buffer (16 bytes, null-padded)
+    let mut ifr_name = [0u8; libc::IFNAMSIZ];
+    let bytes = iface.as_bytes();
+    if bytes.len() >= libc::IFNAMSIZ {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Interface name too long"));
+    }
+    ifr_name[..bytes.len()].copy_from_slice(bytes);
+    let ifr = IfReq {
+        ifr_name,
+        ifr_flags: IFF_UP,
+    };
+    unsafe {
+        let res = libc::ioctl(fd, SIOCSIFFLAGS, &ifr);
+        if res < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    println!("Successfully activated: {}", iface);
+    Ok(())
+}
+
+/// Fails if run by non root user
+pub fn set_all_ethernet_up() -> bool {
+    unsafe {
+        if libc::getuid() != 0 {
+            eprintln!("Must be run as root.");
+            return false;
+        }
+    }
+
+    // Scan sysfs directory for ethernet devices
+    if let Ok(entries) = fs::read_dir("/sys/class/net/") {
+        for entry in entries.flatten() {
+            if let Ok(name) = entry.file_name().into_string() {
+                if name.starts_with("en") || name.starts_with("eth") {
+                    if let Err(e) = bring_up_interface(&name) {
+                        eprintln!("Error bringing up interface {}: {}", name, e);
+                    }
+                }
+            }
+        }
+    }
+    true
+}
+
+
+
+pub fn detect_serial(rx: Receiver<()>, tx_ports: Sender<Vec<SerialPortInfo>>) {
+    get_async_runtime().spawn(async move {
+        let mut rx = rx;
+        loop {
+            let res = rx.recv().await;
+            match res {
+                Some(_) => (),
+                None => break, // In this case channel is closed, so stop
+            }
+            let ports = available_ports();
+            let ports = match ports {
+                Ok(p) => p,
+                Err(_e) => vec![],
+            };
+            let _res = tx_ports.send(ports).await;
+        }
+    });
+}

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -17,12 +17,11 @@ use qitech_lib::{
 };
 #[cfg(not(feature = "mock"))]
 use std::{sync::Arc, time::Duration};
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{Receiver};
 use tokio_serial::SerialPortInfo;
-use tokio_serial::available_ports;
 
 #[cfg(not(feature = "mock"))]
-use crate::app_state::MainState;
+use crate::{app_state::MainState, interfaces::{detect_serial, set_all_ethernet_up}};
 use crate::{
     apis::socketio::main_namespace::{
         ethercat_devices_event::EcatState,
@@ -37,25 +36,7 @@ mod machine_loop;
 #[cfg(feature = "mock")]
 mod mock;
 pub mod persist;
-
-fn detect_serial(rx: Receiver<()>, tx_ports: Sender<Vec<SerialPortInfo>>) {
-    get_async_runtime().spawn(async move {
-        let mut rx = rx;
-        loop {
-            let res = rx.recv().await;
-            match res {
-                Some(_) => (),
-                None => break, // In this case channel is closed, so stop
-            }
-            let ports = available_ports();
-            let ports = match ports {
-                Ok(p) => p,
-                Err(_e) => vec![],
-            };
-            let _res = tx_ports.send(ports).await;
-        }
-    });
-}
+mod interfaces;
 
 fn setup_ethercat(
     state: Arc<SharedAppState>,
@@ -409,6 +390,14 @@ fn main_logic() {
         || std::env::args().any(|a| a == "preop");
     let mut shared_state = SharedAppState::new();
     let mut main_state = MainState::new();
+    
+    // By default all ethernet is unmanaged, so NM does not set them to UP and are permanently DOWN
+    // So we do it for all Ethernet interfaces instead
+    match set_all_ethernet_up() {
+        true => println!("Set All Eth interfaces up"),
+        false => println!("Failed to set all Eth interfaces up"),
+    }
+
     let interface = find_ethercat_interface(&shared_state);
     let eth_control = optimized_ethercat_init(&interface);
     shared_state.ethercat_thread_channel = Some(eth_control.channel.clone());

--- a/qitech_control/src/main.rs
+++ b/qitech_control/src/main.rs
@@ -17,11 +17,9 @@ use qitech_lib::{
 };
 #[cfg(not(feature = "mock"))]
 use std::{sync::Arc, time::Duration};
-use tokio::sync::mpsc::{Receiver};
+use tokio::sync::mpsc::Receiver;
 use tokio_serial::SerialPortInfo;
 
-#[cfg(not(feature = "mock"))]
-use crate::{app_state::MainState, interfaces::{detect_serial, set_all_ethernet_up}};
 use crate::{
     apis::socketio::main_namespace::{
         ethercat_devices_event::EcatState,
@@ -29,14 +27,19 @@ use crate::{
     },
     app_state::get_async_runtime,
 };
+#[cfg(not(feature = "mock"))]
+use crate::{
+    app_state::MainState,
+    interfaces::{detect_serial, set_all_ethernet_up},
+};
 
 pub mod apis;
 mod app_state;
+mod interfaces;
 mod machine_loop;
 #[cfg(feature = "mock")]
 mod mock;
 pub mod persist;
-mod interfaces;
 
 fn setup_ethercat(
     state: Arc<SharedAppState>,
@@ -390,7 +393,7 @@ fn main_logic() {
         || std::env::args().any(|a| a == "preop");
     let mut shared_state = SharedAppState::new();
     let mut main_state = MainState::new();
-    
+
     // By default all ethernet is unmanaged, so NM does not set them to UP and are permanently DOWN
     // So we do it for all Ethernet interfaces instead
     match set_all_ethernet_up() {


### PR DESCRIPTION
## What does this PR do / add / change?
After networkmanager had all ethernet interfaces unamanaged they would stay down permanently. This PR adds a crude way to simply set all interfaces up.

## Checklist before opening the pr

- [X] Tested locally
- [X] Tested on the machine (if hardware interaction is involved)
- [X] No format errors (`cargo fmt` / `npm run format`)
- [X] No build errors (`cargo build` / `npm run build`)
