### PR TITLE
1506 change that the aquapath does not disable both turned on pumps if going to standby

### DIFF
--- a/machine_implementations/src/aquapath1/controller.rs
+++ b/machine_implementations/src/aquapath1/controller.rs
@@ -129,6 +129,7 @@ pub struct Controller {
     pub heating_allowed: bool,
     pub flow: Flow,
     pub should_pump: bool,
+    pub pump_requested: bool,
     pump_started_at: Option<Instant>,
     low_flow_started_at: Option<Instant>,
     flow_became_valid_at: Option<Instant>,
@@ -224,6 +225,7 @@ impl Controller {
             total_energy: 0.0,
             flow,
             should_pump: false,
+            pump_requested: false,
             pump_started_at: None,
             low_flow_started_at: None,
             flow_became_valid_at: None,
@@ -379,6 +381,10 @@ impl Controller {
 
     pub fn get_should_pump(&mut self) -> bool {
         self.should_pump
+    }
+
+    pub fn set_pump_requested(&mut self, requested: bool) {
+        self.pump_requested = requested;
     }
 
     pub fn get_flow(&self) -> VolumeRate {

--- a/machine_implementations/src/aquapath1/mod.rs
+++ b/machine_implementations/src/aquapath1/mod.rs
@@ -210,11 +210,11 @@ impl AquaPathV1 {
             flow_states: FlowStates {
                 left: FlowState {
                     flow: self.left_controller.current_flow.get::<liter_per_minute>(),
-                    should_flow: self.left_controller.should_pump,
+                    should_flow: self.left_controller.pump_requested,
                 },
                 right: FlowState {
                     flow: self.right_controller.current_flow.get::<liter_per_minute>(),
-                    should_flow: self.right_controller.should_pump,
+                    should_flow: self.right_controller.pump_requested,
                 },
             },
             fan_states: FanStates {
@@ -397,7 +397,11 @@ impl AquaPathV1 {
 
     fn turn_pump_on(&mut self) {
         self.left_controller.allow_pump();
+        self.left_controller
+            .set_should_pump(self.left_controller.pump_requested);
         self.right_controller.allow_pump();
+        self.right_controller
+            .set_should_pump(self.right_controller.pump_requested);
     }
 
     fn turn_off_all(&mut self) {
@@ -499,9 +503,20 @@ impl AquaPathV1 {
     }
 
     fn set_should_pump(&mut self, should_pump: bool, cooling_type: AquaPathSideType) {
+        let is_auto = self.mode == AquaPathV1Mode::Auto;
         match cooling_type {
-            AquaPathSideType::Right => self.right_controller.set_should_pump(should_pump),
-            AquaPathSideType::Left => self.left_controller.set_should_pump(should_pump),
+            AquaPathSideType::Right => {
+                self.right_controller.set_pump_requested(should_pump);
+                if is_auto {
+                    self.right_controller.set_should_pump(should_pump);
+                }
+            }
+            AquaPathSideType::Left => {
+                self.left_controller.set_pump_requested(should_pump);
+                if is_auto {
+                    self.left_controller.set_should_pump(should_pump);
+                }
+            }
         }
         self.emit_state();
     }


### PR DESCRIPTION
## What does this PR do / add / change?
Before this change when you had both aquapath pumps turned on and whent from auto mode to standby it turned also the pump switch off for the resevoirs, which lead to the user having to hit 3 buttons to just get back to running the aquapath. 

With this PR the pump switches stay where they are even when going to standby, so you just have to switch the mode again to get going.

## Checklist before opening the pr

- [x] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
