### PR TITLE
1210 feat make unassign button for ethercat terminals

### DIFF
--- a/electron/src/setup/DeviceEepromDialog.tsx
+++ b/electron/src/setup/DeviceEepromDialog.tsx
@@ -69,12 +69,6 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
-/**
- * A terminal is unassigned when its EEPROM identification words are all zero.
- * The backend always reports a `device_machine_identification` for EtherCAT
- * subdevices (it mirrors the raw EEPROM words), so "no assignment" has to be
- * detected by value, not by absence.
- */
 export function isDeviceAssigned(device: Device): boolean {
   const dmi = device.device_identification.device_machine_identification;
   if (!dmi) return false;
@@ -160,9 +154,6 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
       },
     });
 
-  // Unassigning writes zeroed identification words, which is what the backend
-  // interprets as "no machine". Dropping the entry instead would leave the old
-  // values in the terminal's EEPROM.
   const performUnassign = () =>
     client.writeMachineDeviceIdentification({
       hardware_identification_ethercat: {

--- a/electron/src/setup/DeviceEepromDialog.tsx
+++ b/electron/src/setup/DeviceEepromDialog.tsx
@@ -69,6 +69,20 @@ const formSchema = z.object({
 
 type FormSchema = z.infer<typeof formSchema>;
 
+/**
+ * A terminal is unassigned when its EEPROM identification words are all zero.
+ * The backend always reports a `device_machine_identification` for EtherCAT
+ * subdevices (it mirrors the raw EEPROM words), so "no assignment" has to be
+ * detected by value, not by absence.
+ */
+export function isDeviceAssigned(device: Device): boolean {
+  const dmi = device.device_identification.device_machine_identification;
+  if (!dmi) return false;
+  const { machine_identification: mi, serial } =
+    dmi.machine_identification_unique;
+  return mi.vendor !== 0 || mi.machine !== 0 || serial !== 0 || dmi.role !== 0;
+}
+
 export function DeviceEepromDialog({ device, disabled }: Props) {
   const [open, setOpen] = React.useState(false);
   const key = useMemo(() => Math.random(), [open]);
@@ -96,6 +110,7 @@ type ContentProps = {
 export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
   const client = useClient();
   const [isApplying, setIsApplying] = useState(false);
+  const [isUnassigning, setIsUnassigning] = useState(false);
   const [writeSuccess, setWriteSuccess] = useState(false);
 
   const [numpadOpen, setNumpadOpen] = useState(false);
@@ -120,7 +135,11 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
   const values = useFormValues(form);
 
   const isChangingMachine =
-    initialMachine != null && values.machine !== initialMachine;
+    initialMachine != null &&
+    !!values.machine &&
+    values.machine !== initialMachine;
+
+  const isAssigned = isDeviceAssigned(device);
 
   const performWrite = (values: FormSchema) =>
     client.writeMachineDeviceIdentification({
@@ -140,6 +159,51 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
         role: parseInt(values.role!),
       },
     });
+
+  // Unassigning writes zeroed identification words, which is what the backend
+  // interprets as "no machine". Dropping the entry instead would leave the old
+  // values in the terminal's EEPROM.
+  const performUnassign = () =>
+    client.writeMachineDeviceIdentification({
+      hardware_identification_ethercat: {
+        subdevice_index:
+          device.device_identification.device_hardware_identification.Ethercat!
+            .subdevice_index,
+      },
+      device_machine_identification: {
+        machine_identification_unique: {
+          machine_identification: {
+            vendor: 0,
+            machine: 0,
+          },
+          serial: 0,
+        },
+        role: 0,
+      },
+    });
+
+  const handleUnassign = () => {
+    if (
+      !window.confirm(
+        "Unassigning removes this terminal from its machine. A backend restart is required and the machine will not work until another terminal takes this role. Continue?",
+      )
+    )
+      return;
+    setIsUnassigning(true);
+    performUnassign()
+      .then((res) => {
+        if (res.success) {
+          setWriteSuccess(true);
+          form.reset({ machine: "", serial: "", role: "" });
+          toast(
+            <Toast title="Unassigned" icon="lu:CircleCheck">
+              Assignment cleared. Restart required to apply changes.
+            </Toast>,
+          );
+        }
+      })
+      .finally(() => setIsUnassigning(false));
+  };
 
   const confirmIfChangingMachine = (): boolean => {
     if (!isChangingMachine) return true;
@@ -511,7 +575,9 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
             <div className="flex flex-wrap items-center gap-2">
               <Button
                 type="submit"
-                disabled={!form.formState.isValid || isApplying}
+                disabled={
+                  !form.formState.isValid || isApplying || isUnassigning
+                }
                 onClick={() => setWriteSuccess(false)}
               >
                 <Icon name="lu:Save" /> Save
@@ -519,7 +585,9 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
               <Button
                 type="button"
                 variant="outline"
-                disabled={!form.formState.isValid || isApplying}
+                disabled={
+                  !form.formState.isValid || isApplying || isUnassigning
+                }
                 onClick={handleApplyAndRestart}
                 aria-busy={isApplying}
                 title="Saves assignment then restarts the backend. Restart is required for changes to take effect."
@@ -533,6 +601,30 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
                   <>
                     <Icon name="lu:RotateCcw" />
                     Apply & restart
+                  </>
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={!isAssigned || isApplying || isUnassigning}
+                onClick={handleUnassign}
+                aria-busy={isUnassigning}
+                title={
+                  isAssigned
+                    ? "Clears the machine assignment from this terminal's EEPROM. Restart is required for changes to take effect."
+                    : "This terminal is not assigned to a machine."
+                }
+              >
+                {isUnassigning ? (
+                  <>
+                    <LoadingSpinner />
+                    Unassigning…
+                  </>
+                ) : (
+                  <>
+                    <Icon name="lu:Unlink" />
+                    Unassign
                   </>
                 )}
               </Button>

--- a/electron/src/setup/DeviceEepromDialog.tsx
+++ b/electron/src/setup/DeviceEepromDialog.tsx
@@ -104,7 +104,7 @@ type ContentProps = {
 export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
   const client = useClient();
   const [isApplying, setIsApplying] = useState(false);
-  const [isUnassigning, setIsUnassigning] = useState(false);
+  const [isUnassigning, setUnassigning] = useState(false);
   const [writeSuccess, setWriteSuccess] = useState(false);
 
   const [numpadOpen, setNumpadOpen] = useState(false);
@@ -180,7 +180,7 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
       )
     )
       return;
-    setIsUnassigning(true);
+    setUnassigning(true);
     performUnassign()
       .then((res) => {
         if (res.success) {
@@ -193,7 +193,7 @@ export function DeviceEepromDialogContent({ device, setOpen }: ContentProps) {
           );
         }
       })
-      .finally(() => setIsUnassigning(false));
+      .finally(() => setUnassigning(false));
   };
 
   const confirmIfChangingMachine = (): boolean => {

--- a/electron/src/setup/EthercatPage.tsx
+++ b/electron/src/setup/EthercatPage.tsx
@@ -9,7 +9,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import React, { useMemo, useState } from "react";
-import { DeviceEepromDialog } from "./DeviceEepromDialog";
+import { DeviceEepromDialog, isDeviceAssigned } from "./DeviceEepromDialog";
 import { getMachineProperties } from "@/machines/properties";
 import { DeviceRoleComponent } from "@/components/DeviceRole";
 import {
@@ -69,18 +69,21 @@ export function createColumns(
       accessorKey: "qitech_machine",
       header: "Assigned Machine",
       cell: (row) => {
+        if (!isDeviceAssigned(row.row.original)) return "—";
         const machine_identification =
           row.row.original.device_identification.device_machine_identification
             ?.machine_identification_unique.machine_identification;
         if (!machine_identification) return "—";
         const machinePreset = getMachineProperties(machine_identification);
-        return machinePreset?.name + " " + machinePreset?.version;
+        if (!machinePreset) return "UNKNOWN " + machine_identification.machine;
+        return machinePreset.name + " " + machinePreset.version;
       },
     },
     {
       accessorKey: "qitech_serial",
       header: "Assigned Serial",
       cell: (row) => {
+        if (!isDeviceAssigned(row.row.original)) return "—";
         const serial =
           row.row.original.device_identification.device_machine_identification
             ?.machine_identification_unique.serial;
@@ -92,6 +95,7 @@ export function createColumns(
       accessorKey: "qitech_role",
       header: "Assigned Device Role",
       cell: (row) => {
+        if (!isDeviceAssigned(row.row.original)) return "—";
         const device_machine_identification =
           row.row.original.device_identification.device_machine_identification;
         const machine_identification =


### PR DESCRIPTION
## What does this PR do / add / change?
Adds an unassign button to the assigning popup.

## Checklist before opening the pr

- [ ] Tested locally
- [x] Tested on the machine (if hardware interaction is involved)
- [x] No format errors (`cargo fmt` / `npm run format`)
- [x] No build errors (`cargo build` / `npm run build`)
