### PR TITLE
make eeprom assigment disabled when not in preop

### DIFF
--- a/electron/src/setup/EthercatPage.tsx
+++ b/electron/src/setup/EthercatPage.tsx
@@ -112,7 +112,9 @@ export function createColumns(
     {
       accessorKey: "eeprom",
       header: "Edit Assignment",
-      cell: (row) => <DeviceEepromDialog device={row.row.original} />,
+      cell: (row) => (
+        <DeviceEepromDialog device={row.row.original} disabled={!isPreop} />
+      ),
     },
   ];
 }


### PR DESCRIPTION
## What does this PR do / add / change?
See Title

## Checklist before opening the pr

- [x] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
