### PR TITLE
Status badge now cant go past its tile.

### DIFF
--- a/electron/src/control/StatusBadge.tsx
+++ b/electron/src/control/StatusBadge.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export function StatusBadge({ variant, children }: Props) {
-  const badgeStyle = cva(["text-md"], {
+  const badgeStyle = cva(["text-md", "max-w-full", "whitespace-normal"], {
     variants: {
       variant: {
         error: "bg-red-500",
@@ -24,7 +24,7 @@ export function StatusBadge({ variant, children }: Props) {
         variant,
       })}
     >
-      <Icon name={icon} className="size-6" />
+      <Icon name={icon} className="size-6 shrink-0" />
       {children}
     </Badge>
   );


### PR DESCRIPTION
Fix for: 
<img width="1824" height="1026" alt="grafik" src="https://github.com/user-attachments/assets/a8b0d465-de83-4c5d-9b3b-08ab1a9d9a64" />

