### PR TITLE
Change aquapath temp target step to 1

### DIFF
--- a/electron/src/machines/aquapath/aquapath1/Aquapath1ControlPage.tsx
+++ b/electron/src/machines/aquapath/aquapath1/Aquapath1ControlPage.tsx
@@ -105,7 +105,7 @@ export function Aquapath1ControlPage() {
                   value={leftReservoirTargetTemperature}
                   max={80}
                   unit="C"
-                  step={0.1}
+                  step={1}
                   renderValue={(value) => value.toFixed(1)}
                   onChange={(val) => {
                     setLeftTemperature(Math.max(val, minSettableTemperature));
@@ -232,7 +232,7 @@ export function Aquapath1ControlPage() {
                   value={rightReservoirTargetTemperature}
                   max={80}
                   unit="C"
-                  step={0.1}
+                  step={1}
                   renderValue={(value) => value.toFixed(1)}
                   onChange={(val) => {
                     setRightTemperature(Math.max(val, minSettableTemperature));


### PR DESCRIPTION
## What does this PR do / add / change?
As the tite says, it changes the temp target step from .1 to 1, as the aquapath can not set the target so precisly.


## Checklist before opening the pr

- [ ] Tested locally
- [ ] Tested on the machine (if hardware interaction is involved)
- [ ] No format errors (`cargo fmt` / `npm run format`)
- [ ] No build errors (`cargo build` / `npm run build`)
